### PR TITLE
継続学習: reward評価・Case Bank更新 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260321-103000-store-computer-learning-plan.md
+++ b/.companies/domain-tech-collection/.task-log/20260321-103000-store-computer-learning-plan.md
@@ -49,3 +49,15 @@
 | ストコン ドメイン知識 | retail-domain-researcher | docs/retail-domain/store-computer-domain-knowledge.md |
 | AWS移行 技術スタック | tech-researcher | docs/research/store-computer-aws-migration-tech.md |
 | 統合学習スケジュール | secretary | docs/secretary/store-computer-learning-schedule.md |
+
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-03-23T19:35:00"
+```

--- a/.companies/domain-tech-collection/.task-log/20260321-110000-pm-learning-content.md
+++ b/.companies/domain-tech-collection/.task-log/20260321-110000-pm-learning-content.md
@@ -34,3 +34,15 @@
 | ファイル | 作成者 | パス |
 |---------|--------|------|
 | 学習スケジュール（PM追記） | project-manager | docs/secretary/store-computer-learning-schedule.md |
+
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-03-23T19:35:00"
+```

--- a/.companies/domain-tech-collection/.task-log/20260321-120000-info-source-master.md
+++ b/.companies/domain-tech-collection/.task-log/20260321-120000-info-source-master.md
@@ -33,3 +33,15 @@
 - 約75件の情報ソースを小売ドメイン（A系列）・技術スタック（B系列）の2軸で分類
 - 日次収集の優先度ガイド（高/中/低）と月次マスタ更新ポリシーを含む
 - 次フェーズとして日次巡回・要約の自動化と、マスタの定期更新の仕組み化を予定
+
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-03-23T19:35:00"
+```

--- a/.companies/domain-tech-collection/.task-log/20260321-120000-store-computer-domain-knowledge.md
+++ b/.companies/domain-tech-collection/.task-log/20260321-120000-store-computer-domain-knowledge.md
@@ -31,3 +31,15 @@
 ## ステータス
 
 完了
+
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-03-23T19:35:00"
+```

--- a/.companies/domain-tech-collection/.task-log/20260321-143000-storecomputer-latest-trends.md
+++ b/.companies/domain-tech-collection/.task-log/20260321-143000-storecomputer-latest-trends.md
@@ -28,3 +28,15 @@
 - 既存の `store-computer-domain-knowledge.md`（基礎知識）を補完する形で最新動向を整理
 - 各トピックにPM視点の学習ポイントを付加
 - 総括テーブルにSIerとして狙える案件タイプを整理
+
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-03-23T19:35:00"
+```

--- a/.companies/domain-tech-collection/docs/secretary/MEMORY.md
+++ b/.companies/domain-tech-collection/docs/secretary/MEMORY.md
@@ -1,6 +1,6 @@
 # 秘書 MEMORY（Case Bank 学習結果）
 
-> 最終更新: 2026-03-23 | Case Bank: 7件 | 平均報酬: 1.00
+> 最終更新: 2026-03-23 19:35 | Case Bank: 8件 | 平均報酬: 1.00
 
 ## ルーティング先読み
 
@@ -14,6 +14,7 @@
 | 情報ソースマスタ作成・整備 | agent-teams (tech-researcher + retail-domain) | 1.00 |
 | WBS・準備計画の作成 | direct (秘書直接対応) | 1.00 |
 | 知識収集 + TODO作成 | retail-domain-researcher (subagent) | 1.00 |
+| コンビニ業界構造の深掘り調査 | retail-domain-researcher (subagent) | 1.00 |
 
 ## 出力スタイル
 


### PR DESCRIPTION
## Summary
- 未評価タスク5件にrewardスコア(1.0)を追記
- Case Bank: 8件全件評価済み（平均報酬: 1.00）
- MEMORY.md: コンビニ業界構造調査のルーティングパターンを追加

## 変更ファイル
- `.task-log/` 配下5件: reward追記
- `docs/secretary/MEMORY.md`: ルーティング先読み1件追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)