### PR TITLE
docs: 日次レポート最終版 2026-03-26

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-26-today-final.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-26-today-final.md
@@ -1,0 +1,140 @@
+# domain-tech-collection 活動レポート — 2026-03-26 日次（最終版）
+
+> 生成日時: 2026-03-26 20:00 | 生成者: SAS-Sasao | 期間: 2026-03-26
+
+## エグゼクティブサマリー
+
+本日は3セッション・ツール実行1,112回の高稼働日。完了タスク5件、新規Issue6件。朝の日次ダイジェストに続き、ストコンAWSモダナイゼーション調査、WBS 2.1.1完了、W2先行調査3本の並列納品、AWS基礎ハンズオンロードマップの先行作成と、W1〜W2のタスクを幅広くカバーした。「自学タスクの工程A/B分離」パターンが定着し、W2(16h→9h)とWBS 3.1.1(8h→4h)で合計11hの圧縮に成功。judge評価コミット前チェックの失敗パターン記録も行い、プロセス改善も並行して進めた。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 3 回 |
+| ツール実行数（合計） | 1,112 回 |
+| 作成・更新ファイル数 | 21 件 |
+| 完了タスク数 | 5 件 |
+| 本日新規Issue数 | 6 件（interaction-log除く） |
+| クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+1. **[agent-teams→direct]** 日次ダイジェスト巡回 (WBS 1.3)
+   → 成果物: `docs/daily-digest/2026-03-26.md`
+
+2. **[subagent]** ストコン全体像 図解メモ作成 (WBS 2.1.1)
+   → 成果物: `docs/secretary/learning-notes/wbs-2-1-1-storcon-diagram-memo.md`
+
+3. **[agent-teams]** ストコンAWS移行 モダナイゼーション＆データ分析知識収集
+   → 成果物: `docs/research/storcon-aws-modernization-analytics-2026-03-26.md`, `docs/retail-domain/industry-reports/storcon-modernization-business-scenarios-2026-03-26.md`
+
+4. **[subagent-parallel]** W2先行調査3本（業務プロセス・DB比較・ステークホルダー）
+   → 成果物:
+   - `docs/retail-domain/convenience-business-processes.md`（627行）
+   - `docs/research/aws-database-comparison-for-storcon.md`
+   - `docs/research/migration-stakeholder-structure.md`
+   → judge: total **0.87**
+
+5. **[subagent]** AWS基礎4サービス学習ロードマップ+ハンズオン手順書 (WBS 3.1.1 工程A)
+   → 成果物: `docs/research/aws-basics-handson-roadmap.md`（925行）
+   → judge: total **0.93**
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 技術リサーチ室（4件）
+- `docs/research/storcon-aws-modernization-analytics-2026-03-26.md` — 新規
+- `docs/research/aws-database-comparison-for-storcon.md` — 新規（W2先行調査）
+- `docs/research/migration-stakeholder-structure.md` — 新規（W2先行調査）
+- `docs/research/aws-basics-handson-roadmap.md` — 新規（WBS 3.1.1 工程A）
+
+### 小売ドメイン室（2件）
+- `docs/retail-domain/convenience-business-processes.md` — 新規（W2先行調査）
+- `docs/retail-domain/industry-reports/storcon-modernization-business-scenarios-2026-03-26.md` — 新規
+
+### 秘書室（5件）
+- `docs/secretary/todos/2026-03-26.md` — WBS 2.1.1 完了反映
+- `docs/secretary/storcon-preparation-wbs.md` — WBS 2.1.1 ステータス更新
+- `docs/secretary/learning-notes/wbs-2-1-1-storcon-diagram-memo.md` — 新規
+- `docs/secretary/dashboard.html` — ダッシュボード更新
+- `docs/secretary/reports/` — レポート3版生成
+
+### 日次ダイジェスト（1件）
+- `docs/daily-digest/2026-03-26.md` — 新規
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- #91 AWS基礎4サービス学習ロードマップ+ハンズオン手順書（WBS 3.1.1 工程A）
+- #87 W2先行調査3本を納品（業務プロセス・DB比較・ステークホルダー）
+- #83 ストコンAWS移行: モダナイゼーション＆データ分析知識収集
+- #88 活動レポート 日次・夜間最終版
+- #85 活動レポート 日次・夜間更新版
+- #81 活動レポート 日次
+
+### クローズされたIssue（本日）
+なし
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション 51aa8a5e**（08:14-09:18 / 157ツール実行）
+  - 日次ダイジェスト巡回
+  - TODO整理 + WBS 4.1.1 完了反映
+  - 完了タスク除外の仕組化
+  - ストコン全体像の壁打ち + 図解メモ作成
+  - ダッシュボードのjudgeスコア推移不具合調査
+  - hookとの競合問題の相談
+
+- **セッション aad423c9**（12:33-18:46 / 391ツール実行）
+  - ストコンAWS知識収集（モダナイゼーション＆データ分析深掘り）
+  - ダッシュボードのSubagentレーダーチャートのスケール不整合修正
+  - 改善インサイトのロジック確認とSKILL.mdへの明示化
+  - feedbackメモリのダッシュボード反映
+  - グラフサイズ調整
+  - feedbackメモリ→Case Bank統合の実装
+
+- **セッション 4b98c7c8**（18:56-20:00 / 564ツール実行）
+  - ストコン学習 WBS 2.1.1 完了報告＋ステータス更新
+  - 次週以降のタスク壁打ち（自学タスクのエージェント委譲戦略）
+  - W2先行調査3本の並列起動・統合・PR作成
+  - judge評価漏れの指摘→失敗パターン記録
+  - AWS基礎の作業内容整理→選択肢Bで工程A/B分離
+  - AWS基礎ハンズオンロードマップの先行作成
+  - ダッシュボード更新、レポート生成、継続学習
+
+### ファイル生成を伴わなかったやり取り
+- ストコン全体像の壁打ち（B:業務プロセス理解、C:図解メモ作成の方針整理）
+- ダッシュボードの不具合調査・グラフ調整の相談
+- hookとの競合問題の調査
+- W2以降のタスク委譲戦略の壁打ち（工程A/B分離パターン確立）
+- AWS基礎の学習方針壁打ち（3選択肢 → 選択肢B決定）
+
+## 学びと改善
+
+### 確立した運用パターン
+- **自学タスクの工程A/B分離**: 調査・整理（工程A）をエージェントに先行委譲し、笹尾さんは「読んで理解する」（工程B）に集中。W2で16h→9h、WBS 3.1.1で8h→4hの圧縮に成功。合計 **11h の時間削減**。
+
+### 記録した失敗パターン
+- **judge評価のコミット前実施漏れ**: feedbackメモリ + Case Bank failure_patterns に記録。以降のタスクでは改善済み（AWS基礎ロードマップでは正しくコミット前にjudge実施）。
+
+## 次のアクション候補
+
+1. **AWS基礎ハンズオン実施**（3/27-28、WBS 3.1.1 工程B）
+   - 3/27: IAM(45min) + VPC(60min) = 約2h
+   - 3/28: EC2(75min) + S3(60min) = 約2.5h
+   - 根拠: ロードマップ納品済み。W1中に完了すればM1に間に合う
+2. **W2先行調査資料の事前通読**（3/28余裕あれば）
+   - 根拠: 月曜からの工程B着手をスムーズにする
+3. **W3先行調査の仕込み**（3/28に発注）
+   - 根拠: 工程A/B分離パターンの継続。店舗システム構成・コンテナ基礎・リスク管理
+4. **オープンIssueの棚卸し**
+   - 根拠: 91件のIssueが全てOPEN。完了済みのものをクローズする整理が必要
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-26 日次活動レポート最終版（5タスク完了・ツール1,112回）
- AWS基礎ロードマップ納品を含む全タスク反映

## Test plan
- [ ] レポート内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)