### PR TITLE
docs: 日次活動レポート 2026-03-23 [standardization-initiative]

### DIFF
--- a/.companies/standardization-initiative/docs/secretary/reports/2026-03-23-today.md
+++ b/.companies/standardization-initiative/docs/secretary/reports/2026-03-23-today.md
@@ -1,0 +1,89 @@
+# standardization-initiative 活動レポート — 2026-03-23（日次）
+
+> 生成日時: 2026-03-23 18:40 | 生成者: SAS-Sasao | 期間: 2026-03-23
+
+## エグゼクティブサマリー
+
+本日は `standardization-initiative` 組織の運用基盤整備に注力した。品質ゲートチェックリストのセットアップ、TODO進捗の更新（2/4件完了・2件対応中）、およびブランチ・PR必須ポリシーのワークフロー定義を実施。組織切替（domain-tech-collection → standardization-initiative）を行い、本格的な標準化活動の再開準備が整った。ファイル変更時のGitワークフロー運用ルールが明文化され、今後の成果物管理の一貫性が向上する見込み。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 1 回 |
+| ツール実行数（合計） | 88 回 |
+| 人間の発言数 | 59 回 |
+| Claudeの応答数 | 70 回 |
+| 作成・編集ファイル数 | 9 件 |
+| 完了タスク数 | 0 件（本日新規タスクログなし） |
+| オープンIssue数 | 4 件（interaction-log除外） |
+| クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+本日はタスクログ（.task-log/）に新規記録されたタスクはなし。
+過去のタスクログ（全4件、2026-03-19作成分）は全て completed 済み。
+
+## 進行中タスク
+
+なし（タスクログベース）
+
+## 作成・更新された成果物
+
+### masters/（組織基盤）
+- `masters/quality-gates/_default.md` — 共通品質チェックリスト（新規）
+- `masters/quality-gates/by-type/requirements.md` — 要件定義書チェック（新規）
+- `masters/quality-gates/by-type/design.md` — 設計書チェック（新規）
+- `masters/quality-gates/by-type/proposal.md` — 提案書チェック（新規）
+- `masters/quality-gates/by-type/report.md` — 報告書チェック（新規）
+- `masters/quality-gates/by-type/adr.md` — ADRチェック（新規）
+- `masters/quality-gates/by-customer/_template.md` — 顧客別テンプレート（新規）
+- `masters/workflows.md` — wf-branch-policy（ブランチ・PR必須ポリシー）追加
+
+### docs/secretary/
+- `docs/secretary/todos/2026-03-19.md` — TODO進捗更新（タスク1,2完了、3,4対応中）
+
+## Issue 動向
+
+### オープンIssue（全期間、interaction-log除外）
+- #9 [standardization-initiative] 標準化プロジェクトWBS・タスク管理表の作成
+- #7 [standardization-initiative] 見積標準化方針書の作成
+- #5 [standardization-initiative] WBSに基づくタスク管理表を作成
+- #3 [standardization-initiative] 提案書標準化プロジェクトのTODO + WBS作成
+
+### 本日クローズされたIssue
+なし
+
+## 会話トピック
+
+### セッション `19c62c88`（59発言 / 70応答 / 88ツール実行）
+
+1. `/company` 起動 → 組織選択UI表示
+2. 組織切替: `domain-tech-collection` → `standardization-initiative`
+3. `/company-quality-setup` 実行 → 品質ゲートチェックリスト配置
+4. 品質ゲートのコミット・プッシュ（mainへ直接）
+5. `/company` 再起動 → `standardization-initiative` で作業継続
+6. TODO進捗確認依頼 → 期限超過タスクのリストアップ
+7. TODO更新（1,2完了、3,4対応中）→ main直接編集の指摘を受けてブランチ切り直し
+8. ワークフロー定義追加の依頼 → `wf-todo-update` を追加
+9. ワークフロー修正の指摘 → 全ファイル変更対象の `wf-branch-policy` に書き換え
+10. PR #42 作成・マージ
+11. ローカルブランチ一括削除（4ブランチ）
+12. `/company-report` 実行（本レポート）
+
+### ファイル生成を伴わなかったやり取り
+- 組織選択・切替の対話
+- TODO進捗状況の口頭確認
+- ワークフロー方針に関するフィードバック（「全ファイル変更時にブランチ切ってほしい」）
+
+## 次のアクション候補
+
+1. **提案書台帳の雛形作成を完了する**（根拠: TODO #3 対応中、先週期限超過）
+2. **標準化推進室の部署追加を完了する**（根拠: TODO #4 対応中、`/company-admin` で実施）
+3. **SharePointアクセス権限を確認する**（根拠: ブロッカー未解消、来週タスクの前提条件）
+4. **顧客情報取り扱いルールを事前確認する**（根拠: ブロッカー未解消）
+5. **オープンIssue #3, #5, #7, #9 のステータスを棚卸しする**（根拠: 3/19作成から4日経過、進捗反映なし）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-23 の日次活動レポートを生成
- 情報源: session-summaries, task-log, docs変更履歴, GitHub Issues, conversation-log
- 品質ゲートセットアップ、TODO進捗更新、ブランチポリシー定義など本日の活動を網羅

## Test plan
- [ ] レポート内容が本日の活動と整合していること
- [ ] 次のアクション候補が実態と合っていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)