### PR TITLE
feat: 構成図ソースコード・メタデータを組織docsに格納 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/diagrams/storcon-cicd-pipeline.md
+++ b/.companies/domain-tech-collection/docs/diagrams/storcon-cicd-pipeline.md
@@ -1,0 +1,110 @@
+# StoreCon CI/CD Pipeline
+
+## メタデータ
+
+| 項目 | 値 |
+|------|-----|
+| ファイル名 | storcon-cicd-pipeline |
+| 案件 | コンビニストコンAWS移行 |
+| 領域 | CI/CD |
+| 生成日 | 2026-03-27 |
+| MCP Server | awslabs.aws-diagram-mcp-server |
+| 公開URL | [GitHub Pages](https://sas-sasao.github.io/cc-sier-organization/diagrams/storcon-cicd-pipeline.html) |
+
+## 使用AWSサービス
+
+- AWS CodeBuild
+- AWS CodeArtifact
+- Amazon ECR
+- AWS CDK / CloudFormation
+- Amazon ECS Fargate (STG / PRD)
+- Amazon RDS (STG / PRD)
+- Amazon SNS
+- Amazon CloudWatch
+- AWS CloudTrail
+- AWS Secrets Manager
+- IAM Role
+
+## 外部サービス
+
+- GitHub (Repository)
+- GitHub Actions (CI/CD Trigger)
+
+## ソースコード（Python diagrams DSL）
+
+```python
+with Diagram("StoreCon CI/CD Pipeline", show=False, direction="LR", filename="storcon-cicd-pipeline", graph_attr={"fontsize": "16", "pad": "0.5"}):
+
+    # Source
+    with Cluster("Source"):
+        github = Github("GitHub\nRepository")
+        actions = GithubActions("GitHub\nActions")
+
+    # Build & Test
+    with Cluster("Build & Test"):
+        codebuild = Codebuild("CodeBuild\n(Build & Test)")
+        codeartifact = Codeartifact("CodeArtifact\n(Dependencies)")
+
+    # Artifact
+    with Cluster("Artifact Registry"):
+        ecr = ECR("Amazon ECR\n(Container Images)")
+
+    # IaC
+    with Cluster("Infrastructure as Code"):
+        cdk = CloudDevelopmentKit("AWS CDK")
+        cfn = Cloudformation("CloudFormation\n(Stack Deploy)")
+
+    # Deploy Staging
+    with Cluster("Staging Environment"):
+        ecs_stg = ECS("ECS Fargate\n(Staging)")
+        rds_stg = RDS("RDS\n(Staging)")
+
+    # Approval Gate
+    with Cluster("Approval Gate"):
+        sns = SNS("SNS\n(Notification)")
+
+    # Deploy Production
+    with Cluster("Production Environment"):
+        ecs_prd = ECS("ECS Fargate\n(Production)")
+        rds_prd = RDS("RDS\n(Production)")
+
+    # Monitoring
+    with Cluster("Monitoring & Security"):
+        cloudwatch = Cloudwatch("CloudWatch\n(Metrics & Logs)")
+        cloudtrail = Cloudtrail("CloudTrail\n(Audit)")
+        secrets = SecretsManager("Secrets\nManager")
+        iam = IAMRole("IAM Role\n(Least Privilege)")
+
+    # Flow: Source → Build
+    github >> Edge(label="Push / PR", color="darkblue", style="bold") >> actions
+    actions >> Edge(label="Trigger", color="darkblue") >> codebuild
+    codebuild >> codeartifact
+
+    # Flow: Build → Artifact
+    codebuild >> Edge(label="Push Image", color="purple", style="bold") >> ecr
+
+    # Flow: IaC
+    actions >> Edge(label="IaC Deploy", color="darkorange", style="dashed") >> cdk >> cfn
+
+    # Flow: Deploy Staging
+    ecr >> Edge(label="Deploy STG", color="darkgreen", style="bold") >> ecs_stg
+    cfn >> ecs_stg
+    ecs_stg >> rds_stg
+
+    # Flow: Approval → Production
+    ecs_stg >> Edge(label="E2E Test Pass", color="teal") >> sns
+    sns >> Edge(label="Approve", color="red", style="bold") >> ecs_prd
+    ecr >> ecs_prd
+    cfn >> ecs_prd
+    ecs_prd >> rds_prd
+
+    # Monitoring
+    ecs_stg >> Edge(style="dashed", color="gray") >> cloudwatch
+    ecs_prd >> Edge(style="dashed", color="gray") >> cloudwatch
+    ecs_prd >> Edge(style="dashed", color="gray") >> cloudtrail
+
+    # Security
+    secrets >> Edge(style="dashed", color="gray") >> ecs_stg
+    secrets >> Edge(style="dashed", color="gray") >> ecs_prd
+    iam >> Edge(style="dashed", color="gray") >> actions
+```

--- a/.companies/domain-tech-collection/docs/diagrams/storcon-dwh-architecture.md
+++ b/.companies/domain-tech-collection/docs/diagrams/storcon-dwh-architecture.md
@@ -1,0 +1,78 @@
+# StoreCon AWS Migration - DWH Architecture
+
+## メタデータ
+
+| 項目 | 値 |
+|------|-----|
+| ファイル名 | storcon-dwh-architecture |
+| 案件 | コンビニストコンAWS移行 |
+| 領域 | DWH / データ基盤 |
+| 生成日 | 2026-03-27 |
+| MCP Server | awslabs.aws-diagram-mcp-server |
+| 公開URL | [GitHub Pages](https://sas-sasao.github.io/cc-sier-organization/diagrams/storcon-dwh-architecture.html) |
+
+## 使用AWSサービス
+
+- Amazon S3 (Raw / Processed / Curated)
+- AWS DMS (Database Migration Service)
+- Amazon Kinesis Data Streams
+- Amazon Kinesis Data Firehose
+- AWS Glue (ETL)
+- AWS Glue Data Catalog
+- AWS Lake Formation
+- Amazon Redshift
+- Amazon Athena
+- Amazon QuickSight
+
+## ソースコード（Python diagrams DSL）
+
+```python
+with Diagram("StoreCon AWS Migration - DWH Architecture", show=False, direction="LR", filename="storcon-dwh-architecture", graph_attr={"fontsize": "16", "pad": "0.5"}):
+
+    # Data Sources (On-premises)
+    with Cluster("On-Premises (Store)"):
+        pos = EC2("POS Terminal")
+        storcon = EC2("Store Computer")
+
+    # Data Ingestion
+    with Cluster("Data Ingestion"):
+        dms = DMS("Database\nMigration Service")
+        kinesis = KinesisDataStreams("Kinesis\nData Streams")
+        firehose = KinesisDataFirehose("Kinesis\nData Firehose")
+
+    # Data Lake
+    with Cluster("Data Lake (S3)"):
+        with Cluster("Storage Tiers"):
+            s3_raw = S3("Raw Data")
+            s3_processed = S3("Processed Data")
+            s3_curated = S3("Curated Data")
+
+        with Cluster("ETL & Governance"):
+            glue = Glue("AWS Glue\n(ETL)")
+            catalog = GlueDataCatalog("Glue Data\nCatalog")
+            lakeformation = LakeFormation("Lake\nFormation")
+
+    # DWH & Analytics
+    with Cluster("DWH & Analytics"):
+        redshift = Redshift("Amazon\nRedshift")
+        athena = Athena("Amazon\nAthena")
+
+    # BI
+    with Cluster("Visualization"):
+        quicksight = Quicksight("Amazon\nQuickSight")
+
+    # Batch flow
+    storcon >> Edge(label="Batch", color="darkblue", style="bold") >> dms >> s3_raw
+    # Realtime flow
+    pos >> Edge(label="Realtime", color="darkgreen", style="bold") >> kinesis >> firehose >> s3_raw
+
+    # Data lake internal
+    s3_raw >> glue >> s3_processed
+    s3_processed >> glue >> s3_curated
+    glue >> catalog
+    lakeformation >> catalog
+
+    # Analytics
+    s3_curated >> redshift >> quicksight
+    s3_curated >> athena >> quicksight
+```


### PR DESCRIPTION
## Summary
- `.companies/domain-tech-collection/docs/diagrams/` に構成図のソース情報を格納
- 各構成図ごとに1ファイル（メタデータ + 使用サービス + Python DSLコード）

## ファイル構成
```
.companies/domain-tech-collection/docs/diagrams/
├── storcon-dwh-architecture.md    ← DWH構成図のソース
└── storcon-cicd-pipeline.md       ← CI/CD構成図のソース
```

## 各ファイルの内容
- メタデータ（案件名、領域、生成日、公開URL）
- 使用AWSサービス一覧
- Python diagrams DSL ソースコード（再生成可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)