### PR TITLE
docs: 日次レポート夜間更新版 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-25-today-2.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-25-today-2.md
@@ -1,0 +1,149 @@
+# domain-tech-collection 活動レポート — 日次（夜間更新版）
+
+> 生成日時: 2026-03-25 21:20 | 生成者: SAS-Sasao | 期間: 2026-03-25
+
+## エグゼクティブサマリー
+
+本日は3セッションで大きく4タスクを完了した。前半は日次ダイジェスト生成・ストコン深堀り調査・PM全体像学習ノート＋W1必読リスト作成を実施。後半は**AWS Knowledge MCP Serverの導入**と、それを活用した**ストコン×AWS技術スタック深堀り調査**を実施。特にMCP導入は組織のリサーチ基盤を強化する重要な施策であり、今後の調査品質向上が期待できる。全タスク完了・PR全マージ済み。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 3 回（de5aecf5, a9a4025c, 5f4fa7d8） |
+| ツール実行数（合計） | 7,793 回 |
+| 人間の発言数（合計） | 495 回 |
+| Claudeの応答数（合計） | 662 回 |
+| 完了タスク数 | 4 件 |
+| 作成・更新ファイル数 | 10 件（docs配下） |
+| 今日の新規Issue | 3 件（#62, #65, #71） |
+| 今日の既存Issue | #61（日次ダイジェスト）, #68（前回レポート） |
+
+## 完了タスク
+
+### 1. [direct] 日次ニュース巡回・ダイジェスト生成
+- **タスクID**: 20260325-192516-daily-digest
+- **実行モード**: direct（秘書直接WebFetch）
+- **成果物**: [docs/daily-digest/2026-03-25.md](../../daily-digest/2026-03-25.md)
+- **Issue**: [#61](https://github.com/SAS-Sasao/cc-sier-organization/issues/61)
+
+### 2. [subagent] ストコン深掘り調査（WBS 2.1.R1 継続）
+- **タスクID**: 20260325-192516-storcon-research
+- **実行モード**: subagent（retail-domain-researcher）
+- **成果物**: [docs/retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md](../../retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md)
+- **Issue**: [#62](https://github.com/SAS-Sasao/cc-sier-organization/issues/62)
+
+### 3. [direct] PM全体像学習ノート + W1必読リスト + TODO更新
+- **タスクID**: 20260325-195518-pm-overview-w1-reading
+- **実行モード**: direct
+- **成果物**:
+  - [docs/secretary/learning-notes/wbs-4-1-1-migration-pm-overview.md](../learning-notes/wbs-4-1-1-migration-pm-overview.md)
+  - [docs/secretary/learning-notes/w1-reading-list.md](../learning-notes/w1-reading-list.md)
+  - [docs/secretary/todos/2026-03-25.md](../todos/2026-03-25.md)
+- **Issue**: [#65](https://github.com/SAS-Sasao/cc-sier-organization/issues/65)
+- **PR**: [#64](https://github.com/SAS-Sasao/cc-sier-organization/pull/64)
+
+### 4. [subagent] ストコンAWS移行 技術スタック深堀り調査
+- **タスクID**: 20260325-205158-storcon-aws-deep-dive
+- **実行モード**: subagent（retail-domain-researcher + AWS Knowledge MCP活用）
+- **成果物**:
+  - [docs/retail-domain/industry-reports/storcon-aws-tech-deep-dive-2026-03-25.md](../../retail-domain/industry-reports/storcon-aws-tech-deep-dive-2026-03-25.md)（765行）
+  - [docs/secretary/learning-notes/w1-reading-list.md](../learning-notes/w1-reading-list.md)（WBS 2.1.1 + 3.1.1にリンク追加）
+- **Issue**: [#71](https://github.com/SAS-Sasao/cc-sier-organization/issues/71)
+- **PR**: [#70](https://github.com/SAS-Sasao/cc-sier-organization/pull/70)
+- **品質評価**: 優良（DMS/MGN/Transit Gateway等の具体的設定・カットオーバー手順・学習ロードマップMust/Should/Nice-to-have付き）
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 秘書室（secretary）
+| ファイル | 種別 |
+|---------|------|
+| `docs/secretary/learning-notes/w1-reading-list.md` | 更新（AWS深堀り追加） |
+| `docs/secretary/learning-notes/wbs-4-1-1-migration-pm-overview.md` | 新規 |
+| `docs/secretary/todos/2026-03-25.md` | 新規 |
+| `docs/secretary/reports/2026-03-25-today.md` | 新規（前回レポート） |
+| `docs/secretary/dashboard.html` | 更新（ダッシュボード自動更新 x3） |
+| `docs/secretary/storcon-preparation-wbs.md` | 更新（進捗反映） |
+
+### 小売ドメイン室（retail-domain）
+| ファイル | 種別 |
+|---------|------|
+| `docs/retail-domain/industry-reports/storcon-deep-dive-2026-03-25.md` | 新規 |
+| `docs/retail-domain/industry-reports/storcon-aws-tech-deep-dive-2026-03-25.md` | 新規（765行） |
+
+### 日次ダイジェスト
+| ファイル | 種別 |
+|---------|------|
+| `docs/daily-digest/2026-03-25.md` | 新規 |
+
+### インフラ・設定変更
+| ファイル | 種別 |
+|---------|------|
+| `.mcp.json` | 新規（AWS Knowledge MCP Server接続設定） |
+| `masters/mcp-services.md` | 更新（AWS Knowledge MCP登録・active化） |
+
+## Issue 動向
+
+### 本日新規作成のIssue
+- [#61](https://github.com/SAS-Sasao/cc-sier-organization/issues/61) [domain-tech-collection] 日次ダイジェスト 2026-03-25
+- [#62](https://github.com/SAS-Sasao/cc-sier-organization/issues/62) [domain-tech-collection] ストコン深掘り調査（WBS 2.1.R1 継続）
+- [#65](https://github.com/SAS-Sasao/cc-sier-organization/issues/65) feat: PM全体像学習ノート + W1必読リスト + TODO更新
+- [#68](https://github.com/SAS-Sasao/cc-sier-organization/issues/68) [domain-tech-collection] 活動レポート 日次 (2026-03-25)
+- [#71](https://github.com/SAS-Sasao/cc-sier-organization/issues/71) [domain-tech-collection] ストコンAWS移行 技術スタック深堀り調査
+
+### 本日マージされたPR
+- [#63](https://github.com/SAS-Sasao/cc-sier-organization/pull/63) 日次ダイジェスト + ストコン深掘り調査
+- [#64](https://github.com/SAS-Sasao/cc-sier-organization/pull/64) PM全体像学習ノート + W1必読リスト
+- [#66](https://github.com/SAS-Sasao/cc-sier-organization/pull/66) W1必読リストMDリンク修正
+- [#67](https://github.com/SAS-Sasao/cc-sier-organization/pull/67) 日次レポート
+- [#69](https://github.com/SAS-Sasao/cc-sier-organization/pull/69) AWS Knowledge MCP Server導入
+- [#70](https://github.com/SAS-Sasao/cc-sier-organization/pull/70) ストコンAWS技術スタック深堀り調査
+
+## 会話トピック
+
+### セッション de5aecf5（234発言 / 302応答 / 410ツール）
+- 日次ニュース巡回・ダイジェスト生成
+- ストコン深掘り調査（WBS 2.1.R1継続、3チェーンのクラウド移行状況）
+- PM全体像学習ノート生成（WBS 4.1.1）
+- W1必読ドキュメント一覧作成
+- TODO更新
+- 日次レポート生成（前回分）
+- company-evolve 継続学習実行
+
+### セッション a9a4025c（156発言 / 216応答 / 268ツール）
+- W1必読リストのMDリンク修正
+- WBS進捗更新（2.1.R1完了・4.1.1完了反映）
+- AWS Knowledge MCP Server導入の検討・設定
+- MCPサービスの組織マスタ登録
+- ダッシュボード更新
+
+### セッション 5f4fa7d8（105発言 / 144応答 / 154ツール）※現在のセッション
+- MCPサーバー接続確認（再起動後）
+- ストコン×AWS技術スタック深堀り調査（MCP活用）
+- 学習ノート（w1-reading-list.md）への反映
+- 本レポート生成
+
+## 本日のハイライト
+
+### AWS Knowledge MCP Server 導入
+- awslabs公式のリモートMCPサーバーを `.mcp.json` で設定
+- fastmcpプロキシ経由（uvx）で接続
+- 認証不要・レート制限のみ
+- 6ツール利用可能: search_documentation, read_documentation, recommend, list_regions, get_regional_availability, retrieve_agent_sop
+- 早速ストコンAWS調査で活用 → DMS/MGN等の具体的な設定詳細を収集できた
+
+## 次のアクション候補
+
+1. **WBS 2.1.1: ストコン全体像の学習開始**（根拠: 深堀り調査資料が揃ったため、実際の読み込みフェーズへ）
+2. **WBS 3.1.1: AWS基礎ハンズオン実施**（根拠: 深堀りレポートのMust項目 DMS/MGN/Transit Gatewayの理解にはハンズオン経験が必要）
+3. **AWS DMS Workshop 受講**（根拠: 深堀りレポートの推奨ハンズオン。カットオーバー計画の理解に直結）
+4. **日次ダイジェスト 3/26 の自動生成**（根拠: WBS 1.3 継続タスク）
+5. **MCP活用範囲の拡大検討**（根拠: 今回の調査でMCPの有用性が確認できたため、他のAWS MCPサーバー追加を検討）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ (git log) | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-25 日次活動レポート（夜間更新版）を生成
- 前回レポート(#68)以降のMCP導入・ストコンAWS深堀り調査を含む

## 本日のハイライト
- AWS Knowledge MCP Server 導入・接続確認
- ストコン×AWS技術スタック深堀り調査（765行・学習ロードマップ付き）
- PM全体像学習ノート + W1必読リスト完成
- 日次ダイジェスト生成
- 完了タスク: 4件 / 新規Issue: 5件 / マージPR: 6件

🤖 Generated with [Claude Code](https://claude.com/claude-code)