### PR TITLE
feat: AWS Knowledge MCP Server を追加

### DIFF
--- a/.companies/domain-tech-collection/masters/mcp-services.md
+++ b/.companies/domain-tech-collection/masters/mcp-services.md
@@ -1,3 +1,18 @@
 # MCP サービス一覧
 
-（まだ MCP サービスは定義されていません。`/company-admin` で追加できます。）
+## aws-knowledge-mcp-server
+
+- **サービス名**: AWS Knowledge MCP Server
+- **提供元**: awslabs（AWS公式）
+- **ステータス**: configured
+- **連携部署**: [dept-secretary, dept-research, dept-retail-domain]
+- **想定操作**: AWSドキュメント検索、リージョン情報取得、サービス利用可否確認、エージェントSOP取得
+- **設定先**: .mcp.json（プロジェクトルート）
+- **認証**: 不要（公開リモートサーバー、レート制限あり）
+- **提供ツール**:
+  - `search_documentation` — AWSドキュメント・SOP横断検索
+  - `read_documentation` — AWSドキュメントをMarkdownで取得
+  - `recommend` — ドキュメントの関連コンテンツ推薦
+  - `list_regions` — AWSリージョン一覧取得
+  - `get_regional_availability` — サービス・機能のリージョン別利用可否確認
+  - `retrieve_agent_sops` — エージェントSOP（手順書）取得

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aws-knowledge-mcp-server": {
+      "command": "uvx",
+      "args": ["fastmcp", "run", "https://knowledge-mcp.global.api.aws"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- AWS Knowledge MCP Server（awslabs公式）をプロジェクトに導入
- `.mcp.json` にfastmcpプロキシ経由の接続設定を追加
- 組織マスタ `mcp-services.md` にサービス情報を登録（全部署で利用可能）

## 変更ファイル
- `.mcp.json` — MCP サーバー接続設定（新規）
- `.companies/domain-tech-collection/masters/mcp-services.md` — サービス登録

## 提供ツール
| ツール | 説明 |
|--------|------|
| `search_documentation` | AWSドキュメント横断検索 |
| `read_documentation` | AWSドキュメントMarkdown取得 |
| `recommend` | 関連コンテンツ推薦 |
| `list_regions` | リージョン一覧 |
| `get_regional_availability` | サービスのリージョン別利用可否 |
| `retrieve_agent_sops` | エージェントSOP取得 |

## 備考
- 認証不要（公開リモートサーバー）
- 有効化にはClaude Codeの再起動が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)