### PR TITLE
admin: AWS Diagram MCP Server を追加 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/masters/mcp-services.md
+++ b/.companies/domain-tech-collection/masters/mcp-services.md
@@ -16,3 +16,19 @@
   - `list_regions` — AWSリージョン一覧取得
   - `get_regional_availability` — サービス・機能のリージョン別利用可否確認
   - `retrieve_agent_sops` — エージェントSOP（手順書）取得
+
+## aws-diagram-mcp-server
+
+- **サービス名**: AWS Diagram MCP Server
+- **提供元**: awslabs（AWS公式）
+- **ステータス**: configured
+- **連携部署**: [dept-secretary, dept-research, dept-retail-domain]
+- **想定操作**: AWSアーキテクチャ構成図の生成、シーケンス図・フローチャートの作成
+- **設定先**: .mcp.json（プロジェクトルート）
+- **認証**: 不要
+- **前提条件**: uv, Python 3.10, GraphViz
+- **提供ツール**:
+  - `generate_diagram` — Python diagrams DSLを使用した構成図生成
+- **参考ドキュメント**:
+  - [公式README](https://github.com/awslabs/mcp/blob/main/src/aws-diagram-mcp-server/README.md)
+  - [Qiita解説記事](https://qiita.com/y5347M/items/aa35cd9a073937066359)

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,13 @@
     "aws-knowledge-mcp-server": {
       "command": "uvx",
       "args": ["fastmcp", "run", "https://knowledge-mcp.global.api.aws"]
+    },
+    "awslabs.aws-diagram-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.aws-diagram-mcp-server"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.mcp.json` に `awslabs.aws-diagram-mcp-server` を追加
- `masters/mcp-services.md` にエントリ追加（連携部署: 全3部署）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `.mcp.json` | AWS Diagram MCP Server の接続設定追加 |
| `masters/mcp-services.md` | サービスエントリ追加（configured） |

## 参考
- [公式README](https://github.com/awslabs/mcp/blob/main/src/aws-diagram-mcp-server/README.md)
- [Qiita解説記事](https://qiita.com/y5347M/items/aa35cd9a073937066359)

## 前提条件（利用時）
- `uv` インストール済み
- Python 3.10
- GraphViz

🤖 Generated with [Claude Code](https://claude.com/claude-code)