### PR TITLE
feat: /company-diagram, /company-admin にtask-log記録を追加

### DIFF
--- a/.claude/skills/company-admin/SKILL.md
+++ b/.claude/skills/company-admin/SKILL.md
@@ -19,7 +19,6 @@ description: >
 ## 1. 操作対象の判定
 
 起動時に `.companies/.active` を読み取り、`{org-slug}` を特定する。
-また `git config user.name` を実行してユーザー名を取得し、`{operator}` として保持する（取得できない場合は `anonymous`）。
 以降、すべてのマスタ参照先は `.companies/{org-slug}/masters/` となる。
 
 ユーザーの依頼から対象マスタと操作種別を特定します。
@@ -131,7 +130,7 @@ Q3: 想定操作は？
 | ワークフローID | `wf-` プレフィックス + kebab-case + 一意 |
 | プロジェクトID | `proj-` プレフィックス + 一意 |
 | ステータス | 定義された enum 値のいずれか |
-| フォルダパス | `.companies/{org-slug}/docs/` プレフィックス + 他部署と非重複 |
+| フォルダパス | `.companies/{org-slug}/` プレフィックス + 他部署と非重複 |
 
 ### 4.2 整合性検証
 
@@ -168,9 +167,9 @@ Q3: 想定操作は？
 
 ```
 1. masters/departments.md にエントリ追加
-2. .companies/{org-slug}/docs/{folder}/ フォルダ作成（サブフォルダ含む）
+2. .companies/{org-slug}/{folder}/ フォルダ作成（サブフォルダ含む）
    → references/departments.md のテンプレートを参照
-3. .companies/{org-slug}/docs/{folder}/CLAUDE.md 生成
+3. .companies/{org-slug}/{folder}/CLAUDE.md 生成
    → references/departments.md の CLAUDE.md テンプレートから生成
 4. .companies/{org-slug}/CLAUDE.md の組織構成ツリー・部署一覧テーブルに追記
 5. 新規ロールがある場合 → ロール追加の連鎖更新も実行
@@ -204,7 +203,7 @@ Q3: 想定操作は？
 ### 6.4 部署削除時の連鎖更新（安全策付き）
 
 ```
-1. .companies/{org-slug}/docs/{folder}/ 配下のファイル存在チェック
+1. .companies/{org-slug}/{folder}/ 配下のファイル存在チェック
    → ファイルがある場合: 物理削除不可。以下を提案:
      「この部署にはデータが残っています。削除ではなくアーカイブ（archived ステータス）
       にすることをお勧めします。アーカイブしますか？」
@@ -245,7 +244,42 @@ Q3: 想定操作は？
 2. .companies/{org-slug}/CLAUDE.md をテンプレートから再生成
 ```
 
-### 6.8 Gitワークフロー
+### 6.8 タスクログと Issue 作成
+
+マスタ変更もファイル生成を伴う作業のため、task-logを記録する。
+
+**タスク受付時**に `.companies/{org-slug}/.task-log/{task-id}.md` を作成する。
+
+task-id: `YYYYMMDD-HHMMSS-admin-{操作slug}`
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: in-progress
+mode: direct
+started: "{ISO8601}"
+completed: ""
+request: "{ユーザーの依頼原文}"
+issue_number: null
+pr_number: null
+---
+```
+
+記録するセクション:
+- **実行計画**: 対象マスタ、操作種別（追加/変更/削除）、連鎖更新の範囲
+- **成果物**: 更新されたマスタファイル、生成されたSubagent/CLAUDE.md等
+
+**タスク完了時**: `status: completed`、`completed` フィールドを更新。
+
+**Issue 作成**: タスク完了時に `gh issue create` で Issue を作成。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:admin`
+- `dept:secretary`
+
+### 6.9 Gitワークフロー
 
 マスタ変更はすべてGitワークフローで管理します。
 
@@ -298,7 +332,7 @@ Q3: 想定操作は？
 
 | 対象 | 安全策 |
 |------|--------|
-| **部署** | `.companies/{org-slug}/docs/{dept}/` にファイルがある → 削除不可、アーカイブ提案 |
+| **部署** | `.companies/{org-slug}/{dept}/` にファイルがある → 削除不可、アーカイブ提案 |
 | **ロール** | workflows.md で参照中 → 警告 + 代替ロール要求 |
 | **ワークフロー** | そのまま削除可能（他マスタへの影響なし） |
 | **プロジェクト** | archived への変更を推奨。物理削除は関連フォルダが空の場合のみ |

--- a/.claude/skills/company-diagram/SKILL.md
+++ b/.claude/skills/company-diagram/SKILL.md
@@ -102,7 +102,50 @@ docs/diagrams/
 - レイヤー構成テーブル
 - 「構成図一覧に戻る」リンク
 
-## 5. Git ワークフロー
+## 5. タスクログと Issue 作成
+
+構成図の生成はファイル生成を伴う作業のため、必ずtask-logを記録する。
+
+### 5.1 タスクログ記録
+
+**タスク受付時**に `.companies/{org-slug}/.task-log/{task-id}.md` を作成する。
+
+task-id: `YYYYMMDD-HHMMSS-diagram-{name}`
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: in-progress
+mode: direct
+started: "{ISO8601}"
+completed: ""
+request: "{ユーザーの依頼原文}"
+issue_number: null
+pr_number: null
+---
+```
+
+記録するセクション:
+- **実行計画**: 描画対象、使用AWSサービス、MCP Server利用
+- **成果物**: PNG、詳細HTML、一覧HTML更新、ソースMD
+
+**タスク完了時**: `status: completed`、`completed` フィールドを更新。
+
+### 5.2 LLM-as-Judge 評価
+
+成果物が `docs/` 配下にあるため、コミット前に completeness / accuracy / clarity の3軸評価を実施し、task-logに `## judge` セクションを追記する。
+
+### 5.3 Issue 作成
+
+タスク完了時に `gh issue create` で Issue を作成する。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:feat`
+- `dept:secretary`
+
+## 6. Git ワークフロー
 
 ```
 1. ブランチ: {org-slug}/feat/{YYYY-MM-DD}-add-diagram-{name}
@@ -112,13 +155,13 @@ docs/diagrams/
 5. main に戻る
 ```
 
-## 6. GitHub Pages 連携
+## 7. GitHub Pages 連携
 
 - 構成図は `docs/diagrams/` に配置（GitHub Pages 公開対象）
 - トップページ `docs/index.html` にオレンジ枠のカードで自動リンク
 - `/company-dashboard` 実行時も `generate-dashboard.sh` が `docs/diagrams/index.html` を検出してカードを維持
 
-## 7. 前提条件
+## 8. 前提条件
 
 | 項目 | 要件 |
 |------|------|

--- a/plugins/cc-sier/skills/company-admin/SKILL.md
+++ b/plugins/cc-sier/skills/company-admin/SKILL.md
@@ -244,7 +244,42 @@ Q3: 想定操作は？
 2. .companies/{org-slug}/CLAUDE.md をテンプレートから再生成
 ```
 
-### 6.8 Gitワークフロー
+### 6.8 タスクログと Issue 作成
+
+マスタ変更もファイル生成を伴う作業のため、task-logを記録する。
+
+**タスク受付時**に `.companies/{org-slug}/.task-log/{task-id}.md` を作成する。
+
+task-id: `YYYYMMDD-HHMMSS-admin-{操作slug}`
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: in-progress
+mode: direct
+started: "{ISO8601}"
+completed: ""
+request: "{ユーザーの依頼原文}"
+issue_number: null
+pr_number: null
+---
+```
+
+記録するセクション:
+- **実行計画**: 対象マスタ、操作種別（追加/変更/削除）、連鎖更新の範囲
+- **成果物**: 更新されたマスタファイル、生成されたSubagent/CLAUDE.md等
+
+**タスク完了時**: `status: completed`、`completed` フィールドを更新。
+
+**Issue 作成**: タスク完了時に `gh issue create` で Issue を作成。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:admin`
+- `dept:secretary`
+
+### 6.9 Gitワークフロー
 
 マスタ変更はすべてGitワークフローで管理します。
 
@@ -252,7 +287,7 @@ Q3: 想定操作は？
 1. ブランチ作成: {org-slug}/admin/{YYYY-MM-DD}-{操作概要}
    例: a-sha-dwh-project/admin/2026-03-19-add-dept-security
 2. マスタ更新 + 連鎖更新を実行（セクション5・6の処理）
-3. コミット: feat: {操作概要} [{org-slug}]
+3. コミット: feat: {操作概要} [{org-slug}] by {operator}
 4. PR作成（変更サマリーをPR本文に記載）
 5. mainブランチに戻る
 ```

--- a/plugins/cc-sier/skills/company-diagram/SKILL.md
+++ b/plugins/cc-sier/skills/company-diagram/SKILL.md
@@ -102,7 +102,50 @@ docs/diagrams/
 - レイヤー構成テーブル
 - 「構成図一覧に戻る」リンク
 
-## 5. Git ワークフロー
+## 5. タスクログと Issue 作成
+
+構成図の生成はファイル生成を伴う作業のため、必ずtask-logを記録する。
+
+### 5.1 タスクログ記録
+
+**タスク受付時**に `.companies/{org-slug}/.task-log/{task-id}.md` を作成する。
+
+task-id: `YYYYMMDD-HHMMSS-diagram-{name}`
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: in-progress
+mode: direct
+started: "{ISO8601}"
+completed: ""
+request: "{ユーザーの依頼原文}"
+issue_number: null
+pr_number: null
+---
+```
+
+記録するセクション:
+- **実行計画**: 描画対象、使用AWSサービス、MCP Server利用
+- **成果物**: PNG、詳細HTML、一覧HTML更新、ソースMD
+
+**タスク完了時**: `status: completed`、`completed` フィールドを更新。
+
+### 5.2 LLM-as-Judge 評価
+
+成果物が `docs/` 配下にあるため、コミット前に completeness / accuracy / clarity の3軸評価を実施し、task-logに `## judge` セクションを追記する。
+
+### 5.3 Issue 作成
+
+タスク完了時に `gh issue create` で Issue を作成する。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:feat`
+- `dept:secretary`
+
+## 6. Git ワークフロー
 
 ```
 1. ブランチ: {org-slug}/feat/{YYYY-MM-DD}-add-diagram-{name}
@@ -112,13 +155,13 @@ docs/diagrams/
 5. main に戻る
 ```
 
-## 6. GitHub Pages 連携
+## 7. GitHub Pages 連携
 
 - 構成図は `docs/diagrams/` に配置（GitHub Pages 公開対象）
 - トップページ `docs/index.html` にオレンジ枠のカードで自動リンク
 - `/company-dashboard` 実行時も `generate-dashboard.sh` が `docs/diagrams/index.html` を検出してカードを維持
 
-## 7. 前提条件
+## 8. 前提条件
 
 | 項目 | 要件 |
 |------|------|


### PR DESCRIPTION
## Summary
- `/company-diagram` にタスクログ・Judge評価・Issue作成フローを追加（セクション5）
- `/company-admin` にタスクログ・Issue作成フローを追加（セクション6.8）
- Skill直接実行時もCase Bankの学習対象に含まれるようになる

## 背景
2026-03-27午後セッションでMCPサーバー追加（/company-admin）と構成図3件生成（/company-diagram）を実施したが、task-logが作成されずCase Bankに評価対象として追加されなかった。PR12件中7件分の作業が学習対象から漏れた。

## 変更内容
| Skill | 追加セクション | 記録内容 |
|-------|-------------|---------|
| `/company-diagram` | 5. タスクログとIssue作成 | task-log + Judge評価 + Issue |
| `/company-admin` | 6.8 タスクログとIssue作成 | task-log + Issue |

## feedbackメモリにも記録済み
`feedback_skill_tasklog.md` — 今後の新規Skill作成時にも同じ失敗を繰り返さないよう記憶

🤖 Generated with [Claude Code](https://claude.com/claude-code)