### PR TITLE
docs: 日次レポート 2026-03-27 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today.md
@@ -1,0 +1,94 @@
+# domain-tech-collection 活動レポート — 2026-03-27（日次）
+
+> 生成日時: 2026-03-27 09:20 | 生成者: SAS-Sasao | 期間: 2026-03-27
+
+## エグゼクティブサマリー
+
+本日は日次ダイジェスト（`wf-daily-digest`）の実行と、ダイジェストHTMLのGitHub Pages連携機能の新規開発を実施した。ダイジェストは8ソースから32件（技術17+小売15）を収集しjudge total 0.83の高品質判定。続いて、ダイジェストMDをHTMLに変換する `generate-daily-digest-html.sh` スクリプトと `/company-digest-html` スキルを新規作成し、GitHub Pages（https://sas-sasao.github.io/cc-sier-organization/daily-digest/）での閲覧を可能にした。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 1回 |
+| ツール実行数（合計） | 108回 |
+| 作成・編集ファイル数 | 7件 |
+| 完了タスク数 | 1件 |
+| オープンIssue数（本日作成） | 1件 (#95) |
+| クローズIssue数（本日） | 0件 |
+
+### ツール実行内訳
+
+| 種別 | 回数 |
+|------|------|
+| Write | 10 |
+| Read | 40 |
+| Bash | 39 |
+| Other | 19 |
+
+## 完了タスク
+
+- **[agent-teams]** 毎日の技術リサーチ（wf-daily-digest）
+  - 成果物: [2026-03-27.md](../../daily-digest/2026-03-27.md)
+  - Judge: total 0.83（completeness:8 / accuracy:8 / clarity:9）
+  - PR: #94 → マージ済み
+  - Issue: #95
+
+## 進行中タスク
+
+なし
+
+## 作成・更新された成果物
+
+### daily-digest/（日次ダイジェスト）
+- [2026-03-27.md](../../daily-digest/2026-03-27.md) — 技術17件+小売15件=32件のダイジェスト
+
+### .task-log/（タスクログ）
+- `20260327-084645-daily-digest.md` — wf-daily-digest実行ログ
+
+### 新規開発: GitHub Pages ダイジェスト連携
+- `.claude/hooks/generate-daily-digest-html.sh` — MD→HTML変換スクリプト（106.3KB出力）
+- `.claude/skills/company-digest-html/SKILL.md` — `/company-digest-html` スキル定義
+- `plugins/cc-sier/skills/company-digest-html/SKILL.md` — プラグイン配布用
+- `docs/daily-digest/index.html` — 全6ダイジェスト/204記事のSPAページ
+- `docs/index.html` — トップページにダイジェストカード追加
+
+## Issue 動向
+
+### 新規オープンのIssue（本日関連）
+- #95 日次ダイジェスト 2026-03-27（`type:daily-digest`）
+
+### クローズされたIssue
+なし
+
+## 会話トピック
+
+### セッション c917fba2（108ツール実行）
+
+| # | 依頼内容 | 種別 |
+|---|---------|------|
+| 1 | `/company` — 組織選択、domain-tech-collectionで作業続行 | 組織操作 |
+| 2 | 毎日の技術リサーチを実行してほしい | wf-daily-digest |
+| 3 | OKマージしたからmain以外のローカルブランチ削除して | Git操作 |
+| 4 | ニュース巡回の内容をHTMLでGitHub Pagesと連携した仕組みをコマンドして欲しい | 機能開発依頼 |
+| 5 | SKILLSコマンドから実行できる仕組みにしている？ | 確認・指摘 |
+| 6 | 2でお願いしたい（独立スキルとして作成）— ダッシュボードとは用途・実行タイミングが異なるため | 設計判断 |
+| 7 | OKマージしたからmain以外のローカルブランチ削除して | Git操作 |
+| 8 | `/company-digest-html` — 新スキルの動作確認 | スキル実行 |
+| 9 | `/company-report` — 本レポート生成 | レポート |
+
+### ファイル生成を伴わなかったやり取り
+- 組織選択UI（`/company` → A選択）
+- ブランチ削除（2回）
+- スキル設計方針の壁打ち（独立スキル vs ダッシュボード統合）
+
+## 次のアクション候補
+
+1. **Issue #95 のクローズ** — ダイジェストPR #94 はマージ済みのためクローズ可能
+2. **`wf-daily-digest` 完了後の自動HTML生成検討** — 現在は `/company-digest-html` を手動実行する必要があるが、ワークフロー完了後の自動連携を検討
+3. **AWS What's New の代替取得方法調査** — JS描画ページの取得制約が継続中。RSSフィード等の代替手段を検討
+4. **ストコン案件の学習タスク継続** — WBSの未完了タスクの進行
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-27 の日次活動レポートを生成
- セッション1回 / ツール実行108回 / 完了タスク1件
- 主な活動: wf-daily-digest実行 + /company-digest-html スキル新規開発

## Test plan
- [x] 5ソース（session-summaries, task-log, docs, Issues, conversation-log）からデータ収集
- [x] レポートMD生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)