### PR TITLE
docs: 日次活動レポート 2026-03-25 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-25-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-25-today.md
@@ -1,0 +1,106 @@
+# domain-tech-collection 活動レポート — 2026-03-25（日次）
+
+> 生成日時: 2026-03-25 20:30 | 生成者: SAS-Sasao | 期間: 2026-03-25
+
+## エグゼクティブサマリー
+
+本日は **3つの業務タスク** と **1つの基盤改善** を実施した充実した1日。
+日次ダイジェスト巡回（WBS 1.3）とストコン深掘り調査（WBS 2.1.R1）を前セッションで完了した後、
+今セッションで **LLM-as-Judge ハーネスの全4ステップ実装**（PR #63）、
+**PM全体像学習ノート生成 + W1必読リスト整備**（PR #64）、**W1必読リストのリンク修正**（PR #66）を実施。
+WBS 4.1.1（PM全体像）と 2.1.R1（コンビニ業界構造調査）が完了となり、W1の進捗が前進した。
+また、「ドキュメント間リンク必須化」のフィードバックをメモリに記録し、今後の品質基準を引き上げた。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 2 回 |
+| ツール実行数（合計） | 227 回 |
+| 作成・編集ファイル数 | 10 件 |
+| 完了タスク数 | 3 件 |
+| オープンIssue数（本日作成） | 4 件 |
+| マージ済みPR数 | 3 件（#60, #63, #64, #66 ※#63はプラグイン実装） |
+
+## 完了タスク
+
+- **[direct]** ニュース巡回（日次ダイジェスト生成）
+  → 成果物: [docs/daily-digest/2026-03-25.md](../../daily-digest/2026-03-25.md)（reward: 0.8）
+- **[subagent]** ストコン調査（WBS 2.1.R1 継続）→ retail-domain-researcher
+  → 成果物: [docs/retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md](../../retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md)（reward: 0.2 ※成果物パス未検出）
+- **[direct]** PM全体像学習ノート + W1必読リスト + TODO更新
+  → 成果物:
+    - [docs/secretary/learning-notes/wbs-4-1-1-migration-pm-overview.md](../learning-notes/wbs-4-1-1-migration-pm-overview.md)
+    - [docs/secretary/learning-notes/w1-reading-list.md](../learning-notes/w1-reading-list.md)
+    - [docs/secretary/todos/2026-03-25.md](../todos/2026-03-25.md)
+  → Issue: #65 / PR: #64
+
+## 進行中タスク
+
+- **[継続]** WBS 1.3 日次ダイジェスト巡回 — W1-10（毎日）
+- **[継続]** WBS 5.1 ストコンドメイン知識文書の拡充 — 小売ドメイン室
+- **[継続]** WBS 5.2 AWS移行技術レポートの拡充 — 技術リサーチ室
+
+## 作成・更新された成果物
+
+### 秘書室（docs/secretary/）
+- [wbs-4-1-1-migration-pm-overview.md](../learning-notes/wbs-4-1-1-migration-pm-overview.md) — PM全体像学習ノート（WBS 4.1.1 完了）
+- [w1-reading-list.md](../learning-notes/w1-reading-list.md) — W1必読ドキュメント一覧（MDリンク付き）
+- [2026-03-25.md](../todos/2026-03-25.md) — 今日のTODO
+- [storcon-preparation-wbs.md](../storcon-preparation-wbs.md) — WBS進捗更新（2.1.R1, 4.1.1 完了）
+- dashboard.html — ダッシュボード更新
+
+### 小売ドメイン室（docs/retail-domain/）
+- [storcon-deep-dive-2026-03-25.md](../../retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md) — ストコン深掘り調査（3チェーン移行詳細・POS連携）
+
+### 日次ダイジェスト（docs/daily-digest/）
+- [2026-03-25.md](../../daily-digest/2026-03-25.md) — 8ソースから30件収集
+
+### プラグイン基盤（.claude/）
+- secretary.md — LLM-as-Judge 評価ステップ追加 + Step 0 拡張
+- rebuild-case-bank.sh — judge パース + failure_patterns 集計
+- subagent-refiner.sh — judge failure_reason → constraints 注入
+- generate-dashboard.sh — レーダー・judge推移・失敗パターン等4ウィジェット追加
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- #59 インタラクションログ 2026-03-25
+- #61 日次ダイジェスト 2026-03-25
+- #62 ストコン深掘り調査（WBS 2.1.R1 継続）
+- #65 PM全体像学習ノート + W1必読リスト + TODO更新
+
+### マージ済みPR（本日）
+- #60 日次ダイジェスト3/25 + ストコン深掘り調査
+- #63 LLM-as-Judge ハーネス + 継続学習強化（全4ステップ）
+- #64 PM全体像学習ノート + W1必読リスト + TODO更新 + WBS進捗更新
+- #66 W1必読リストのドキュメント参照を全てMDリンク化
+
+## 会話トピック
+
+### セッション de5aecf5（前セッション）
+- /company 起動 → 日次ダイジェスト巡回 + ストコン深掘り調査
+
+### セッション a9a4025c（本セッション）
+- LLM-as-Judge ハーネス全4ステップ実装依頼
+- ローカルブランチの削除依頼
+- /company 起動 → TODO整理依頼
+- PM全体像学習の調査・ドキュメント生成依頼 + W1必読リスト作成
+- WBS更新の追加依頼
+- W1必読リストのMDリンク修正依頼 + フィードバック記録
+- /company-report（本レポート生成）
+
+### ファイル生成を伴わなかったやり取り
+- ローカルブランチ削除（git操作のみ）
+
+## 次のアクション候補
+
+1. **WBS 2.1.1: ストコンの全体像理解を開始する**（根拠: W1タスク・5h・学習TODO/リソース準備済み）
+2. **WBS 3.1.1: AWS基礎ハンズオンを開始する**（根拠: W1タスク・8h・未生成ドキュメント1件あり）
+3. **3/25ストコン深掘り調査の内容確認**（根拠: reward 0.2だが成果物は存在、内容確認未実施）
+4. **週次振り返り（WBS 1.2）の実施準備**（根拠: W1末 3/28に実施予定）
+5. **/company-evolve で継続学習を実行**（根拠: 新規task-log 3件＋LLM-as-Judge導入で学習サイクル始動）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary

- 2026-03-25 の日次活動レポートを生成
- 3タスク完了（日次ダイジェスト・ストコン調査・PM学習ノート）+ LLM-as-Judge基盤実装
- 4PR マージ、4 Issue 作成

## Test plan

- [x] レポート内のリンクが相対パスで正しく記述されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)