### PR TITLE
docs: README と詳細ガイドを整備（継続学習・Phase3対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,381 +1,125 @@
-# cc-sier
+# cc-sier-organization
 
-**Claude Code で SIer業務の仮想組織を構築・運営するプラグイン**
+**Claude Code で SIer の仕事を仮想組織として動かすプラグイン**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+```
+あなた ──依頼──▶ 秘書エージェント ──振り分け──▶ 専門Subagent ──成果物──▶ Git PR
+                      ↑                                              ↓
+              Case Bank 参照                             自動ログ・学習
+```
+
+Claude Code に「組織」の概念を持ち込み、秘書エージェントが依頼を受け取り、専門Subagentに委譲し、成果物をGit経由で管理します。使うほど賢くなる継続学習機能を内蔵しています。
+
+---
+
+## なぜ cc-sier-organization を使うのか
+
+### 普通の Claude Code との違い
+
+| | 普通の Claude Code | cc-sier-organization |
+|---|---|---|
+| 依頼の振り分け | 毎回手動でコンテキスト説明 | 秘書が自動でSubagentに委譲 |
+| 成果物の管理 | フォルダが散乱しがち | `.companies/{org}/docs/` に自動整理 |
+| 作業履歴 | セッションをまたいで消える | `.task-log/` + GitHub Issues に永続化 |
+| 組織のルール | プロンプトで毎回説明 | `masters/` に一度書けばずっと参照 |
+| 複数プロジェクト | ディレクトリを手動で切り替え | `/company {org}` で一発切り替え |
+| 品質の向上 | 指示を繰り返すしかない | 継続学習で自動的に精度が上がる |
+
+### 具体的なメリット
+
+**① 認知負荷ゼロの委譲**
+「A社のDWH設計をやって」と言うだけで、秘書が data-architect Subagentに委譲し、設計書を `docs/data/` に配置してPRを作ります。何を誰に頼むかを考えなくていい。
+
+**② ルールの一元管理**
+顧客ごとの制約、部署ごとの文書フォーマット、使用技術スタックを `masters/` に記述すれば、全Subagentが自動参照します。「前も言ったのに」がなくなります。
+
+**③ 作業履歴が自動で残る**
+ツール実行のたびに `.interaction-log/` に記録され、セッション終了時に GitHub Issues に自動投稿されます。振り返りや引き継ぎが楽になります。
+
+**④ 組織がだんだん賢くなる**（継続学習 / Memento-Skills）
+使えば使うほど、高品質だった作業パターンが自動でワークフロー化されます。Subagentの説明文が実績データで更新されます。新しいSkillやSubagentが必要になったら自動生成を提案します。
+
+**⑤ 複数組織・複数プロジェクトを一つのリポジトリで**
+`/company-spawn` で新しいアプリリポジトリを切り出しながら、元の組織の知識は共有し続けられます。
 
 ---
 
 ## できること
 
-### ① 秘書に話しかけるだけで業務が回る
-
-`/company` で秘書が起動。依頼内容に応じて自動で専門エージェントに振り分ける。
-
-- TODO管理、壁打ち、メモ、ダッシュボードを秘書が一手に対応
-- マスタのトリガーワードと照合し、最適な部署・Subagent に自動ルーティング
-- 判断に迷う依頼も秘書が受け止めて対応方針を提案
-
-```
-あなた: 「今日のTODOに設計レビューの準備を追加して」
-秘書:   TODOに追加 → .companies/{org}/docs/secretary/todos/2026-03-19.md
-
-あなた: 「A社のインフラ構成を設計して」
-秘書:   トリガーワード「インフラ」→ cloud-engineer Subagent に委譲
-```
-
-### ② 専門エージェントが並列で動く（Agent Teams）
-
-20種の Subagent を同梱。ワークフロー定義に従い、Claude Code が自動でチームを編成する。
-
-- **設計レビュー** → SA + リードデベロッパー + QAリードが同時レビュー
-- **受託案件キックオフ** → PM + SA + QAリードが並列でドキュメント作成
-- **技術比較** → 複数のリサーチャーが同時調査して比較表を統合
-
-```
-あなた: 「A社のDWH設計をやって」
-  ↓
-秘書: チーム編成
-  ├── データアーキテクト → メダリオン全体設計
-  ├── システムアーキテクト → 非機能要件・インフラ選定
-  └── QAリード           → データ品質テスト戦略
-  ↓
-統合レポートを .companies/{org}/docs/data/ に保存
-PRを自動作成してURLを報告
-```
-
-### ③ マスタ駆動で組織が育つ
-
-部署・ロール・ワークフローは md ファイルのマスタで管理。対話的に追加・変更・削除できる。
-
-- `/company-admin` でロール追加 → Subagent ファイル自動生成 → マスタ整合性チェックまで一気通貫
-- 部署削除時はデータ有無を確認し、アーカイブを提案（安全策付き）
-- 最初は秘書室だけでスタート。使うほど部署が増えて組織が成長する
-
-```
-/company-admin
-「セキュリティ室を追加して。脆弱性診断と設計レビューを担当」
-  ↓
-1. masters/departments.md にエントリ追加
-2. masters/roles.md に security-engineer ロール追加
-3. .claude/agents/security-engineer.md を自動生成
-4. docs/security/ フォルダ + CLAUDE.md を作成
-5. 組織CLAUDE.md の部署一覧を更新
-```
-
-### ④ マルチ組織 + Git PR ワークフロー
-
-案件ごとに独立した組織を作成・切り替え。成果物は自動で PR 管理される。
-
-- `/company` 起動時に組織選択 UI を表示。複数案件を並行運用可能
-- ファイル生成時: 自動ブランチ作成 → 作業 → コミット → PR作成 → main 復帰
-- 成果物はすべて `.companies/{org}/docs/` に集約。リポジトリルートは汚さない
-- `.active` はGit管理しないため、各メンバーが独立して作業組織を選択できる
-
-### ⑤ タスクの実行過程が GitHub Issue で可視化される
-
-ファイル生成を伴うタスクの完了時に、実行過程を GitHub Issue として自動作成する。
-
-- 秘書の判断（なぜその実行モード・ロールを選んだか）
-- 各 Subagent の作業サマリーと成果物
-- エージェント間の連携内容（誰が誰に何を渡したか）
-- 作業者（operator）の記録
-- ラベルで組織・実行モード・部署・タスク種別をフィルタ可能
-
-```
-[a-sha-dwh] DWH メダリオンアーキテクチャ設計     mode:agent-teams  dept:data
-
-## 実行計画（秘書の判断）
-- 実行モード: Agent Teams
-- アサイン: data-architect, system-architect, qa-lead
-- 作業者: sasao
-- 判断理由: データソース4種 + 分析要件5種 → 並列設計が効率的
-
-## エージェント作業ログ
-### data-architect → メダリオン3層設計を完了
-### system-architect → Azure Synapse を推奨
-### qa-lead → データ品質テスト戦略を策定
-
-## 成果物一覧
-| ファイル | 作成者 | パス |
-|---------|--------|------|
-| メダリオン全体設計 | data-architect | docs/data/models/.../architecture.md |
-```
-
-### ⑥ 設計からアプリリポジトリを切り出す
-
-`/company-spawn` で、cc-sierの設計成果物をもとに実装用のリポジトリを自動生成する。
-
-- 設計書・ADRを `docs/design/` に自動コピー
-- 使いたいSubagentを選んで新リポにエクスポート（パス自動書き換え付き）
-- 技術スタックに応じたスキャフォールド（dbt, Terraform, React等）を生成
-- 設計の出自情報（`origin.md`）で cc-sier との紐づけを維持
-
-```
-/company-spawn
-「A社DWHの実装リポを作りたい。dbt + Terraformで」
-  ↓
-秘書: ヒアリング → 実行計画の提示 → 承認
-  ↓
-devops-coordinator:
-  1. gh repo create a-sha-dwh-app --private
-  2. メダリオン設計書・ADRを docs/design/ にコピー
-  3. data-architect, cloud-engineer を .claude/agents/ にエクスポート
-  4. dbt + Terraform のスキャフォールドを生成
-  5. CLAUDE.md, origin.md, README.md を生成
-  6. 初期コミット＋push
-  ↓
-cc-sier側: projects.md にリポジトリURLを記録 → PR作成
-  ↓
-「cd ../a-sha-dwh-app && claude で新リポに移動してください。
- Subagentがそのまま使えます。」
-```
-
-### ⑦ インタラクションログが自動記録される（Hooks）
-
-Claude Code のツール実行を自動でログに記録し、セッション終了時に GitHub Issue へ投稿する。
-
-- **PostToolUse hook**: ツール実行のたびにログファイルへ1行追記（ツール名・パス・コマンド等）
-- **Stop hook**: セッション終了時に GitHub Issue を自動作成（同日2回目以降はコメント追記）
-- `.companies/{org}/.interaction-log/YYYY-MM-DD.md` にローカルログを保存
-- `.active` を読み取って動作するため、新規・既存どの組織でも設定不要で自動記録
-- `gh` 未インストール or 未認証の場合はローカルログだけ残してスキップ
-- ツール実行が0回のセッションは Issue を作らない（空打ちノイズ防止）
-
-```
-セッション中（PostToolUse hook が毎回追記）:
-  14:30:05 — Read     path: `.companies/a-sha-dwh/masters/departments.md`
-  14:30:12 — Edit     path: `.companies/a-sha-dwh/masters/departments.md`
-  14:30:18 — Bash     cmd: `git add ...`
-
-セッション終了（Stop hook が Issue 作成）:
-  → GitHub Issue: [a-sha-dwh] インタラクションログ 2026-03-21
-    ├── ツール実行数: 15 回
-    ├── セッションID: abc12345
-    └── ログ全文（折りたたみ表示）
-```
-
-### ⑧ セッション統計が自動で残る
-
-セッション終了時に、ツール実行の統計情報を JSON ファイルとして自動保存する。AIを使わず bash だけで軽量に生成される。
-
-- `.companies/{org}/.session-summaries/YYYYMMDD-HHMMSS-{id}.json` に保存
-- ツール種別ごとの実行回数（Write / Read / Bash / その他）を集計
-- 書き込みが発生したファイルパスを一覧で記録
-- GitHub Issue のコメントにも統計テーブルと書き込みファイル一覧を掲載
-
-```json
-{
-  "session_id": "a3f9b2c1...",
-  "org_slug": "jutaku-dev-team",
-  "date": "2026-03-21",
-  "tool_count": 12,
-  "by_type": { "write": 3, "read": 4, "bash": 5, "other": 0 },
-  "files_written": [".companies/jutaku-dev-team/docs/architecture/adrs/ADR-001.md"]
-}
-```
-
-### ⑨ 活動サマリーレポートを自動生成（/company-report）
-
-`/company-report` で、指定期間の活動をまとめたレポートを自動生成する。4つの情報源を統合し、AIが要約する。
-
-- **期間指定**: 当日（デフォルト）/ 週次（過去7日）/ 月次（当月）/ カスタム日付範囲
-- **4つの情報源**: セッション統計JSON + タスクログ + docs/ の変更履歴 + GitHub Issues
-- **出力**: mdファイル保存 + GitHub Issue 投稿 + Git PR 作成まで自動実行
-- **継続学習**: レポート完了後、自動的に `/company-evolve` を起動してログから学習を実行
-
-```
-/company-report          # 当日のレポート
-今週のレポートを作って    # 過去7日
-月次振り返り              # 当月1日〜今日
-```
-
-レポートの構成:
-```
-# {org-slug} 活動レポート — 2026-03-21
-
-## エグゼクティブサマリー   ← AIが3〜5文で要約
-## 活動統計                  ← セッション数・ツール実行数など数値まとめ
-## 完了タスク                ← .task-log の completed 一覧
-## 進行中タスク              ← .task-log の in-progress 一覧
-## 作成・更新された成果物    ← 部署別にグルーピング
-## Issue 動向                ← 期間内のクローズ/オープン
-## 次のアクション候補        ← AIが優先度順に3〜5件を推定
-```
-
-### ⑩ 使うほど進化する継続学習（/company-evolve）
-
-過去のログからユーザーの好みとパターンを自動抽出し、エージェントメモリを更新する。
-`/company-report` 完了後に自動起動するため、意識せず学習が進む。
-
-- **出力スタイルの好み**: 「ASCII図」「比較表」「簡潔に」等のリクエスト傾向を検出
-- **Subagentの先読み**: よく使うSubagentをランキング化し、次回から先読み提案
-- **ワークフロー自動登録**: 同じ操作が3回以上繰り返されたら `workflows.md` に自動追加
-- MEMORY.md はセクション単位で上書き（200行制限に引っかからない設計）
-- `workflows.md` への書き込みのみ Git 管理（ブランチ → PR）、MEMORY.md はローカル管理
-
-```
-/company-evolve            # 手動実行（直近30日分を学習）
-/company-report week       # レポート生成後に自動起動
-
-学習結果 → .claude/agent-memory/secretary/MEMORY.md に書き込み
-  → 次のセッションで秘書が先読み提案
-  → 「今日もDWH設計ですか？data-architectに直接繋ぎましょうか？」
-```
-
-### ⑪ 複数人で同じリポジトリを共有できる
-
-チーム全員が cc-sier-organization をクローンし、PRベースで協働する。
-
-- 組織の切り替え（`.active`）は各メンバーのローカルで独立管理
-- コミットメッセージ・タスクログ・PRに作業者（operator）が自動記録される
-- `git config user.name` から自動取得。設定不要
-
-```
-# Aさん: standardization-initiative で作業
-/company → A) standardization-initiative で作業を続ける
-
-# Bさん（同時に）: jutaku-dev-team で作業
-/company → B) jutaku-dev-team で作業を続ける
-
-# コミットメッセージに作業者が記録される
-design: メダリオン設計書を作成 [a-sha-dwh] by sasao
-todo: Sprint1 タスクを追加 [jutaku-dev-team] by tanaka
-```
+| 機能 | コマンド / Skill | 説明 |
+|---|---|---|
+| ① 組織に入る | `/company {org-slug}` | アクティブ組織を切り替え |
+| ② タスクを依頼 | 自然言語で話しかける | 秘書が自動でSubagentに振り分け |
+| ③ マスタ管理 | `/company-admin` | 顧客・役割・ワークフローのCRUD |
+| ④ アプリ切り出し | `/company-spawn` | 新規Gitリポジトリを生成 |
+| ⑤ 定期レポート | `/company-report` | 週次・月次サマリーをGitへ |
+| ⑥ 継続学習 | `/company-evolve` | 組織の知識と手順を自動更新 |
+| ⑦ ログ自動記録 | Stop hook | セッション終了時にIssueへ自動投稿 |
+| ⑧ Skill 自動生成 | Skill Synthesizer | 繰り返しパターンからSkillを生成 |
+| ⑨ Agent 精緻化 | Subagent Refiner | 実績データでAgentを自動更新 |
+| ⑩ Agent 自動生成 | Subagent Spawner | 対応Agentがない作業に新規生成 |
 
 ---
 
-## 導入メリット
+## 同梱の組織・Subagent
 
-| 観点 | Before（従来） | After（CC-SIer） |
-|------|---------------|-----------------|
-| 作業の振り分け | 自分でプロンプトを毎回考える | 秘書がマスタ参照で自動振り分け |
-| 専門知識の適用 | 1つのセッションで全領域カバー | 専門 Subagent が独立コンテキストで対応 |
-| 並列作業 | 逐次処理のみ | Agent Teams で 3〜5名が同時並行 |
-| ナレッジ蓄積 | チャット履歴に埋もれる | 組織ディレクトリに md 形式で永続化 |
-| 案件の分離 | 全案件が同じコンテキスト | マルチ組織で案件ごとに独立管理 |
-| 成果物の管理 | ルートに散乱 | `docs/` 配下に集約 + PR で変更追跡 |
-| 組織の拡張 | 最初から全構成を定義 | `/company-admin` で使いながら動的追加 |
-| 作業の追跡 | 「何をやったか」が不明 | タスク完了時に GitHub Issue で自動可視化 |
-| 操作ログ | ツール実行が見えない | Hooks で全操作を自動記録 → Issue に投稿 |
-| やり取りの記録 | ログが散らばるか記録されない | Hooksで全ツール実行を自動記録、GitHub Issueに自動集約 |
-| 活動の振り返り | 手動でチャット履歴を遡る | `/company-report` で期間指定・AI要約レポートをワンコマンドで生成 |
-| 継続的な改善 | 毎回同じ設定を繰り返す | `/company-evolve` でログから好みを学習、使うほど先読み精度が上がる |
-| 設計→実装 | 手動コピー | `/company-spawn` で設計＋Subagentごと切り出し |
-| チーム運用 | 1人前提 | 全員がクローンして独立作業、PRで共有 |
+### 組織（初期3種）
 
----
+| org-slug | 用途 |
+|---|---|
+| `standardization-initiative` | 社内標準化・ガイドライン策定 |
+| `jutaku-dev-team` | 受注開発プロジェクト管理 |
+| `domain-tech-collection` | 技術調査・ドメイン知識蓄積 |
 
-## 導入方法
+### Subagent（20種）
 
-### 前提条件
+秘書（secretary）が依頼内容に応じて以下のSubagentに委譲します。
 
-- Claude Code がインストール済み
-- Agent Teams を有効化（推奨）:
-  ```json
-  // ~/.claude/settings.json
-  {"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"}}
-  ```
-- GitHub CLI（`gh`）推奨（PR自動作成・リポジトリ作成に使用）
-- tmux 推奨（Agent Teams のパネル分割表示に必要）
-
-### ステップ1: リポジトリをクローン
-
-```bash
-git clone https://github.com/SAS-Sasao/cc-sier-organization.git
-cd cc-sier-organization
-```
-
-### ステップ2: Claude Code を起動
-
-```bash
-# tmux内で起動するとAgent Teamsのパネル分割が有効になる
-tmux
-claude
-```
-
-`.claude/skills/` と `.claude/agents/` が自動認識される。インストール作業不要。
-
-### ステップ2.5: Hooks に実行権限を付与（初回のみ）
-
-```bash
-chmod +x .claude/hooks/capture-interaction.sh
-chmod +x .claude/hooks/session-boundary.sh
-```
-
-`gh auth login` で GitHub CLI を認証しておくと、セッション終了時に自動で GitHub Issue が作成されます。
-
-### ステップ3: 組織を作成
-
-```
-/company
-```
-
-秘書が起動し、4問のヒアリングで組織を初期化:
-1. 組織名（プロジェクト名）
-2. オーナー名
-3. 事業内容
-4. 起動する部署の選択
-
-### ステップ4: 仕事を始める
-
-```
-/company
-今日のTODOを教えて
-```
-
-### チームメンバーの参加方法
-
-```bash
-# メンバーがクローンしてClaude Codeを起動するだけ
-git clone https://github.com/SAS-Sasao/cc-sier-organization.git
-cd cc-sier-organization
-claude
-
-# /company で組織を選択して作業開始
-/company
-```
-
-各メンバーの `.active` はローカル管理のため、他のメンバーに影響なく組織を切り替えられる。
+| カテゴリ | Subagent |
+|---|---|
+| 設計 | system-architect, data-architect, infra-engineer |
+| 開発 | backend-engineer, frontend-engineer, devops-engineer |
+| 文書 | technical-writer, proposal-writer, report-writer |
+| PM | project-manager, scrum-master |
+| 分析 | business-analyst, data-analyst, cost-optimizer |
+| 知識管理 | knowledge-manager, domain-researcher |
+| 品質 | code-reviewer, qa-engineer |
+| その他 | security-engineer, integration-specialist |
 
 ---
 
-## コマンド一覧
+## 継続学習（Memento-Skills ベース）
 
-| コマンド | 概要 |
-|---------|------|
-| `/company` | 組織の作成・選択・秘書との対話・作業依頼 |
-| `/company-admin` | マスタ管理（部署・ロール・ワークフローの CRUD） |
-| `/company-spawn` | 設計成果物をもとにアプリケーションリポジトリを新規作成 |
-| `/company-report` | 活動サマリーレポートの生成（today / week / month） |
-| `/company-evolve` | ログからの継続学習・エージェントメモリ自動更新 |
+cc-sier-organization は論文「Memento-Skills: Let Agents Design Agents」の設計思想を実装しています。
 
----
+### 仕組みの概要
 
-## 同梱 Subagent 一覧（20種）
+```
+Write フェーズ（セッション終了・/company-evolve 起動時）
+  ├── Skill Evaluator    : タスクの成否を報酬スコアで評価
+  ├── Case Bank 再構築   : 全タスクを構造化インデックスに保存
+  ├── MEMORY.md 更新     : 出力スタイル・ルーティング先読みを学習
+  ├── ワークフロー生成   : 高品質パターンを手順書として登録
+  ├── Skill Synthesizer  : 未対応パターンに新規Skillを提案（PR）
+  └── Subagent Refiner   : 実績でAgentの説明・制約を精緻化（PR）
+       └── Subagent Spawner: 対応Agentがない作業に新規Agentを生成（PR）
 
-| Subagent | モデル | 担当領域 |
-|----------|--------|---------|
-| secretary | opus | 窓口・TODO・壁打ち・メモ・振り分け |
-| project-manager | sonnet | WBS・マイルストーン・進捗・リスク管理 |
-| system-architect | opus | 全体設計・技術選定・ADR・設計レビュー |
-| data-architect | opus | データモデル・DWH・メダリオンアーキテクチャ |
-| ai-developer | opus | プロンプト設計・RAG・LLMアプリ開発 |
-| lead-developer | sonnet | コードレビュー・技術方針・実装ガイドライン |
-| backend-developer | sonnet | API設計・DB設計・サーバーサイド実装 |
-| frontend-developer | sonnet | UI実装・UX改善・コンポーネント設計 |
-| qa-lead | sonnet | テスト戦略・テスト計画・品質メトリクス |
-| test-engineer | sonnet | テスト自動化・テストケース設計・カバレッジ |
-| ci-cd-engineer | sonnet | パイプライン設計・デプロイ自動化・リリース |
-| cloud-engineer | sonnet | IaC実装・クラウド設計・セキュリティ |
-| sre-engineer | sonnet | 監視設計・SLI/SLO・インシデント対応 |
-| standards-lead | sonnet | 開発標準・規約管理・テンプレート整備 |
-| process-engineer | sonnet | ワークフロー最適化・業務プロセス改善 |
-| knowledge-manager | sonnet | ポストモーテム・ナレッジ蓄積・知見構造化 |
-| technical-writer | sonnet | 技術文書・教育資料・オンボーディング |
-| tech-researcher | sonnet | 技術調査・競合分析・PoC実施 |
-| retail-domain-researcher | sonnet | 小売ドメイン知識・業界用語体系化・業務プロセス分析 |
-| devops-coordinator | sonnet | リポジトリ初期構成・アプリ切り出し・CI/CD |
+Read フェーズ（次のセッション起動時）
+  └── 秘書が Case Bank を参照 → 類似タスクの高品質パターンをルーティングに反映
+```
+
+### 評価指標（報酬スコア）
+
+タスクを以下の4シグナルで自動評価し、0.0〜1.0のスコアを付与します。
+
+| シグナル | 内容 |
+|---|---|
+| completed | status が completed であるか |
+| artifacts_exist | 成果物ファイルが実際に存在するか |
+| no_excessive_edits | 同一ファイルへの修正が5回以下か |
+| no_retry | 「やり直し」などの否定的フィードバックがないか |
+
+詳細は [`docs/guide/05-learning-system.md`](docs/guide/05-learning-system.md) を参照。
 
 ---
 
@@ -384,270 +128,100 @@ claude
 ```
 cc-sier-organization/
 │
-├── .claude/                          ← Claude Code が認識する実行ファイル
+├── .claude/
+│   ├── settings.json              # Hooks設定（自動ログ・学習）
+│   ├── agents/
+│   │   ├── secretary.md           # 秘書（メインエージェント）
+│   │   └── {subagent}.md × 20    # 専門Subagent
 │   ├── skills/
-│   │   ├── company/                  ← /company（メイン Skill）
-│   │   │   ├── SKILL.md
-│   │   │   └── references/           ← 部署テンプレート、ワークフロー定義等
-│   │   ├── company-admin/            ← /company-admin（マスタ管理 Skill）
-│   │   │   ├── SKILL.md
-│   │   │   └── references/
-│   │   ├── company-spawn/            ← /company-spawn（アプリリポ切り出し Skill）
-│   │   │   ├── SKILL.md
-│   │   │   └── references/
-│   │   ├── company-report/           ← /company-report（活動レポート Skill）
-│   │   │   └── SKILL.md
-│   │   └── company-evolve/           ← /company-evolve（継続学習 Skill）
-│   │       └── SKILL.md
-│   ├── agents/                       ← 20種の Subagent 定義
-│   │   ├── secretary.md
-│   │   ├── system-architect.md
-│   │   ├── devops-coordinator.md
-│   │   └── ...
-│   ├── hooks/                        ← インタラクションログ Hooks
-│   │   ├── capture-interaction.sh    ← PostToolUse: ツール実行ログ追記
-│   │   └── session-boundary.sh       ← Stop: 統計JSON生成 + Issue投稿
-│   └── agent-memory/                 ← エージェント学習データ（Git管理外）
-│       └── secretary/
-│           └── MEMORY.md             ← /company-evolve が自動更新
+│   │   ├── company/               # /company Skill
+│   │   ├── company-admin/         # /company-admin Skill
+│   │   ├── company-spawn/         # /company-spawn Skill
+│   │   ├── company-report/        # /company-report Skill
+│   │   └── company-evolve/        # /company-evolve Skill（継続学習）
+│   └── hooks/
+│       ├── capture-interaction.sh # PostToolUse: ツール実行ログ
+│       ├── session-boundary.sh    # Stop: セッション集計・GitHub Issue
+│       ├── skill-evaluator.sh     # 報酬スコア付与
+│       ├── rebuild-case-bank.sh   # Case Bank 再構築
+│       ├── skill-synthesizer.sh   # 新規Skill自動生成
+│       └── subagent-refiner.sh    # Agent精緻化・新規生成
 │
-├── .companies/                       ← 組織データ（マルチ組織対応）
-│   ├── .active                       ← アクティブ組織（ローカル管理・Git管理外）
-│   └── {org-slug}/                   ← 組織ごとのディレクトリ
-│       ├── CLAUDE.md                 ← 組織ルール（ルート直下）
-│       ├── masters/                  ← マスタデータ（ルート直下）
-│       │   ├── organization.md
-│       │   ├── departments.md
-│       │   ├── roles.md
-│       │   ├── workflows.md
-│       │   └── projects.md          ← 実装リポジトリURLも記録
-│       ├── .task-log/                ← タスク実行ログ
-│       ├── .interaction-log/         ← Hooks自動生成ログ（Git管理外）
-│       ├── .session-summaries/       ← セッション統計JSON（Hooks自動生成・Git管理外）
-│       └── docs/                     ← 全成果物はここに集約
-│           ├── secretary/
-│           │   └── reports/          ← /company-report が生成するレポート
-│           ├── architecture/
-│           ├── data/
-│           └── ...
+├── .companies/
+│   ├── .active                    # 現在のアクティブ組織
+│   └── {org-slug}/
+│       ├── CLAUDE.md              # 組織状態サマリー
+│       ├── masters/               # 組織マスタ（顧客・役割・ワークフロー）
+│       ├── docs/                  # 成果物（Git管理）
+│       ├── .task-log/             # タスク実行ログ（Git管理）
+│       ├── .interaction-log/      # ツール実行ログ（Git管理外）
+│       ├── .session-summaries/    # セッション統計（Git管理外）
+│       └── .case-bank/            # 継続学習インデックス（Git管理外）
 │
-├── dist/cc-sier/                     ← 配布用プラグインパッケージ
-│   ├── .claude-plugin/
-│   ├── skills/
-│   └── agents/
-│
-├── docs/
-│   └── requirements.md               ← 要件定義書
-├── CLAUDE.md                         ← 開発用指示ファイル
-├── README.md
-└── LICENSE
+└── docs/
+    └── guide/                     # 詳細ガイド
 ```
-
-| 層 | パス | 役割 |
-|----|------|------|
-| Skills / Subagent / Hooks | `.claude/` | Skill、Subagent、インタラクションログ Hooks の実体 |
-| 組織データ | `.companies/` | マスタ定義 + `docs/` 配下の成果物（案件ごとに独立） |
-| 配布パッケージ | `dist/` | `sync-to-dist.sh` で生成するプラグイン配布用ファイル |
 
 ---
 
-## /company-spawn によるアプリリポジトリ切り出し
+## クイックスタート
 
-cc-sier で設計した成果物をもとに、実装用の独立リポジトリを作成できる。
-
-### 切り出しの流れ
-
-```
-cc-sier-organization/          a-sha-dwh-app/（新リポ）
-
-.companies/a-sha-dwh/          ┌─ CLAUDE.md（設計参照情報付き）
-├── docs/                      ├─ .claude/agents/
-│   ├── data/models/ ─────────→│   ├─ data-architect.md（パス書換済）
-│   │   └── architecture.md    │   └─ cloud-engineer.md（パス書換済）
-│   └── architecture/          ├─ docs/design/
-│       └── adrs/ ────────────→│   ├─ architecture.md
-│                              │   ├─ ADR-001.md
-.claude/agents/                │   └─ origin.md（出自追跡情報）
-├── data-architect.md ────────→├─ src/
-└── cloud-engineer.md ────────→│   ├─ dbt/（スキャフォールド）
-                               │   └─ terraform/
-                               └─ README.md
-```
-
-### 新リポでのSubagent利用
-
-エクスポートされたSubagentは新リポ用にパスが自動書き換えされるため、そのまま使える。
+### 1. セットアップ
 
 ```bash
-cd ../a-sha-dwh-app
-claude
+git clone https://github.com/SAS-Sasao/cc-sier-organization
+cd cc-sier-organization
 
-# data-architectがdocs/配下に成果物を保存する
-# （.companies/{org}/docs/ ではなく docs/ に書き換え済み）
+# Hooksの実行権限を付与
+chmod +x .claude/hooks/*.sh
+
+# GitHub CLI（自動Issue投稿に必要）
+gh auth login
 ```
 
-### 設計トレーサビリティ
+### 2. 組織に入る
 
-新リポの `docs/design/origin.md` に、どのcc-sier組織のどの設計に基づいているかが記録される。cc-sier側の `masters/projects.md` にも新リポのURLが記録され、双方向のトレーサビリティが維持される。
-
----
-
-## ログと自動記録
-
-cc-sier は Hooks と Skill を組み合わせて、操作ログの自動記録からレポート生成までを一気通貫で行う。
-
-### 動作フロー
-
-```
-セッション中                          セッション終了
-─────────────                        ──────────────
-PostToolUse hook                     Stop hook
-  │                                    │
-  ├─ ツール実行を検知                    ├─ ログに区切り線を追記
-  ├─ .interaction-log/YYYY-MM-DD.md    ├─ .session-summaries/ にJSON保存
-  │  に1行追記                          └─ GitHub Issue にミニサマリー投稿
-  └─ ツール名・パス・コマンドを記録
-                                     ─────────────
-                                     /company-report（任意実行）
-                                       │
-                                       ├─ 4ソースを統合して収集
-                                       ├─ AIが要約してレポート生成
-                                       ├─ md保存 + Issue投稿 + PR作成
-                                       └─ /company-evolve を自動起動
-                                            │
-                                            ├─ パターン抽出（好み・ルーティング・ワークフロー）
-                                            ├─ MEMORY.md に学習結果を書き込み
-                                            └─ 次のセッションから先読み提案が有効に
+```bash
+/company jutaku-dev-team
 ```
 
-### `.interaction-log/` と `.session-summaries/` の違い
-
-| 項目 | `.interaction-log/` | `.session-summaries/` |
-|------|--------------------|-----------------------|
-| 生成タイミング | ツール実行のたび（PostToolUse） | セッション終了時（Stop） |
-| ファイル形式 | Markdown（日別1ファイル） | JSON（セッション別1ファイル） |
-| 内容 | ツール実行の詳細ログ（全行） | ツール種別ごとの集計・書き込みファイル一覧 |
-| 用途 | 詳細な操作履歴の確認 | `/company-report` の統計データソース |
-| AI依存 | なし（bash のみ） | なし（bash のみ） |
-
-### GitHub Issue の仕組み
-
-- **1日1件ルール**: 同日の最初のセッションで Issue を新規作成。2回目以降のセッションは既存 Issue にコメントを追記
-- **ラベル**: `interaction-log` + `org:{slug}` で自動分類
-- **各コメントの内容**: ツール種別ごとの統計テーブル + 書き込みファイル一覧 + 全ログ（折りたたみ）
-- **前提条件**: `gh` CLI がインストール済み＆認証済みの場合のみ投稿（未認証ならローカルログのみ）
-
-### `/company-report` の使い方
-
-期間を指定して活動レポートを生成する。
+### 3. 依頼する
 
 ```
-/company-report          # 当日のレポート（デフォルト）
-今週のレポートを作って    # 過去7日
-月次振り返り              # 当月1日〜今日
-3/19〜3/21のレポート      # カスタム日付範囲
+A社の要件定義書を作成してほしい。
+クラウドネイティブなWebシステムで、ユーザー管理・在庫管理・発注管理が必要。
 ```
 
-4つの情報源を統合:
-
-| 情報源 | 収集内容 |
-|--------|---------|
-| `.session-summaries/*.json` | セッション数・ツール実行数・書き込みファイル一覧 |
-| `.task-log/*.md` | 完了タスク・進行中タスクの一覧 |
-| `docs/` 配下の成果物 | `git log` で期間内の変更ファイルを部署別に整理 |
-| GitHub Issues | クローズ・オープンのIssue一覧（`org:{slug}` ラベルで絞り込み） |
-
-出力先:
-- `docs/secretary/reports/YYYY-MM-DD-{period}.md` にmdファイル保存
-- GitHub Issue に投稿（ラベル: `company-report`, `org:{slug}`）
-- Git ブランチ作成 → コミット → PR作成まで自動実行
-- レポート完了後、自動的に `/company-evolve` を起動して継続学習を実行
-
----
-
-## 継続学習（/company-evolve）
-
-cc-sier は使うほど賢くなる。過去のログからパターンを抽出し、エージェントメモリを自動更新する。
-
-### フライホイール
+### 4. 学習を走らせる
 
 ```
-   セッション実行
-        │
-        ▼
-   Hooks がログ・統計を自動蓄積
-   (.interaction-log/ + .session-summaries/)
-        │
-        ▼
-   /company-report でレポート生成
-        │
-        ▼
-   /company-evolve が自動起動
-        │
-        ▼
-   パターン抽出 → MEMORY.md 更新
-        │
-        ▼
-   次のセッションで秘書が先読み提案
-        │
-        ▼
-   より効率的な作業 → より多くの蓄積 ─── (ループ)
-```
-
-### 3つの学習ドメイン
-
-| 学習内容 | 検出条件 | 書き込み先 |
-|---------|---------|-----------|
-| 出力スタイルの好み | requestに「ASCII図」「比較表」「簡潔に」が3回以上等 | `.claude/agent-memory/secretary/MEMORY.md` |
-| よく使うSubagentの先読み | task-log の委譲先を集計してランキング化 | `.claude/agent-memory/secretary/MEMORY.md` |
-| 繰り返しパターンのワークフロー登録 | 同じ操作が3回以上繰り返されたら自動登録 | `.companies/{org}/masters/workflows.md` |
-
-### MEMORY.md の仕組み
-
-- セクション単位で上書き（追記しないため200行制限に引っかからない）
-- 上位5件のみ残し、古いエントリは新しいものに置き換え
-- `workflows.md` への書き込みのみ Git 管理（ブランチ → PR）
-- MEMORY.md はローカル管理（`.gitignore` で除外）
-- パターン検出はコストゼロの bash 集計ベース（API 呼び出しなし）
-
-### 効果のイメージ
-
-```
-初回セッション:
-  あなた: 「A社のインフラ構成を設計して」
-  秘書:   トリガーワード「インフラ」→ cloud-engineer に委譲
-
-5回目のセッション（学習後）:
-  あなた: 「A社の」
-  秘書:   「今日もDWH設計ですか？data-architectに直接繋ぎましょうか？
-           前回と同じくASCII図付きで出力します。」
+/company-evolve
 ```
 
 ---
 
-## マルチユーザー運用
+## インストール要件
 
-### 仕組み
+- Claude Code（最新版）
+- Git
+- GitHub CLI（`gh`）: Issue/PR の自動作成に必要
+- Python 3（継続学習の Case Bank 構築に必要）
+- bash
 
-- `.companies/.active` はGit管理外（`.gitignore` で除外）
-- 各メンバーが `/company` 実行時にローカルの `.active` を設定
-- コミットメッセージ・タスクログに `by {operator}` が自動記録（`git config user.name` から取得）
-- PRに作業者情報が含まれるため、誰がどの作業をしたか追跡可能
+---
 
-### 運用パターン
+## 詳細ガイド
 
-```
-リポジトリ: cc-sier-organization（全員がクローン）
-  │
-  ├── Aさん: .active = standardization-initiative
-  │   └── 標準化の壁打ち・WBS作成 → PRで共有
-  │
-  ├── Bさん: .active = jutaku-dev-team
-  │   └── 受託案件の設計レビュー → PRで共有
-  │
-  └── Cさん: .active = a-sha-dwh
-      └── DWH設計 → /company-spawn で実装リポ作成
-```
+| ドキュメント | 内容 |
+|---|---|
+| [00 全体概要](docs/guide/00-overview.md) | 設計思想・アーキテクチャ |
+| [01 クイックスタート](docs/guide/01-quickstart.md) | 初期設定から最初の依頼まで |
+| [02 Skills リファレンス](docs/guide/02-skills.md) | 全Skillの使い方と引数 |
+| [03 Subagent 一覧](docs/guide/03-subagents.md) | 各Subagentの役割と得意領域 |
+| [04 Hooks 設定](docs/guide/04-hooks.md) | 自動ログ・カスタマイズ |
+| [05 継続学習システム](docs/guide/05-learning-system.md) | Phase 1〜3の詳細仕様 |
+| [06 マルチ組織運用](docs/guide/06-multi-org.md) | 複数組織の管理方法 |
+| [07 company-spawn](docs/guide/07-company-spawn.md) | アプリリポジトリの切り出し方 |
 
 ---
 

--- a/docs/guide/00-overview.md
+++ b/docs/guide/00-overview.md
@@ -1,0 +1,127 @@
+# 00 全体概要
+
+cc-sier-organization の設計思想とアーキテクチャを説明します。
+
+---
+
+## 設計思想
+
+### 「組織」をコードで表現する
+
+SIerの日常業務は高度に構造化されています。顧客ごとの制約、役割分担、成果物フォーマット、承認フロー。これらを毎回プロンプトで説明するのは無駄であり、ミスの原因にもなります。
+
+cc-sier-organization は「組織のルール・知識・役割分担」をリポジトリ内のファイルとして表現し、Claude Code がそれを自律的に参照しながら動くことを目指しています。
+
+```
+従来の使い方:
+  あなた ──「A社のDWH設計。A社はOracleを使っていて、XXX制約があって...」──▶ Claude
+
+cc-sier-organization の使い方:
+  あなた ──「A社のDWH設計をやって」──▶ 秘書 ──▶ data-architect
+                                        ↑
+                              masters/customers/a-corp.md を自動参照
+```
+
+### Memento-Skills：使うほど賢くなる
+
+静的な設定ファイルだけでは、使い込むほど生まれる「暗黙知」を蓄積できません。cc-sier-organization は論文「Memento-Skills: Let Agents Design Agents」の設計を実装し、以下の学習ループを持ちます。
+
+```
+実行 → 評価（報酬スコア） → Case Bank 蓄積 → 次の判断に反映
+                                    ↓
+                          高品質パターンを検出
+                                    ↓
+                  新規Skill/Subagent として自動生成（PR提案）
+```
+
+LLMのパラメータを更新することなく、**Skill ファイル（Markdown）自体が進化的なメモリとして機能**します。
+
+---
+
+## アーキテクチャ全体図
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Claude Code セッション                   │
+│                                                          │
+│  あなた ──依頼──▶ secretary.md                            │
+│                      │                                   │
+│              ┌───────┴───────┐                           │
+│              │  Read フェーズ  │                           │
+│              │ Case Bank 参照 │                           │
+│              └───────┬───────┘                           │
+│                      │ 類似ケース注入                      │
+│                      ▼                                   │
+│               振り分け判断                                │
+│              ┌────┬────┬────┐                            │
+│              ▼    ▼    ▼    ▼                            │
+│           SA-1  SA-2  SA-3  SA-N    ← 20種Subagent       │
+│              └────┴────┴────┘                            │
+│                      │                                   │
+│                      ▼                                   │
+│                成果物生成 → .companies/{org}/docs/         │
+│                      │                                   │
+│                      ▼                                   │
+│              Git PR 作成（自動）                          │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+             │                          │
+      PostToolUse Hook              Stop Hook
+             │                          │
+             ▼                          ▼
+   .interaction-log/         .session-summaries/ + GitHub Issue
+             │                          │
+             └──────────┬───────────────┘
+                        │
+              /company-evolve（Write フェーズ）
+                        │
+            ┌───────────┴────────────┐
+            │                        │
+      Case Bank 構築          Skill/Agent 進化
+      (.case-bank/index.json)   (PR提案)
+```
+
+---
+
+## ファイル・ロールの関係
+
+### `.claude/` ─ Claude Code の設定
+
+| ファイル | 役割 |
+|---|---|
+| `settings.json` | Hooks の設定（どのイベントにどのスクリプトを実行するか） |
+| `agents/secretary.md` | 秘書エージェントの行動規範・起動時手順 |
+| `agents/{name}.md` | 各専門Subagentの役割・出力形式・制約 |
+| `skills/{name}/SKILL.md` | Claude Code `/コマンド` の実行手順 |
+| `hooks/*.sh` | イベント駆動スクリプト |
+
+### `.companies/{org-slug}/` ─ 組織データ
+
+| ファイル/ディレクトリ | 役割 | Git 管理 |
+|---|---|---|
+| `CLAUDE.md` | 組織状態サマリー（秘書が毎回読む） | ✅ |
+| `masters/` | 顧客・役割・ワークフロー定義 | ✅ |
+| `docs/` | 成果物（設計書・報告書など） | ✅ |
+| `.task-log/` | タスク実行ログ（reward スコア付き） | ✅ |
+| `.interaction-log/` | ツール実行の詳細ログ | ❌ |
+| `.session-summaries/` | セッション統計 JSON | ❌ |
+| `.case-bank/` | 継続学習インデックス | ❌ |
+
+---
+
+## Skill vs Subagent の使い分け
+
+| | Skill | Subagent |
+|---|---|---|
+| 呼び出し方 | `/company` などのスラッシュコマンド | 秘書が自動で委譲 |
+| 役割 | 決まった手順のワークフロー（手順書） | 特定分野の専門家（判断と実行） |
+| 設定ファイル | `.claude/skills/{name}/SKILL.md` | `.claude/agents/{name}.md` |
+| 自動生成 | Skill Synthesizer が生成 | Subagent Spawner が生成 |
+
+---
+
+## 次のステップ
+
+- セットアップを始めるには [01 クイックスタート](01-quickstart.md) へ
+- コマンド一覧を確認するには [02 Skills リファレンス](02-skills.md) へ
+- 継続学習の仕組みを深く理解するには [05 継続学習システム](05-learning-system.md) へ

--- a/docs/guide/01-quickstart.md
+++ b/docs/guide/01-quickstart.md
@@ -1,0 +1,112 @@
+# 01 クイックスタート
+
+セットアップから最初のタスク完了まで、15分でできます。
+
+---
+
+## 前提条件
+
+```bash
+claude --version    # Claude Code
+git --version       # Git
+gh --version        # GitHub CLI（Issue/PR自動作成に必要）
+python3 --version   # 継続学習のCase Bank構築に必要
+```
+
+---
+
+## Step 1: リポジトリのセットアップ
+
+```bash
+git clone https://github.com/SAS-Sasao/cc-sier-organization
+cd cc-sier-organization
+
+# Hooksスクリプトに実行権限を付与
+chmod +x .claude/hooks/*.sh
+
+# GitHub CLI の認証（初回のみ）
+gh auth login
+```
+
+---
+
+## Step 2: 組織に入る
+
+Claude Code を起動し、使用する組織を選択します。
+
+```
+/company jutaku-dev-team
+```
+
+**利用可能な組織（初期）:**
+
+| org-slug | 用途 |
+|---|---|
+| `jutaku-dev-team` | 受注開発プロジェクト |
+| `standardization-initiative` | 社内標準化 |
+| `domain-tech-collection` | 技術調査・知識収集 |
+
+新しい組織を作るには → [06 マルチ組織運用](06-multi-org.md)
+
+---
+
+## Step 3: 最初のタスクを依頼する
+
+```
+A社の受注システムについて要件定義書を作成してほしい。
+ECサイトで商品管理、注文管理、顧客管理が必要。
+AWSを使う予定。
+```
+
+秘書が business-analyst → technical-writer の順で委譲し、
+`docs/system/requirements/` に成果物を配置してPRを作成します。
+
+---
+
+## Step 4: 継続学習を初回実行する
+
+```
+/company-evolve
+```
+
+Case Bank が構築され、次のセッションから秘書のルーティング精度が向上します。
+
+---
+
+## よくある使い方パターン
+
+### プロジェクト管理
+
+```
+今日のタスクを整理して
+B社向けのシステム設計書（概要レベル）を作成して
+今日の進捗をまとめて
+```
+
+### 技術調査
+
+```
+/company domain-tech-collection
+
+Apache Kafkaについて調査して。
+AWSのMSKとの比較、SIer案件での適用ケースをまとめてほしい。
+```
+
+### 週次レポート
+
+```
+/company-report week
+```
+
+---
+
+## トラブルシューティング
+
+**`gh: command not found`**
+GitHub CLI をインストールしてください。ログ記録・PR作成機能が使えなくなります。
+
+**`.companies/.active が存在しない`**
+`/company {org-slug}` を先に実行してアクティブ組織を設定してください。
+
+**`Case Bank not found, skipping`**
+`/company-evolve` を実行する前に少なくとも1件タスクを完了させてください。

--- a/docs/guide/02-skills.md
+++ b/docs/guide/02-skills.md
@@ -1,0 +1,92 @@
+# 02 Skills リファレンス
+
+---
+
+## /company
+
+組織を選択・切り替えます。
+
+```
+/company {org-slug}
+/company              ← 一覧表示
+```
+
+**動作:** `.companies/{org-slug}/` を確認 → `.companies/.active` を更新 → `CLAUDE.md` と `masters/` を読み込み
+
+---
+
+## /company-admin
+
+組織のマスタデータを作成・更新・削除します。
+
+| マスタ | ファイル | 内容 |
+|---|---|---|
+| 顧客情報 | `masters/customers/{slug}.md` | 顧客名・制約・担当者・技術スタック |
+| 役割定義 | `masters/roles.md` | 組織内の役割と責任範囲 |
+| ワークフロー | `masters/workflows.md` | 定型業務の手順テンプレート |
+
+すべての変更はブランチ経由でPRを作成します（直接mainへのコミットなし）。
+
+---
+
+## /company-report
+
+組織の活動レポートを生成します。
+
+```
+/company-report [period]
+```
+
+| 引数 | 対象期間 |
+|---|---|
+| `today`（省略時） | 本日 |
+| `week` | 過去7日 |
+| `month` | 当月1日〜今日 |
+| `2026-03-01:2026-03-15` | カスタム日付範囲 |
+
+**レポートの内容:** エグゼクティブサマリー / 活動統計 / 完了タスク / 進行中タスク / 成果物一覧 / Issue動向 / 次のアクション候補
+
+**出力先:** `docs/secretary/reports/YYYY-MM-DD-{period}.md` + GitHub Issue + Git PR
+
+完了後: `/company-evolve` が自動起動します。
+
+---
+
+## /company-evolve
+
+組織の継続学習を実行します。
+
+```
+/company-evolve [days]   ← days省略時は30日
+```
+
+| Phase | 処理 |
+|---|---|
+| 1 | Skill Evaluator: タスクに報酬スコアを付与 |
+| 1 | Case Bank 再構築: 全タスクをインデックス化 |
+| 2 | MEMORY.md 更新: 出力スタイル・ルーティング先読み |
+| 2 | ワークフロー自動生成: 高品質パターンを手順書に |
+| 3 | Skill Synthesizer: 繰り返しパターンに新規Skillを提案（PR） |
+| 3 | Subagent Refiner: 実績データでAgentを更新（PR） |
+| 3 | Subagent Spawner: 対応Agentがない作業に新規Agentを提案（PR） |
+
+詳細は [05 継続学習システム](05-learning-system.md) を参照。
+
+---
+
+## /company-spawn
+
+新しいアプリリポジトリを生成します。詳細は [07 company-spawn](07-company-spawn.md) を参照。
+
+---
+
+## Tips
+
+**Skill とSubagent の使い分け:**
+```
+/company-report week    ← 決まったフロー → Skill
+B社の新システムを設計して  ← 創造的判断 → 秘書 → Subagent
+```
+
+**masters/ を充実させると精度が上がる:**
+特に `masters/customers/{slug}.md` の技術スタック・制約欄が重要です。

--- a/docs/guide/03-subagents.md
+++ b/docs/guide/03-subagents.md
@@ -1,0 +1,91 @@
+# 03 Subagent 一覧
+
+---
+
+## secretary（秘書）
+
+メインエージェント。起動時に `.case-bank/index.json` を読み込み（Read フェーズ）、
+`masters/` を参照して Subagent に委譲し、タスクログを記録して Git PR を作ります。
+
+---
+
+## 設計・インフラ系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| system-architect | システム全体のアーキテクチャ設計 | 非機能要件定義、技術選定、構成図 | `docs/system/architecture/` |
+| data-architect | データ基盤・DWH設計 | ER図、テーブル設計、クラウドDWH選定 | `docs/data/` |
+| infra-engineer | インフラ設計・IaC | AWS/Azure構成設計、Terraform、コスト試算 | `docs/infra/` |
+
+---
+
+## 開発系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| backend-engineer | バックエンド実装・API設計 | Django/FastAPI、REST API設計 | `docs/system/api/` |
+| frontend-engineer | フロントエンド実装・UI設計 | React/Vue、レスポンシブ、アクセシビリティ | `docs/system/frontend/` |
+| devops-engineer | CI/CD・運用設計 | GitHub Actions、Docker、監視設計 | `docs/infra/cicd/` |
+
+---
+
+## 文書系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| technical-writer | 技術文書の作成・整備 | 要件定義書、設計書、手順書 | `docs/system/` |
+| proposal-writer | 提案書・見積書の作成 | RFP対応、コスト積算 | `docs/proposals/` |
+| report-writer | 報告書・議事録の作成 | 進捗報告、月次報告書 | `docs/reports/` |
+
+---
+
+## PM系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| project-manager | プロジェクト計画・進捗管理 | WBS作成、リスク管理 | `docs/pm/` |
+| scrum-master | アジャイル開発の推進 | スプリント計画、バックログ整理 | `docs/pm/agile/` |
+
+---
+
+## 分析系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| business-analyst | ビジネス要件の分析・整理 | ヒアリング設計、業務フロー分析 | `docs/system/requirements/` |
+| data-analyst | データ分析・可視化設計 | KPI設計、ダッシュボード設計 | `docs/data/analytics/` |
+| cost-optimizer | コスト最適化の提案 | AWSコスト分析、Reserved Instance戦略 | `docs/infra/cost/` |
+
+---
+
+## 知識管理系
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| knowledge-manager | 知識の整理・体系化 | ナレッジベース構築、FAQ作成 | `docs/knowledge/` |
+| domain-researcher | 技術・ドメインの調査 | 技術比較、市場調査、トレンド分析 | `docs/research/` |
+
+---
+
+## 品質・その他
+
+| Subagent | 役割 | 得意 | 成果物 |
+|---|---|---|---|
+| code-reviewer | コードレビュー | セキュリティチェック、パフォーマンス分析 | `docs/review/` |
+| qa-engineer | テスト設計・品質保証 | テスト計画、テストケース設計 | `docs/qa/` |
+| security-engineer | セキュリティ設計・脆弱性評価 | 脅威モデリング、ISMS対応 | `docs/security/` |
+| integration-specialist | システム連携・API統合 | EDI連携、API連携設計 | `docs/integration/` |
+
+---
+
+## Subagentの自動精緻化（Phase 3）
+
+`/company-evolve` の Subagent Refiner が以下を自動更新します（3件以上の新規ケースでトリガー）。
+
+| 更新セクション | 内容 |
+|---|---|
+| `refined_capabilities` | 高報酬ケースから導出した得意領域 |
+| `output_format` | 過去ケースの実際の出力先ディレクトリ |
+| `constraints` | 低報酬ケース（reward < 0.4）から導出した注意事項 |
+
+対応Subagentが存在しない繰り返しパターンを検出すると、Subagent Spawner が新規 Subagent を自動生成してPR提案します。

--- a/docs/guide/04-hooks.md
+++ b/docs/guide/04-hooks.md
@@ -1,0 +1,97 @@
+# 04 Hooks 設定
+
+---
+
+## 概要
+
+| Hook タイプ | タイミング | スクリプト | 役割 |
+|---|---|---|---|
+| `PostToolUse` | ツール実行のたびに | `capture-interaction.sh` | インタラクションログ記録 |
+| `Stop` | Claude の応答完了時 | `session-boundary.sh` | セッション統計・GitHub Issue・学習 |
+
+---
+
+## settings.json の設定
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": "bash .claude/hooks/capture-interaction.sh"}]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": "bash .claude/hooks/session-boundary.sh"}]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## capture-interaction.sh（PostToolUse）
+
+ツール実行のたびに `.interaction-log/YYYY-MM-DD.md` に記録します。
+
+```markdown
+### 14:32:15 | tool: Write
+
+- path: `.companies/jutaku-dev-team/docs/system/requirements.md`
+- action: write
+- session: abc123
+```
+
+ログは `.gitignore` に含まれており、Git 管理外です。
+
+---
+
+## session-boundary.sh（Stop）
+
+セッション終了時に以下を順番に実行します。
+
+```
+1. session_id 取得
+2. .companies/.active から org-slug 取得
+3. .interaction-log/ に区切り線追記
+4. ツール種別カウント（Write/Read/Bash/Other）
+5. .session-summaries/ に統計JSON保存
+6. GitHub Issue に投稿（1日1件・追記方式）
+7. [Phase 1] Skill Evaluator: 本日タスクの報酬スコア付与
+8. [Phase 1] Case Bank 再構築
+9. [Phase 3] Skill Synthesizer: 新規Skill候補をPR提案
+10. [Phase 3] Subagent Refiner/Spawner: Agent更新をPR提案
+```
+
+### GitHub Issue のルール
+
+- **1日1件**: 同日の複数セッションはコメントとして追記
+- **ラベル**: `interaction-log`, `org:{slug}`
+- **本文**: ミニサマリー + ログ全文（`<details>` で折りたたみ）
+
+---
+
+## カスタマイズ
+
+**特定ツールのみ記録する:**
+```json
+{"matcher": "Write|Edit|CreateFile"}   // Write系のみ
+{"matcher": ".*"}                       // すべて（デフォルト）
+```
+
+**Phase 3 の PR が多すぎる場合:**
+`session-boundary.sh` の Phase 3 呼び出しブロックをコメントアウトして、`/company-evolve` を手動で実行するときだけ走らせることができます。
+
+---
+
+## 動作確認
+
+```bash
+# interaction-log が更新されているか確認
+ls -la .companies/jutaku-dev-team/.interaction-log/
+tail -20 .companies/jutaku-dev-team/.interaction-log/$(date +%Y-%m-%d).md
+```

--- a/docs/guide/05-learning-system.md
+++ b/docs/guide/05-learning-system.md
@@ -1,0 +1,182 @@
+# 05 継続学習システム
+
+---
+
+## 設計思想
+
+論文「Memento-Skills: Let Agents Design Agents」の実装です。LLMのパラメータを更新することなく継続学習を実現します。
+
+```
+通常の学習:    経験 → パラメータ更新（ファインチューニング）
+Memento-Skills: 経験 → Skill ファイル（Markdown）の更新
+```
+
+**「進化的なメモリ」として機能するファイル一覧:**
+
+| ファイル | メモリとしての役割 |
+|---|---|
+| `.task-log/*.md` | エピソードメモリ（過去の実行履歴） |
+| `.case-bank/index.json` | 構造化エピソードメモリ |
+| `secretary/MEMORY.md` | 作業スタイルの好み・ルーティング傾向 |
+| `masters/workflows.md` | 手続き的メモリ（成功した手順） |
+| `.claude/agents/*.md` | Subagentの知識・制約（Refinerが更新） |
+| `.claude/skills/*/SKILL.md` | Skill定義（Synthesizerが生成） |
+
+---
+
+## Phase 1: ポリシー評価
+
+### Skill Evaluator（報酬スコア付与）
+
+セッション終了時に `skill-evaluator.sh` が本日完了したタスクを評価します。
+
+| シグナル | 条件 | 点数 |
+|---|---|---|
+| 基礎点 | status が completed | 60点 |
+| artifacts_exist | 成果物ファイルが実際に存在する | +20点 |
+| no_excessive_edits | 同一ファイルへのWriteが5回以下 | +20点 |
+| no_retry | 「やり直し」等が検出されない | ペナルティなし |
+
+スコアは 0.0〜1.0 に正規化して task-log に追記します。
+
+| スコア | 意味 | 活用 |
+|---|---|---|
+| 0.7 以上 | 高品質 | Skill生成・ワークフロー登録の候補 |
+| 0.4〜0.7 | 普通 | Case Bankに記録するが特別扱いしない |
+| 0.4 未満 | 低品質 | constraints への注意事項追記 |
+
+### Case Bank（構造化エピソードメモリ）
+
+`rebuild-case-bank.sh` が task-log 全件を走査して `.case-bank/index.json` を再構築します。
+
+```json
+{
+  "cases": [
+    {
+      "id": "20260319-143000-dwh-design",
+      "state": {
+        "request_keywords": ["DWH", "設計", "メダリオン"],
+        "request_head": "A社のDWH設計をやって"
+      },
+      "action": {
+        "subagent": "data-architect",
+        "mode": "subagent",
+        "artifact_count": 3
+      },
+      "reward": 0.9,
+      "outcome": {
+        "files_written": [".companies/jutaku-dev-team/docs/data/models/architecture.md"]
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Phase 2: スタイル学習
+
+### MEMORY.md の更新
+
+`docs/secretary/MEMORY.md` に出力スタイルとルーティング先読みを記録します。
+
+| 検出条件 | 記録内容 |
+|---|---|
+| 「ASCII図」が3回以上 | `ASCII図を必ず添付する` |
+| 「比較表」が3回以上 | `比較表をセットで出力する` |
+| 「短く」が3回以上 | `簡潔な出力を好む` |
+
+### ワークフロー自動生成
+
+高報酬パターン（3件以上・平均reward≥0.7）を `masters/workflows.md` に自動追記します。
+
+---
+
+## Phase 3: 自律進化
+
+### Skill Synthesizer
+
+**「手順書がないのに繰り返している作業」を検出してSkillを自動生成します。**
+
+検出条件:
+- mode が `direct`（Skillなしで直接対応）
+- artifact_count ≥ 2（成果物がある）
+- reward ≥ 0.5（品質が担保されている）
+- 同じ request_head が3件以上
+- 既存Skillトリガーとの重複 ≤ 50%
+
+生成先: `.claude/skills/{slug}/SKILL.md` → PR 経由でレビュー
+
+### Subagent Refiner
+
+**実績データで既存Subagentの説明文を精緻化します。**（前回更新から3件以上新規ケースでトリガー）
+
+追記される3セクション:
+- `refined_capabilities`: 高報酬ケースから導出した得意領域
+- `output_format`: 過去ケースの実際の出力先ディレクトリ
+- `constraints`: 低報酬ケースから導出した注意事項
+
+### Subagent Spawner
+
+**対応Subagentがない繰り返し作業に新規Subagentを生成します。**
+
+検出条件: direct mode かつ artifact_count ≥ 2 かつ 3件以上 かつ avg_reward ≥ 0.5 かつ 既存Agentに同名なし
+
+生成先: `.claude/agents/{slug}.md` → PR 経由でレビュー
+
+---
+
+## Read フェーズ：次のセッションへの反映
+
+秘書の起動時に Case Bank を読み込み、類似ケースの高報酬パターンを Stateful Prompt として注入します。
+
+```
+【過去の類似ケース（Case Bank より）】
+- 「A社のDWH設計をやって」→ data-architect（subagent）報酬:0.90
+高報酬ケースと同じルーティングを優先すること。
+```
+
+照合ロジック: request_keywords の重複率 ≥ 0.3 で「類似」と判定（API コストゼロ）。
+
+---
+
+## 全フェーズのデータフロー
+
+```
+セッション実行
+    ↓ PostToolUse
+.interaction-log/YYYY-MM-DD.md に記録
+
+セッション終了（Stop hook）
+    ├── .session-summaries/ に統計JSON
+    ├── GitHub Issue に投稿
+    ├── [Phase 1] task-log に reward スコア付与
+    ├── [Phase 1] .case-bank/index.json を再構築
+    ├── [Phase 3] 新規SKILL.md の PR
+    └── [Phase 3] Agent更新の PR
+
+/company-evolve（定期 or /company-report 後自動）
+    ├── [Phase 2] MEMORY.md 更新
+    ├── [Phase 2] workflows.md 追記
+    ├── [Phase 3] skill-synthesizer 再実行
+    └── [Phase 3] subagent-refiner 再実行
+
+次のセッション起動
+    → 秘書が .case-bank/index.json を Read
+    → Stateful Prompt として注入
+    → より精度の高いルーティング
+```
+
+---
+
+## ファイルのGit管理方針
+
+| ファイル | Git管理 | 理由 |
+|---|---|---|
+| `.task-log/*.md` | ✅ | 成果物・履歴として保存 |
+| `masters/workflows.md` | ✅ | チーム共有する知識 |
+| `agents/*.md` | ✅ | レビュー経由で更新 |
+| `skills/*/SKILL.md` | ✅ | レビュー経由で更新 |
+| `.interaction-log/` | ❌ | 生ログは大きく個人的 |
+| `.session-summaries/` | ❌ | 中間データ |
+| `.case-bank/` | ❌ | ローカル学習データ |

--- a/docs/guide/06-multi-org.md
+++ b/docs/guide/06-multi-org.md
@@ -1,0 +1,59 @@
+# 06 マルチ組織運用
+
+---
+
+## 組織とは
+
+`.companies/{org-slug}/` 以下のディレクトリが1つの「組織」です。
+顧客単位、部署単位、プロジェクト単位など任意の粒度で作成できます。
+
+```
+.companies/
+├── .active                      ← 現在のアクティブ組織
+├── jutaku-dev-team/
+├── standardization-initiative/
+└── domain-tech-collection/
+```
+
+---
+
+## 新しい組織を作る
+
+```
+/company-admin
+→「新しい組織を作りたい。org-slug は b-corp-renewal-project。
+  B社の既存システム刷新プロジェクト用。AWSメイン。」
+```
+
+自動作成されるもの:
+
+```
+.companies/b-corp-renewal-project/
+├── CLAUDE.md
+├── masters/
+│   ├── customers/
+│   ├── roles.md
+│   └── workflows.md
+└── docs/
+    └── secretary/
+```
+
+---
+
+## 組織を切り替える
+
+```
+/company b-corp-renewal-project
+```
+
+---
+
+## 組織をまたいだ知識共有
+
+| 共有される | 場所 |
+|---|---|
+| Subagentの定義 | `.claude/agents/*.md` |
+| Skillの定義 | `.claude/skills/*/SKILL.md` |
+| Hooksスクリプト | `.claude/hooks/*.sh` |
+
+Case Bank は組織ごとに独立しています。ただし Skill Synthesizer が生成した SKILL.md と Subagent Spawner が生成した agent.md は全組織で共有されます。

--- a/docs/guide/07-company-spawn.md
+++ b/docs/guide/07-company-spawn.md
@@ -1,0 +1,51 @@
+# 07 company-spawn
+
+---
+
+## 概要
+
+`/company-spawn` は、設計・検討したシステムを**実際の開発リポジトリとして切り出す**Skillです。
+
+```
+cc-sier-organization（組織・知識・設計）
+         │
+         │ /company-spawn
+         ↓
+{app-repo}/（実際の開発リポジトリ）
+  ├── CLAUDE.md        ← 親組織の知識を継承
+  ├── .claude/agents/  ← 必要なSubagentのみコピー
+  ├── src/
+  └── docs/            ← 設計書が移植される
+```
+
+---
+
+## 使い方
+
+```
+/company-spawn
+→「新しいリポジトリを作りたい。
+  名前は a-corp-ordering-system。
+  要件定義書と基本設計書は既にdocs/に作ってある。」
+```
+
+対話形式で以下を確認・設定します。
+
+| 質問 | 例 |
+|---|---|
+| リポジトリ名 | `a-corp-ordering-system` |
+| GitHub Organization | `SAS-Sasao` |
+| 移植する成果物 | `docs/system/requirements/`, `docs/data/` |
+| 必要なSubagent | `backend-engineer, devops-engineer` |
+| 言語・フレームワーク | `Python/Django, PostgreSQL` |
+
+---
+
+## 親組織との関係
+
+切り出し後、アプリリポジトリは独立した Claude Code プロジェクトとして動作します。
+
+- **cc-sier-organization**: 進捗追跡・設計変更提案・レポート生成
+- **{app-repo}**: 実際のコード開発・PR管理・アプリ固有の継続学習
+
+2リポジトリが並走する形になります。


### PR DESCRIPTION
## 変更内容

### README.md
- 「なぜ使うのか」比較表を冒頭に追加
- できること一覧を⑩まで更新（継続学習機能を反映）
- Memento-Skills ベースの継続学習セクションを追加
- ディレクトリ構成を最新化
- クイックスタートを簡潔化してガイドへの誘導を強化

### docs/guide/（新規作成）
- 00-overview.md: 設計思想・アーキテクチャ全体図
- 01-quickstart.md: セットアップ〜最初の依頼まで
- 02-skills.md: 全Skillの使い方と引数
- 03-subagents.md: 20種Subagentの役割一覧
- 04-hooks.md: 自動ログ・カスタマイズ方法
- 05-learning-system.md: Phase 1〜3の詳細仕様
- 06-multi-org.md: 複数組織の管理方法
- 07-company-spawn.md: アプリリポジトリの切り出し方

🤖 Generated with [Claude Code](https://claude.com/claude-code)