### PR TITLE
docs: 日次レポート夜間最終版2 2026-03-27

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today-night.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-27-today-night.md
@@ -1,0 +1,141 @@
+# domain-tech-collection 活動レポート — 2026-03-27 日次・夜間最終版
+
+> 生成日時: 2026-03-27T20:08:11+09:00 | 生成者: SAS-Sasao | 期間: 2026-03-27
+
+## エグゼクティブサマリー
+
+本日は計6件のタスクを完了し、PM教育資料とAWSアーキテクチャ構成図の両面で大きな進展があった。午前は日次ダイジェスト（技術17件+小売15件=32件）を生成し、午後前半はPMスキルマップ（6責務領域×3フェーズ学習ロードマップ）と技術者出身PM失敗パターン集（7パターン×ケーススタディ）を作成。午後後半〜夜間にかけてはAWS Diagram MCP Serverを使い、モダンデータレイクハウス・MLパイプライン・販売管理システムの3件の構成図を連続生成した。特にコスト概算テーブル付きの販売管理システム構成図は実務提案への活用が期待される。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 83 回（session-summaries記録） |
+| 会話セッション数 | 3 セッション（conversation-log記録） |
+| 完了タスク数 | 6 件 |
+| 作成・編集ファイル数 | 18+ 件 |
+| 新規オープンIssue数（本日） | 9 件（うちinteraction-log除外で8件） |
+| クローズIssue数（本日） | 0 件 |
+
+## 完了タスク
+
+### 1. 日次ダイジェスト生成
+- **モード**: agent-teams（秘書直接実行）
+- **依頼**: 毎日の技術リサーチ（wf-daily-digest）
+- **成果物**: `docs/daily-digest/2026-03-27.md`
+- **Judge**: 0.83（completeness:8, accuracy:8, clarity:9）
+- **備考**: 8ソース並列WebFetch、技術17件+小売15件=32件収集。Case Bankの失敗パターン適用でsubagent委譲せず秘書が直接実行
+
+### 2. PMスキルマップ作成
+- **モード**: direct（秘書直接実行）
+- **依頼**: 壁打ち結果をもとに機能チームPMの6領域×学習ロードマップを成果物化
+- **成果物**: `docs/secretary/learning-notes/pm-skill-map.md`
+- **Judge**: 0.87（completeness:9, accuracy:8, clarity:9）
+- **備考**: 6責務領域（スコープ管理/計画・進捗/ステークホルダー調整/リスク・課題/品質/チーム運営）の定義。3フェーズ学習ロードマップ（Phase1:今〜5月中旬, Phase2:5月中旬〜6月, Phase3:6月〜）
+
+### 3. PM失敗パターン集作成
+- **モード**: direct（秘書直接実行）
+- **依頼**: SIer技術者出身PMの失敗パターン集をケーススタディ形式で作成
+- **成果物**: `docs/secretary/learning-notes/pm-failure-patterns.md`
+- **Judge**: 0.93（completeness:9, accuracy:9, clarity:10）
+- **備考**: 7パターンの失敗事例。症状→根本原因→ケーススタディ→処方箋→セルフチェック。具体的フレームワーク（15分ルール、3層翻訳、断り方5パターン等）
+
+### 4. AWS構成図: モダンデータレイクハウス
+- **モード**: direct / company-diagram
+- **依頼**: モダンなデータレイクハウス構成を学びたい
+- **成果物**: `docs/diagrams/modern-data-lakehouse.png`, `.html`, `index.html`更新
+- **Judge**: 5.0/5.0 | **Reward**: 0.8
+- **備考**: Medallionアーキテクチャ（Bronze/Silver/Gold）。11 AWSサービス。graph_attrパラメータ制約を発見・回避
+
+### 5. AWS構成図: モダンMLパイプライン
+- **モード**: direct / company-diagram
+- **依頼**: DWHデータをMLするためのモダンなアーキテクチャ提案
+- **成果物**: `docs/diagrams/modern-ml-pipeline.png`, `.html`, `index.html`更新
+- **Judge**: 5.0/5.0 | **Reward**: 0.8
+- **備考**: SageMaker中心のMLOps + Bedrock RAG拡張。前回のレイクハウス構成図との連続性を設計
+
+### 6. AWS構成図: 販売管理システム
+- **モード**: direct / company-diagram
+- **依頼**: 月額AWS費用20万円、50-70名向け販売管理システムの構成図
+- **成果物**: `docs/diagrams/sales-management-system.png`, `.html`, `index.html`更新
+- **Judge**: 5.0/5.0 | **Reward**: 0.8
+- **備考**: ECS Fargate + Aurora Serverless v2 + Cognito。月額$173-223（約2.6-3.3万円）で20万円予算に余裕。コスト概算テーブル付き
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 秘書室（secretary/）
+- `docs/secretary/learning-notes/pm-skill-map.md` — PMスキルマップ&学習ロードマップ
+- `docs/secretary/learning-notes/pm-failure-patterns.md` — PM失敗パターン集（7パターン）
+- `docs/secretary/dashboard.html` — ダッシュボード更新
+- `docs/secretary/reports/2026-03-27-today.md` — 日次レポート
+- `docs/secretary/reports/2026-03-27-today-final.md` — 日次レポート最終版
+
+### ダイジェスト
+- `docs/daily-digest/2026-03-27.md` — 技術17件+小売15件=32件の日次ニュースダイジェスト
+
+### 構成図（diagrams/）
+- `docs/diagrams/modern-data-lakehouse.png` + `.html` — Medallionデータレイクハウス
+- `docs/diagrams/modern-ml-pipeline.png` + `.html` — MLパイプライン
+- `docs/diagrams/sales-management-system.png` + `.html` — 販売管理システム
+- `docs/diagrams/storcon-dwh-architecture.md` — ストコンDWHソースMD
+- `docs/diagrams/storcon-cicd-pipeline.md` — ストコンCI/CDソースMD
+- `docs/diagrams/storcon-app-architecture.md` — ストコンアプリソースMD
+- `docs/diagrams/index.html` — 一覧ページ更新（6件）
+
+## Issue 動向
+
+### 新規オープンのIssue（本日、interaction-log除外）
+- #121 feat: 販売管理システムAWS構成図を追加
+- #119 feat: モダンMLパイプライン構成図を追加
+- #117 feat: モダンデータレイクハウス構成図を追加
+- #114 活動レポート 日次・夜間最終版
+- #105 活動レポート 日次・最終版
+- #103 技術者出身PM失敗パターン集（7パターン×ケーススタディ）
+- #101 機能チームPMスキルマップ&学習ロードマップ作成
+- #99 活動レポート 日次
+- #95 日次ダイジェスト 2026-03-27
+
+### クローズされたIssue（本日）
+なし
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション c917fba2**（午後前半）
+  - /company Skill 実行（PM壁打ち、教育資料生成）
+  - PMスキルマップ作成依頼
+  - PM失敗パターン集作成依頼
+  - ダッシュボード更新
+
+- **セッション 569a7280**（午後後半〜夜間）
+  - /company-diagram Skill 実行
+  - モダンデータレイクハウス構成図の生成依頼
+  - モダンMLパイプライン構成図の生成依頼
+  - 販売管理システム構成図の生成依頼（コスト要件付き）
+  - ブランチ削除・push依頼（Git運用）
+
+- **セッション d1b18915**（夜間）
+  - /company-diagram Skill 実行（現在のセッション）
+  - 販売管理システム構成図の生成（継続）
+  - /company-report 実行
+
+### ファイル生成を伴わなかったやり取り
+- PM壁打ち・相談（スキルマップの前段としてのディスカッション）
+- Gitブランチ削除・pushの指示（運用作業）
+
+## 次のアクション候補
+
+1. **AWS構成図のレビューと学習深掘り**（根拠: 本日3件の構成図を生成したが、各サービスの実務設定・運用ノウハウはまだ未整理）
+2. **PMスキルマップ Phase1 の学習開始**（根拠: pm-skill-map.md で定義した Phase1「今〜5月中旬」の学習ロードマップに着手すべき時期）
+3. **PM失敗パターンの自己チェック実施**（根拠: pm-failure-patterns.md の7パターンに対するセルフチェックを実施し、自身の傾向を把握）
+4. **ストコンAWS移行のW2タスク継続**（根拠: WBS 3.x のAWS基礎学習ロードマップが未完了）
+5. **オープンIssueの整理**（根拠: 累計40+件のオープンIssueがあり、完了済みタスクのクローズが必要）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-27 日次活動レポート（夜間最終版2）を生成
- 本日の全6タスク完了を反映（日次ダイジェスト、PM教育資料2件、AWS構成図3件）
- 5情報源（session-summaries/task-log/docs/GitHub Issues/conversation-log）から収集

## Test plan
- [ ] レポートIssue #122 の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)