### PR TITLE
feat: drawio MCP Server を追加

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260329-090643-admin-add-mcp-drawio.md
+++ b/.companies/domain-tech-collection/.task-log/20260329-090643-admin-add-mcp-drawio.md
@@ -1,0 +1,25 @@
+---
+task_id: "20260329-090643-admin-add-mcp-drawio"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: direct
+started: "2026-03-29T09:06:43+09:00"
+completed: "2026-03-29T09:08:00+09:00"
+request: "drawio-mcp MCPサーバーを追加してほしい"
+subagent: "secretary"
+issue_number: null
+pr_number: null
+reward: null
+---
+
+## 実行計画
+
+- 対象マスタ: mcp-services.md, .mcp.json
+- 操作種別: 追加
+- 連鎖更新: .mcp.json にサーバー設定追加
+
+## 成果物
+
+- `.mcp.json` — drawioサーバー追加
+- `masters/mcp-services.md` — drawioサービスエントリ追加

--- a/.companies/domain-tech-collection/masters/mcp-services.md
+++ b/.companies/domain-tech-collection/masters/mcp-services.md
@@ -57,3 +57,29 @@
   - `read_iac_documentation_page` — CDK/CFnドキュメントをMarkdown形式で取得
 - **参考ドキュメント**:
   - [公式ページ](https://awslabs.github.io/mcp/servers/aws-iac-mcp-server)
+
+## drawio
+
+- **サービス名**: Draw.io MCP Server
+- **提供元**: jgraph（draw.io公式）
+- **ステータス**: active
+- **連携部署**: [dept-secretary, dept-research]
+- **想定操作**: ER図・フローチャート・シーケンス図・ネットワーク図・C4モデル等の汎用図の生成。Mermaid記法・CSV・draw.io XMLの3形式に対応
+- **設定先**: .mcp.json（プロジェクトルート）
+- **認証**: 不要
+- **前提条件**: Node.js, npx
+- **トリガー**: ER図、フローチャート、シーケンス図、ネットワーク図、業務フロー図、C4モデル、draw.io
+- **提供ツール**:
+  - `open_drawio_mermaid` — Mermaid記法から図を生成（フローチャート・シーケンス図・状態遷移図向け）
+  - `open_drawio_csv` — CSVデータから図を生成（組織図・ネットワークトポロジ向け）
+  - `open_drawio_xml` — draw.io XMLから図を生成（アーキテクチャ図・インフラ構成図向け、最も精密なレイアウト制御）
+- **使い分けガイド**:
+  - シンプルなフロー・シーケンス図 → `open_drawio_mermaid`
+  - 階層構造・組織図 → `open_drawio_csv`
+  - 精密なレイアウト・AWS以外のインフラ図 → `open_drawio_xml`
+  - AWS構成図 → 引き続き `aws-diagram-mcp-server` を推奨（AWSアイコン対応）
+- **出力形式**: draw.ioエディタで直接開けるURL。エディタからPNG/SVG/PDFにエクスポート可能
+- **参考ドキュメント**:
+  - [GitHub](https://github.com/jgraph/drawio-mcp)
+  - [サーバーワークスBlog解説](https://blog.serverworks.co.jp/drawio-mcp-claude-code)
+  - [Zenn解説記事](https://zenn.dev/aya1357/articles/12f4ede03bc32c)

--- a/.mcp.json
+++ b/.mcp.json
@@ -17,6 +17,10 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
+    },
+    "drawio": {
+      "command": "npx",
+      "args": ["-y", "@drawio/mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- draw.io公式MCPサーバー（`@drawio/mcp`）を `.mcp.json` に追加
- `masters/mcp-services.md` にサービスエントリ・使い分けガイドを追記

## 変更内容

### .mcp.json
```json
"drawio": {
  "command": "npx",
  "args": ["-y", "@drawio/mcp"]
}
```

### 提供ツール
| ツール | 用途 |
|--------|------|
| `open_drawio_mermaid` | Mermaid記法 → フローチャート・シーケンス図 |
| `open_drawio_csv` | CSV → 組織図・ネットワーク図 |
| `open_drawio_xml` | draw.io XML → 精密なアーキテクチャ図 |

### AWS Diagram MCP Server との使い分け
- **AWS構成図** → 引き続き `aws-diagram-mcp-server`（AWSアイコン対応）
- **ER図・フローチャート・シーケンス図・業務フロー** → `drawio`

## Test plan
- [ ] `npx -y @drawio/mcp` でMCPサーバーが起動すること
- [ ] Claude Codeでdrawioツールが認識されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)