### PR TITLE
docs: 日次レポート最終版 2026-03-27 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today.md
@@ -1,38 +1,48 @@
-# domain-tech-collection 活動レポート — 2026-03-27（日次）
+# domain-tech-collection 活動レポート — 2026-03-27（日次・最終版）
 
-> 生成日時: 2026-03-27 09:20 | 生成者: SAS-Sasao | 期間: 2026-03-27
+> 生成日時: 2026-03-27 14:50 | 生成者: SAS-Sasao | 期間: 2026-03-27
+> ※ 09:20版から更新。PM学習タスク2件・ダッシュボード修正・継続学習を反映
 
 ## エグゼクティブサマリー
 
-本日は日次ダイジェスト（`wf-daily-digest`）の実行と、ダイジェストHTMLのGitHub Pages連携機能の新規開発を実施した。ダイジェストは8ソースから32件（技術17+小売15）を収集しjudge total 0.83の高品質判定。続いて、ダイジェストMDをHTMLに変換する `generate-daily-digest-html.sh` スクリプトと `/company-digest-html` スキルを新規作成し、GitHub Pages（https://sas-sasao.github.io/cc-sier-organization/daily-digest/）での閲覧を可能にした。
+本日は3つの軸で活動した。(1) 日次ダイジェスト（`wf-daily-digest`）で8ソースから32件を収集（judge 0.83）。(2) ダイジェストHTMLのGitHub Pages連携として `/company-digest-html` スキルを新規開発し、`generate-dashboard.sh` との競合問題も修正した。(3) PM知識習得の壁打ちから「機能チームPMスキルマップ」と「技術者出身PM失敗パターン集」の2成果物を作成（judge 0.87, 0.93）。また、Case Bankのreward未付与問題を発見・修正し、失敗パターンとして記憶に追加した。
 
 ## 活動統計
 
 | 指標 | 値 |
 |------|-----|
 | セッション数 | 1回 |
-| ツール実行数（合計） | 108回 |
-| 作成・編集ファイル数 | 7件 |
-| 完了タスク数 | 1件 |
-| オープンIssue数（本日作成） | 1件 (#95) |
+| ツール実行数（合計） | 197回 |
+| 作成・編集ファイル数 | 12件 |
+| 完了タスク数 | 3件 |
+| オープンIssue数（本日作成） | 5件 (#95, #99, #101, #103) |
 | クローズIssue数（本日） | 0件 |
 
 ### ツール実行内訳
 
 | 種別 | 回数 |
 |------|------|
-| Write | 10 |
-| Read | 40 |
-| Bash | 39 |
-| Other | 19 |
+| Write | 25 |
+| Read | 58 |
+| Bash | 87 |
+| Other | 27 |
 
 ## 完了タスク
 
 - **[agent-teams]** 毎日の技術リサーチ（wf-daily-digest）
   - 成果物: [2026-03-27.md](../../daily-digest/2026-03-27.md)
   - Judge: total 0.83（completeness:8 / accuracy:8 / clarity:9）
-  - PR: #94 → マージ済み
-  - Issue: #95
+  - PR: #94 → マージ済み / Issue: #95
+
+- **[direct]** 機能チームPMスキルマップ&学習ロードマップ作成
+  - 成果物: [pm-skill-map.md](../learning-notes/pm-skill-map.md)
+  - Judge: total 0.87（completeness:9 / accuracy:8 / clarity:9）
+  - PR: #100 → マージ済み / Issue: #101
+
+- **[direct]** 技術者出身PM失敗パターン集（7パターン×ケーススタディ）
+  - 成果物: [pm-failure-patterns.md](../learning-notes/pm-failure-patterns.md)
+  - Judge: total 0.93（completeness:9 / accuracy:9 / clarity:10）
+  - PR: #102 / Issue: #103
 
 ## 進行中タスク
 
@@ -40,11 +50,12 @@
 
 ## 作成・更新された成果物
 
-### daily-digest/（日次ダイジェスト）
-- [2026-03-27.md](../../daily-digest/2026-03-27.md) — 技術17件+小売15件=32件のダイジェスト
+### secretary/learning-notes/（PM学習）
+- [pm-skill-map.md](../learning-notes/pm-skill-map.md) — 6責務領域×L1-L4レベル評価、3フェーズ学習ロードマップ、Phase 1成果物15件
+- [pm-failure-patterns.md](../learning-notes/pm-failure-patterns.md) — 7パターンの失敗事例集（ストコン案件ケーススタディ+処方箋+セルフチェック）
 
-### .task-log/（タスクログ）
-- `20260327-084645-daily-digest.md` — wf-daily-digest実行ログ
+### daily-digest/（日次ダイジェスト）
+- [2026-03-27.md](../../daily-digest/2026-03-27.md) — 技術17件+小売15件=32件
 
 ### 新規開発: GitHub Pages ダイジェスト連携
 - `.claude/hooks/generate-daily-digest-html.sh` — MD→HTML変換スクリプト（106.3KB出力）
@@ -53,41 +64,68 @@
 - `docs/daily-digest/index.html` — 全6ダイジェスト/204記事のSPAページ
 - `docs/index.html` — トップページにダイジェストカード追加
 
+### バグ修正
+- `.claude/hooks/generate-dashboard.sh` — ダイジェストカードがダッシュボード再生成時に消える問題を修正
+
+### 継続学習
+- Case Bank: 20件インデックス（reward未付与問題を修正）
+- feedbackメモリ: `feedback_reward_from_judge.md` を追加
+
 ## Issue 動向
 
-### 新規オープンのIssue（本日関連）
+### 新規オープンのIssue（本日）
 - #95 日次ダイジェスト 2026-03-27（`type:daily-digest`）
+- #99 活動レポート 日次 2026-03-27（`company-report`）
+- #101 機能チームPMスキルマップ&学習ロードマップ作成（`type:knowledge`）
+- #103 技術者出身PM失敗パターン集（`type:knowledge`）
 
 ### クローズされたIssue
 なし
 
 ## 会話トピック
 
-### セッション c917fba2（108ツール実行）
+### セッション c917fba2（197ツール実行）
 
 | # | 依頼内容 | 種別 |
 |---|---------|------|
-| 1 | `/company` — 組織選択、domain-tech-collectionで作業続行 | 組織操作 |
+| 1 | `/company` → 組織選択 → A | 組織操作 |
 | 2 | 毎日の技術リサーチを実行してほしい | wf-daily-digest |
-| 3 | OKマージしたからmain以外のローカルブランチ削除して | Git操作 |
-| 4 | ニュース巡回の内容をHTMLでGitHub Pagesと連携した仕組みをコマンドして欲しい | 機能開発依頼 |
+| 3 | OKマージしたからブランチ削除して | Git操作 |
+| 4 | ニュース巡回の内容をHTMLでGitHub Pagesと連携する仕組みをコマンドして | 機能開発 |
 | 5 | SKILLSコマンドから実行できる仕組みにしている？ | 確認・指摘 |
-| 6 | 2でお願いしたい（独立スキルとして作成）— ダッシュボードとは用途・実行タイミングが異なるため | 設計判断 |
-| 7 | OKマージしたからmain以外のローカルブランチ削除して | Git操作 |
-| 8 | `/company-digest-html` — 新スキルの動作確認 | スキル実行 |
-| 9 | `/company-report` — 本レポート生成 | レポート |
+| 6 | 独立スキルとして作成（ダッシュボードとは用途が異なるため） | 設計判断 |
+| 7 | OKマージしたからブランチ削除して | Git操作 |
+| 8 | `/company-digest-html` 動作確認 | スキル実行 |
+| 9 | `/company-report` 日次レポート生成 | レポート |
+| 10 | `/company-evolve` 継続学習実行 | 学習 |
+| 11 | `/company-dashboard` ダッシュボード更新 | ダッシュボード |
+| 12 | daily-digestのリンクボタンがなくなってない？ | バグ指摘 |
+| 13 | shファイルもpushしておいて | Git操作 |
+| 14 | daily-digestの活動に報酬って付与されていない？ | バグ指摘 |
+| 15 | 報酬付与できなかったのは失敗パターンとして記憶して | メモリ登録 |
+| 16 | `/company-dashboard` ダッシュボード再更新 | ダッシュボード |
+| 17 | OKマージしたからブランチ削除して | Git操作 |
+| 18 | `/company` → A → PMの知識習得について深堀りたい | 壁打ち |
+| 19 | 壁打ち: PMとして身につけるべきスキル → Bで（役割ベース） | 壁打ち |
+| 20 | 概ねあってる！→ 成果物まで落とし込んでlearning-notesに追記して | 成果物化依頼 |
+| 21 | OKマージしたからブランチ削除して | Git操作 |
+| 22 | `/company` → A → SIer PM失敗パターン集を資料ベースで作成して | 成果物化依頼 |
+| 23 | `/company-report` 最終版レポート | レポート |
 
 ### ファイル生成を伴わなかったやり取り
-- 組織選択UI（`/company` → A選択）
-- ブランチ削除（2回）
-- スキル設計方針の壁打ち（独立スキル vs ダッシュボード統合）
+- 組織選択UI（3回）
+- ブランチ削除（4回）
+- PM知識習得の壁打ち（6領域の整理→強み/弱みの仮説→優先順位付け）
+- ダッシュボード再生成時のダイジェストカード消失のバグ指摘・修正
+- Case Bank reward未付与問題の指摘・修正・記憶登録
 
 ## 次のアクション候補
 
-1. **Issue #95 のクローズ** — ダイジェストPR #94 はマージ済みのためクローズ可能
-2. **`wf-daily-digest` 完了後の自動HTML生成検討** — 現在は `/company-digest-html` を手動実行する必要があるが、ワークフロー完了後の自動連携を検討
+1. **PMスキルマップ Phase 1 着手** — 最優先のステークホルダー調整5成果物（ステークホルダーマップ、ステコミ報告テンプレ等）をW2で開始（根拠: [pm-skill-map.md](../learning-notes/pm-skill-map.md)）
+2. **PM失敗パターンのセルフチェック定期実行** — 参画後に週次で7パターンのセルフチェックリストを振り返る仕組みを検討（根拠: [pm-failure-patterns.md](../learning-notes/pm-failure-patterns.md)）
 3. **AWS What's New の代替取得方法調査** — JS描画ページの取得制約が継続中。RSSフィード等の代替手段を検討
-4. **ストコン案件の学習タスク継続** — WBSの未完了タスクの進行
+4. **WBS未完了タスクの継続** — セクション2（ドメイン知識）W2タスク、セクション3（技術）W1タスクが未着手
+5. **rebuild-case-bank.sh の改修** — judge結果からrewardを自動算出するロジック追加（根拠: feedback_reward_from_judge.md）
 
 ---
 _このレポートは /company-report Skill によって自動生成されました_


### PR DESCRIPTION
## Summary
- 09:20版を更新し、PM学習タスク2件・ダッシュボード修正・継続学習・バグ修正を反映
- 完了タスク: 3件（daily-digest, pm-skill-map, pm-failure-patterns）
- ツール実行数: 197回 / 成果物: 12件

## Test plan
- [x] 5ソースからデータ収集済み
- [x] 全完了タスクとIssueを反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)