### PR TITLE
docs: 日次レポート 2026-03-28 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-28-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-28-today.md
@@ -1,0 +1,108 @@
+# domain-tech-collection 活動レポート — 本日（2026-03-28）
+
+> 生成日時: 2026-03-28 | 生成者: SAS-Sasao | 期間: 2026-03-28
+
+## エグゼクティブサマリー
+
+本日は日次ダイジェスト生成（Agent Teams）とサーバーレスWebアプリケーション構成図の新規追加を完了した。加えて、README.mdへの新機能3件の追記・ガイドドキュメント3件の新規作成、構成図テンプレートへの「設計のポイント」必須化と既存5ページへの追記を実施し、プロジェクト全体のドキュメント整備を大幅に前進させた。2セッション・計278ツール実行と高い活動密度の1日だった。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 2 回 |
+| 人間の発言数（合計） | 166 回 |
+| Claudeの応答数（合計） | 224 回 |
+| ツール実行数（合計） | 278 回 |
+| 作成・編集ファイル数 | 29 件 |
+| 完了タスク数 | 2 件 |
+| 新規オープンIssue数 | 3 件 |
+| クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+### 1. 日次ダイジェスト 2026-03-28
+- **実行モード**: agent-teams（wf-daily-digest）
+- **アサイン**: secretary (team-lead) + tech-researcher + retail-domain-researcher
+- **成果物**: `.companies/domain-tech-collection/docs/daily-digest/2026-03-28.md`
+- **Judge**: completeness 5/5, accuracy 4/5, clarity 5/5 → **total 0.95**
+- **PR**: [#126](https://github.com/SAS-Sasao/cc-sier-organization/pull/126) / **Issue**: [#127](https://github.com/SAS-Sasao/cc-sier-organization/issues/127)
+- **備考**: 全8ソースの同時巡回に成功。AWS What's NewもRSS経由で取得。技術39件+小売25件=64件
+
+### 2. AWS構成図追加（serverless-web-app）
+- **実行モード**: direct
+- **アサイン**: secretary（/company-diagram Skill）
+- **成果物**: `docs/diagrams/serverless-web-app.png`, `docs/diagrams/serverless-web-app.html`
+- **Judge**: completeness 9/10, accuracy 8/10, clarity 9/10 → **total 0.87**
+- **PR**: [#129](https://github.com/SAS-Sasao/cc-sier-organization/pull/129) / **Issue**: [#130](https://github.com/SAS-Sasao/cc-sier-organization/issues/130)
+- **備考**: 既存7件を分析し未カバーの「サーバーレス」領域を選定。CloudFront + API Gateway + Lambda + DynamoDB + Cognito構成
+
+## 進行中タスク
+
+（なし）
+
+## 作成・更新された成果物
+
+### 組織ディレクトリ（.companies/domain-tech-collection/）
+- `docs/daily-digest/2026-03-28.md` — 日次ダイジェスト
+- `docs/research/topics/daily-digest-2026-03-28.md` — 技術巡回レポート
+- `.task-log/20260328-100000-daily-digest.md` — タスクログ
+- `.task-log/20260328-160000-diagram-serverless-web-app.md` — タスクログ
+
+### GitHub Pages（docs/）
+- `docs/diagrams/serverless-web-app.png` / `.html` — 新規構成図
+- `docs/diagrams/index.html` — ギャラリー一覧（8件に更新）
+- `docs/diagrams/storcon-dwh-architecture.html` — 設計のポイント追記
+- `docs/diagrams/storcon-cicd-pipeline.html` — 設計のポイント追記
+- `docs/diagrams/modern-data-lakehouse.html` — 設計のポイント追記
+- `docs/diagrams/storcon-app-architecture.html` — 設計のポイント追記
+- `docs/daily-digest/index.html` — ダイジェストHTML更新
+
+### プラグイン・ドキュメント
+- `README.md` — 新機能3件追記（/company-diagram, /company-digest-html, LLM-as-Judge）
+- `docs/guide/11-diagram-generation.md` — 新規ガイド
+- `docs/guide/12-daily-digest.md` — 新規ガイド
+- `docs/guide/13-llm-as-judge.md` — 新規ガイド
+- `docs/guide/02-skills.md` — 新Skillリファレンス追記
+- `.claude/skills/company-diagram/SKILL.md` — テンプレート必須セクション追加
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- [#130](https://github.com/SAS-Sasao/cc-sier-organization/issues/130) feat: AWS構成図を追加（serverless-web-app）
+- [#127](https://github.com/SAS-Sasao/cc-sier-organization/issues/127) 日次ダイジェスト 2026-03-28
+- [#128](https://github.com/SAS-Sasao/cc-sier-organization/issues/128) インタラクションログ 2026-03-28
+
+### クローズされたIssue（本日）
+（なし）
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション a41a86fc**（55発言 / 71応答 / 88ツール実行）
+  - /company 起動 → 日次ダイジェスト生成（wf-daily-digest）
+
+- **セッション 044f6307**（111発言 / 153応答 / 190ツール実行）
+  - README.mdに3/25〜3/27の新機能を追記してほしい
+  - ガイドドキュメント（docs/guide/）の追加
+  - コミット & プッシュ
+  - /company-digest-html でダイジェストHTML生成
+  - /company-diagram でサーバーレスWebアプリ構成図を生成
+  - 構成図テンプレートに「設計のポイント」を必須化・既存5ページに追記
+  - /company 起動 → /company-report
+
+### ファイル生成を伴わなかったやり取り
+- ローカルブランチの削除依頼（2回）
+- 組織選択（/company → A で続行）
+
+## 次のアクション候補
+
+1. **オープンIssue 3件のクローズ確認**（根拠: #127, #128, #130が未クローズ）
+2. **構成図ギャラリーの拡充**（根拠: 8件目を追加完了。ネットワーク/セキュリティ/IoT等の未カバー領域あり）
+3. **日次ダイジェストHTMLの定期更新**（根拠: 本日分を含むHTML再生成が未実行の可能性）
+4. **/company-evolve の実行**（根拠: 本日2タスク完了。Case Bankの更新でルーティング精度向上が期待できる）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 本日（2026-03-28）の活動レポートを生成
- 完了タスク2件（日次ダイジェスト、サーバーレス構成図）
- 2セッション・278ツール実行・29ファイル変更

## Issue
#131

🤖 Generated with [Claude Code](https://claude.com/claude-code)