### PR TITLE
docs: 日次レポート夜間最終版 2026-03-26

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-26-today-3.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-26-today-3.md
@@ -1,0 +1,131 @@
+# domain-tech-collection 活動レポート — 2026-03-26 日次（夜間最終版）
+
+> 生成日時: 2026-03-26 19:30 | 生成者: SAS-Sasao | 期間: 2026-03-26
+
+## エグゼクティブサマリー
+
+本日は3セッション・ツール実行1,038回の高稼働日。朝の日次ダイジェスト巡回に続き、ストコンAWSモダナイゼーション調査、WBS 2.1.1 ストコン全体像学習の完了報告、W2先行調査3本の並列委譲・納品と、多岐にわたるタスクを消化した。特筆すべきは「自学タスクの調査・整理工程（工程A）をエージェントに先行委譲する」運用パターンの確立で、W2の自学時間を16h→約9hに圧縮する見込みを立てた。一方、judge評価のコミット前実施漏れが発覚し、失敗パターンとしてCase Bank・feedbackメモリに記録した。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 3 回 |
+| ツール実行数（合計） | 1,038 回 |
+| 作成・編集ファイル数 | 11 件 |
+| 完了タスク数 | 4 件 |
+| 本日新規オープンIssue数 | 5 件（interaction-log除く） |
+| 本日クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+1. **[agent-teams→direct]** 日次ダイジェスト巡回 (WBS 1.3)
+   → 成果物: `docs/daily-digest/2026-03-26.md`
+
+2. **[subagent]** ストコン全体像 図解メモ作成 (WBS 2.1.1)
+   → 成果物: `docs/secretary/learning-notes/wbs-2-1-1-storcon-diagram-memo.md`
+
+3. **[agent-teams]** ストコンAWS移行 モダナイゼーション＆データ分析知識収集
+   → 成果物: `docs/research/storcon-aws-modernization-analytics-2026-03-26.md`, `docs/retail-domain/industry-reports/storcon-modernization-business-scenarios-2026-03-26.md`
+
+4. **[subagent-parallel]** W2先行調査3本（業務プロセス・DB比較・ステークホルダー）
+   → 成果物:
+   - `docs/retail-domain/convenience-business-processes.md`（627行・Mermaid図6点）
+   - `docs/research/aws-database-comparison-for-storcon.md`（DB比較+推奨構成）
+   - `docs/research/migration-stakeholder-structure.md`（27ロール+RACI+RAID Log）
+   → judge: total 0.87（completeness:9 / accuracy:8 / clarity:9）
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 秘書室
+- `docs/secretary/todos/2026-03-26.md` — TODO更新（WBS 2.1.1 完了反映）
+- `docs/secretary/storcon-preparation-wbs.md` — WBS 2.1.1 ステータス `[x]` に更新
+- `docs/secretary/learning-notes/wbs-2-1-1-storcon-diagram-memo.md` — 新規
+- `docs/secretary/dashboard.html` — ダッシュボード更新
+
+### 技術リサーチ室
+- `docs/research/storcon-aws-modernization-analytics-2026-03-26.md` — 新規
+- `docs/research/aws-database-comparison-for-storcon.md` — 新規（W2先行調査）
+- `docs/research/migration-stakeholder-structure.md` — 新規（W2先行調査）
+
+### 小売ドメイン室
+- `docs/retail-domain/industry-reports/storcon-modernization-business-scenarios-2026-03-26.md` — 新規
+- `docs/retail-domain/convenience-business-processes.md` — 新規（W2先行調査）
+
+### 日次ダイジェスト
+- `docs/daily-digest/2026-03-26.md` — 新規
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- #87 W2先行調査3本を納品（業務プロセス・DB比較・ステークホルダー）
+- #85 活動レポート 日次・夜間更新版 (2026-03-26)
+- #83 ストコンAWS移行: モダナイゼーション＆データ分析知識収集
+- #79 WBS 2.1.1 ストコン全体像 図解メモ作成
+- #75 日次ダイジェスト 2026-03-26
+
+### クローズされたIssue（本日）
+なし
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション 51aa8a5e**（08:14-09:18 / 157ツール実行）
+  - 日次ダイジェスト巡回（wf-daily-digest）
+  - TODO整理 + WBS 4.1.1 完了ステータス反映
+  - 完了タスク除外の仕組化（秘書室CLAUDE.mdにルール追記）
+  - ストコン全体像の壁打ち + 図解メモ作成依頼
+  - ダッシュボードのjudgeスコア推移不具合調査
+  - hookとの競合問題の相談
+
+- **セッション aad423c9**（12:33-18:46 / 391ツール実行）
+  - ストコンAWS知識収集（モダナイゼーション＆データ分析深掘り）
+  - ダッシュボードのSubagentレーダーチャートのスケール不整合修正
+  - 改善インサイトのロジック確認とSKILL.mdへの明示化
+  - feedbackメモリのダッシュボード反映
+  - グラフサイズ調整（中央寄せ・改善インサイトカードと高さ揃え）
+  - feedbackメモリ→Case Bank統合の実装（Read/Writeフェーズ）
+
+- **セッション 4b98c7c8**（18:56-19:16 / 490ツール実行）
+  - ストコン学習 WBS 2.1.1 完了報告＋ステータス更新
+  - 次週以降のタスクについて壁打ち（自学タスクのエージェント委譲戦略）
+  - W2先行調査3本の並列起動・統合・PR作成
+  - judge評価漏れの指摘→失敗パターン記録
+  - ダッシュボード生成
+
+### ファイル生成を伴わなかったやり取り
+- ストコン全体像の壁打ち（B:業務プロセス理解、C:図解メモ作成の方針整理）
+- ダッシュボードのグラフサイズ・スケール不整合についての相談
+- 改善インサイトのロジック有無の確認
+- hookとの競合問題の調査・相談
+- W2以降のタスク委譲戦略の壁打ち（自学 = 工程A:調査整理 + 工程B:内化定着 の分離）
+
+## 学びと改善
+
+### 確立した運用パターン
+- **自学タスクの工程分離**: 調査・整理（工程A）をエージェントに先行委譲し、笹尾さんは「読んで理解する」（工程B）に集中する。W2で16h→9hの圧縮見込み。
+
+### 記録した失敗パターン
+- **judge評価のコミット前実施漏れ**: メイン会話で直接オーケストレーションした際、git commitの前にjudge評価を実施し忘れた。feedbackメモリ + Case Bank failure_patterns に記録済み。
+
+## 次のアクション候補
+
+1. **W1残タスク: AWS基礎 WBS 3.1.1**（8h未着手・今週中にコース選定まで）
+   - 根拠: W1の最大未消化タスク。W2に繰り越すと負荷超過の恐れ
+2. **W2先行調査の精読開始**（3/31〜）
+   - 根拠: 本日納品の3本を事前に軽く目を通しておくと月曜スタートがスムーズ
+3. **W3先行調査の仕込み**（3/27-28に発注）
+   - 根拠: W2と同じ工程分離パターンを継続。店舗システム構成・コンテナ基礎・リスク管理の先行調査
+4. **オープンIssueの棚卸し**
+   - 根拠: 87件のIssueが全てOPEN。完了済みのものをクローズする整理が必要
+5. **Case Bank index.json のcase_count整合性修正**
+   - 根拠: linterが case_count を 17 に戻しているが実際は18件。hookとの競合を解消する必要あり
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-26 の日次活動レポート（夜間最終版）を生成
- 3セッション・ツール1,038回・完了タスク4件のサマリー
- W2先行調査の並列委譲パターン確立、judge評価漏れの失敗記録を含む

## Test plan
- [x] レポート内容の正確性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)