### PR TITLE
feat: draw.io ダイアグラム生成Skill（/company-drawio）を追加

### DIFF
--- a/.claude/hooks/generate-dashboard.sh
+++ b/.claude/hooks/generate-dashboard.sh
@@ -1115,6 +1115,14 @@ if Path("docs/diagrams/index.html").exists():
       <div class="org-label">アーキテクチャ図ギャラリー →</div>
     </a>'''
 
+# draw.ioダイアグラムページが存在すれば追加
+if Path("docs/drawio/index.html").exists():
+    cards += '''
+    <a href="./drawio/index.html" class="card" style="border:2px solid #8b5cf6;">
+      <div class="org-name">draw.io ダイアグラム</div>
+      <div class="org-label">ER図・フロー・シーケンス図 →</div>
+    </a>'''
+
 html = f"""<!DOCTYPE html>
 <html lang="ja">
 <head>

--- a/.claude/skills/company-drawio/SKILL.md
+++ b/.claude/skills/company-drawio/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: company-drawio
+description: >
+  draw.io MCP Server を使用してアプリケーション構成図・ER図・フローチャート・
+  シーケンス図等の汎用ダイアグラムを生成する。
+  「ER図」「フローチャート」「シーケンス図」「業務フロー」「draw.io」
+  「ネットワーク図」「C4モデル」と言われたときに使用する。
+  ※ AWS構成図は /company-diagram を使用すること。
+---
+
+# draw.io ダイアグラム生成 Skill
+
+draw.io MCP Server（`@drawio/mcp`）を使い、
+汎用ダイアグラムを生成して GitHub Pages に公開する。
+
+---
+
+## 1. 起動
+
+1. `.companies/.active` から org-slug を取得
+2. `git config user.name` で operator を取得
+3. ユーザーの依頼から図の種類を判定
+
+## 2. AWS Diagram MCP との使い分け
+
+| 用途 | 使用Skill |
+|------|----------|
+| AWS構成図（AWSアイコン付き） | `/company-diagram` |
+| ER図・テーブル設計 | **本Skill（/company-drawio）** |
+| フローチャート・業務フロー | **本Skill** |
+| シーケンス図 | **本Skill** |
+| ネットワーク図（非AWS） | **本Skill** |
+| C4モデル・システム概要図 | **本Skill** |
+| 組織図・階層構造 | **本Skill** |
+
+## 3. draw.io MCP ツールの使い分け
+
+| ツール | 入力形式 | 推奨用途 |
+|--------|---------|---------|
+| `open_drawio_mermaid` | Mermaid記法 | フローチャート、シーケンス図、ER図、状態遷移図 |
+| `open_drawio_csv` | CSV | 組織図、ネットワークトポロジ、階層構造 |
+| `open_drawio_xml` | draw.io XML | 精密なレイアウトが必要な図、複雑なアーキテクチャ図 |
+
+**選択基準**:
+- シンプルなフロー・シーケンス図 → `open_drawio_mermaid`（最も簡潔）
+- 階層・ツリー構造 → `open_drawio_csv`（表形式でノード定義）
+- 精密な配置・スタイル制御 → `open_drawio_xml`（完全なレイアウト制御）
+
+## 4. ダイアグラム生成フロー
+
+### 4.1 ヒアリング（必要に応じて）
+
+```
+Q1: どんな図を作りますか？（ER図、フローチャート、シーケンス図等）
+Q2: 含めたい要素は？（テーブル名、処理ステップ、アクター等）
+Q3: 図の名前は？（英語kebab-case推奨）
+```
+
+### 4.2 ダイアグラム生成
+
+1. 依頼内容から最適なツール（mermaid/csv/xml）を選択
+2. ダイアグラムコンテンツを作成
+3. MCP ツールを呼び出し（ブラウザでdraw.ioエディタが開く）
+4. ソースコンテンツを `.drawio` ファイルとして保存
+
+### 4.3 ファイル配置
+
+```
+docs/drawio/
+├── index.html                        ← 一覧ページ（カードグリッド）
+├── {filename}.html                   ← 詳細ページ（draw.ioビューア埋め込み）
+├── {filename}.drawio                 ← draw.io XMLソース
+└── {filename}.png                    ← エクスポート画像（任意）
+
+.companies/{org-slug}/docs/drawio/
+└── {filename}.md                     ← ソースメタデータ・Mermaid/XMLコード
+```
+
+## 5. ページ構成
+
+### 5.1 一覧ページ（index.html）のカードテンプレート
+
+`<div class="grid">` 内に追記する:
+```html
+<a href="./{filename}.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">{アイコン}</div>
+    <div class="card-title">{図タイトル}</div>
+    <div class="card-meta">
+      <span class="tag tag-project">{案件名}</span>
+      <span class="tag tag-type">{図の種類}</span>
+    </div>
+    <div class="card-desc">{1行の説明}</div>
+    <div class="card-date">{YYYY-MM-DD}</div>
+  </div>
+</a>
+```
+
+件数表示（`<p class="count">` 内の右側の数字のみ）も更新する。
+左側の数字（`<span id="match-count">`）はJSが自動制御するため変更不要。
+
+**注意**: 一覧ページには検索・フィルタ・ページネーション機能が実装済み。
+カード追加時にこの範囲を編集・削除しないこと。カードは `<div class="grid">` 内にのみ追記する。
+
+### 5.2 詳細ページ（{filename}.html）の構成
+
+**以下のセクションは必須**:
+
+1. **draw.ioビューア** — iframe でdraw.io Viewerを埋め込み、インライン表示
+2. **概要** — 図の目的・対象システム・スコープ
+3. **構成要素** — テーブル形式（要素名 / 種類 / 説明）
+4. **設計のポイント** — 設計判断・トレードオフ（2〜4項目）
+
+共通要素:
+- ヘッダー: タイトル、タグ（案件名・図の種類）、生成日
+- 「draw.ioで編集」ボタン（エディタURLへのリンク）
+- 「一覧に戻る」リンク
+
+### 5.3 draw.io Viewer 埋め込み
+
+詳細ページにdraw.ioの図をインライン表示するには、以下のiframeを使用:
+
+```html
+<div class="diagram-container">
+  <iframe src="https://viewer.diagrams.net/?tags={}&highlight=0000ff&nav=1&title={filename}.drawio#R{URLエンコードされたXML}"
+          width="100%" height="500" frameborder="0" style="border-radius:8px;"></iframe>
+</div>
+```
+
+**注意**: XMLが大きい場合はURLが長くなるため、.drawioファイルへのリンクで代替する:
+```html
+<div class="diagram-container">
+  <a href="./{filename}.drawio" class="edit-btn" target="_blank">draw.io で開く</a>
+</div>
+```
+
+### 5.4 図の種類別アイコン
+
+カードに表示するアイコン（絵文字）:
+
+| 図の種類 | アイコン | tag-type色 |
+|---------|---------|-----------|
+| ER図 | 🗄️ | `#8b5cf6`（紫） |
+| フローチャート | 🔀 | `#3b82f6`（青） |
+| シーケンス図 | 🔄 | `#22c55e`（緑） |
+| ネットワーク図 | 🌐 | `#06b6d4`（シアン） |
+| 業務フロー | 📋 | `#f59e0b`（オレンジ） |
+| C4モデル | 🏗️ | `#ef4444`（赤） |
+| 組織図 | 👥 | `#6b7280`（グレー） |
+| その他 | 📊 | `#6b7280`（グレー） |
+
+## 6. タスクログと Issue 作成
+
+構成図の生成はファイル生成を伴う作業のため、必ずtask-logを記録する。
+
+### 6.1 タスクログ記録
+
+task-id: `YYYYMMDD-HHMMSS-drawio-{name}`
+
+### 6.2 Issue 作成
+
+タスク完了時に `gh issue create` で Issue を作成する。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:feat`
+- `dept:secretary`
+
+## 7. Git ワークフロー
+
+```
+1. ブランチ: {org-slug}/feat/{YYYY-MM-DD}-add-drawio-{name}
+2. git add docs/drawio/ .companies/{org-slug}/
+3. コミット: feat: draw.io図を追加（{name}）[{org-slug}] by {operator}
+4. PR作成 → URL報告
+5. main に戻る
+```
+
+## 8. GitHub Pages 連携
+
+- ダイアグラムは `docs/drawio/` に配置（GitHub Pages 公開対象）
+- トップページ `docs/index.html` に紫枠のカードで自動リンク
+- `/company-dashboard` 実行時も `generate-dashboard.sh` が `docs/drawio/index.html` を検出してカードを維持
+
+## 9. 前提条件
+
+| 項目 | 要件 |
+|------|------|
+| MCP Server | `drawio`（`@drawio/mcp`）が `.mcp.json` に設定済み |
+| Node.js | インストール済み |
+| npx | インストール済み |

--- a/.companies/domain-tech-collection/.task-log/20260329-093000-feat-drawio-skill.md
+++ b/.companies/domain-tech-collection/.task-log/20260329-093000-feat-drawio-skill.md
@@ -1,0 +1,28 @@
+---
+task_id: "20260329-093000-feat-drawio-skill"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: direct
+started: "2026-03-29T09:30:00+09:00"
+completed: "2026-03-29T09:35:00+09:00"
+request: "draw.io MCPを使用してダイアグラムを作成しポータルにアップする仕組みをSKILL化"
+subagent: "secretary"
+issue_number: null
+pr_number: null
+reward: null
+---
+
+## 実行計画
+
+- 新規Skill `/company-drawio` の作成
+- draw.io MCP（mermaid/csv/xml）でER図・フロー・シーケンス図等を生成
+- ギャラリーページ・ポータルカード・ダッシュボード連携
+
+## 成果物
+
+- `.claude/skills/company-drawio/SKILL.md` — Skill定義
+- `plugins/cc-sier/skills/company-drawio/SKILL.md` — Plugin版
+- `docs/drawio/index.html` — ギャラリーページ（検索・フィルタ・ページネーション付き）
+- `docs/index.html` — ポータルに紫枠カード追加
+- `.claude/hooks/generate-dashboard.sh` — ダッシュボード再生成時のdrawioカード維持

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>draw.io ダイアグラム一覧 - cc-sier-organization</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --purple:#8b5cf6; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.subtitle { color:var(--muted); font-size:.88rem; margin-bottom:24px; }
+.count { color:var(--muted); font-size:.82rem; margin-bottom:16px; }
+
+/* Search & Filter */
+.search-bar { margin-bottom:16px; }
+.search-input { width:100%; max-width:480px; padding:10px 16px; border:1px solid var(--border);
+                border-radius:8px; font-size:.9rem; background:var(--bg2); color:var(--text);
+                outline:none; transition:border-color .2s; }
+.search-input:focus { border-color:var(--blue); }
+.search-input::placeholder { color:var(--muted); }
+.filter-tags { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:20px; }
+.filter-btn { padding:4px 12px; border:1px solid var(--border); border-radius:16px;
+              font-size:.75rem; font-weight:600; cursor:pointer; background:var(--bg2);
+              color:var(--muted); transition:all .15s; }
+.filter-btn:hover { border-color:var(--blue); color:var(--blue); }
+.filter-btn.active { background:var(--blue); color:#fff; border-color:var(--blue); }
+.no-results { display:none; padding:40px; text-align:center; color:var(--muted); font-size:.9rem; }
+
+/* Pagination */
+.pagination { display:flex; justify-content:center; align-items:center; gap:6px; margin-top:24px; flex-wrap:wrap; }
+.page-btn { min-width:36px; height:36px; display:inline-flex; align-items:center; justify-content:center;
+            border:1px solid var(--border); border-radius:8px; background:var(--bg2); color:var(--text);
+            font-size:.85rem; cursor:pointer; transition:all .15s; text-decoration:none; }
+.page-btn:hover { border-color:var(--blue); color:var(--blue); }
+.page-btn.active { background:var(--blue); color:#fff; border-color:var(--blue); pointer-events:none; }
+.page-btn.disabled { opacity:.35; pointer-events:none; }
+.page-info { font-size:.82rem; color:var(--muted); margin:0 8px; }
+
+.grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(300px,1fr)); gap:20px; }
+.card { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+        text-decoration:none; color:var(--text); overflow:hidden;
+        transition:box-shadow .2s, transform .15s; display:block; }
+.card:hover { box-shadow:0 6px 20px var(--shadow); transform:translateY(-2px); }
+.card-body { padding:20px 24px; }
+.card-icon { font-size:2rem; margin-bottom:8px; }
+.card-title { font-size:1rem; font-weight:600; margin-bottom:6px; }
+.card-meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 8px; border-radius:4px; font-size:.72rem; font-weight:600; }
+.tag-type { color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) {
+  .tag-project { background:#78350f; color:#fde68a; }
+}
+.card-desc { font-size:.84rem; color:var(--muted); line-height:1.5; }
+.card-date { font-size:.78rem; color:var(--muted); margin-top:8px; }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+.empty-state { text-align:center; padding:60px 20px; color:var(--muted); }
+.empty-state p { font-size:.9rem; margin-top:12px; }
+</style>
+</head>
+<body>
+<a href="../" class="back-btn">&larr; トップに戻る</a>
+<h1>draw.io ダイアグラム一覧</h1>
+<p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
+<p class="count"><span id="match-count">0</span> / 0 件のダイアグラム</p>
+
+<!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
+<div class="search-bar">
+  <input type="text" id="search-input" class="search-input" placeholder="タイトル・プロジェクト・種類・説明で検索...">
+</div>
+<div class="filter-tags" id="filter-tags"></div>
+<p class="no-results" id="no-results">該当するダイアグラムがありません</p>
+<!-- ▲ 検索・フィルタ ここまで -->
+
+<div class="grid">
+</div>
+
+<!-- ▼ ページネーション（カード追加時に編集不要） -->
+<div class="pagination" id="pagination"></div>
+<!-- ▲ ページネーション ここまで -->
+
+<div class="empty-state" id="empty-state">
+  <p style="font-size:2rem;">📊</p>
+  <p>まだダイアグラムがありません。<br><code>/company-drawio</code> で最初の図を作成しましょう。</p>
+</div>
+
+<p class="updated">Powered by draw.io MCP Server</p>
+
+<!-- ▼ 検索・フィルタ・ページネーション JavaScript（カード追加時に編集不要） -->
+<script>
+(function() {
+  var PER_PAGE = 20;
+  var currentPage = 1;
+  var input = document.getElementById('search-input');
+  var tagsContainer = document.getElementById('filter-tags');
+  var noResults = document.getElementById('no-results');
+  var matchCount = document.getElementById('match-count');
+  var paginationEl = document.getElementById('pagination');
+  var emptyState = document.getElementById('empty-state');
+  var allCards = Array.prototype.slice.call(document.querySelectorAll('.card'));
+  var activeFilters = { project: '', type: '' };
+  var filtered = [];
+
+  // Hide empty state if cards exist
+  if (allCards.length > 0) emptyState.style.display = 'none';
+
+  // Build filter tag buttons from existing cards
+  var projects = [], types = [];
+  allCards.forEach(function(c) {
+    var p = c.querySelector('.tag-project');
+    var t = c.querySelector('.tag-type');
+    if (p && projects.indexOf(p.textContent) === -1) projects.push(p.textContent);
+    if (t && types.indexOf(t.textContent) === -1) types.push(t.textContent);
+  });
+
+  function createBtn(label, type) {
+    var btn = document.createElement('button');
+    btn.className = 'filter-btn';
+    btn.textContent = label;
+    btn.setAttribute('data-type', type);
+    btn.addEventListener('click', function() {
+      if (this.classList.contains('active')) {
+        this.classList.remove('active');
+        activeFilters[type] = '';
+      } else {
+        document.querySelectorAll('.filter-btn[data-type="' + type + '"]').forEach(function(b) { b.classList.remove('active'); });
+        this.classList.add('active');
+        activeFilters[type] = label;
+      }
+      currentPage = 1;
+      applyFilter();
+    });
+    return btn;
+  }
+
+  projects.forEach(function(p) { tagsContainer.appendChild(createBtn(p, 'project')); });
+  types.forEach(function(t) { tagsContainer.appendChild(createBtn(t, 'type')); });
+
+  function applyFilter() {
+    var query = input.value.toLowerCase();
+    filtered = allCards.filter(function(c) {
+      var text = c.textContent.toLowerCase();
+      var pTag = c.querySelector('.tag-project');
+      var tTag = c.querySelector('.tag-type');
+      var pMatch = !activeFilters.project || (pTag && pTag.textContent === activeFilters.project);
+      var tMatch = !activeFilters.type || (tTag && tTag.textContent === activeFilters.type);
+      var qMatch = !query || text.indexOf(query) !== -1;
+      return pMatch && tMatch && qMatch;
+    });
+    renderPage();
+  }
+
+  function renderPage() {
+    var total = filtered.length;
+    var totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
+    if (currentPage > totalPages) currentPage = totalPages;
+    var start = (currentPage - 1) * PER_PAGE;
+    var end = start + PER_PAGE;
+    var pageItems = filtered.slice(start, end);
+
+    allCards.forEach(function(c) { c.style.display = 'none'; });
+    pageItems.forEach(function(c) { c.style.display = ''; });
+
+    if (total === 0) {
+      matchCount.textContent = '0';
+      noResults.style.display = allCards.length > 0 ? 'block' : 'none';
+    } else {
+      matchCount.textContent = (start + 1) + '-' + Math.min(end, total) + ' / ' + total;
+      noResults.style.display = 'none';
+    }
+
+    paginationEl.innerHTML = '';
+    if (totalPages <= 1) return;
+
+    function addBtn(label, page, disabled, active) {
+      var btn = document.createElement('button');
+      btn.className = 'page-btn' + (active ? ' active' : '') + (disabled ? ' disabled' : '');
+      btn.textContent = label;
+      if (!disabled && !active) {
+        btn.addEventListener('click', function() {
+          currentPage = page;
+          renderPage();
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+      }
+      paginationEl.appendChild(btn);
+    }
+
+    addBtn('\u00AB', 1, currentPage === 1, false);
+    addBtn('\u2039', currentPage - 1, currentPage === 1, false);
+    var pages = [];
+    for (var i = 1; i <= totalPages; i++) {
+      if (i === 1 || i === totalPages || (i >= currentPage - 1 && i <= currentPage + 1)) {
+        pages.push(i);
+      } else if (pages[pages.length - 1] !== '...') {
+        pages.push('...');
+      }
+    }
+    pages.forEach(function(p) {
+      if (p === '...') {
+        var span = document.createElement('span');
+        span.className = 'page-info';
+        span.textContent = '...';
+        paginationEl.appendChild(span);
+      } else {
+        addBtn(String(p), p, false, p === currentPage);
+      }
+    });
+    addBtn('\u203A', currentPage + 1, currentPage === totalPages, false);
+    addBtn('\u00BB', totalPages, currentPage === totalPages, false);
+  }
+
+  input.addEventListener('input', function() { currentPage = 1; applyFilter(); });
+  applyFilter();
+})();
+</script>
+<!-- ▲ 検索・フィルタ・ページネーション JavaScript ここまで -->
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,10 @@ p  { color:#6c757d; font-size:.88rem; margin-bottom:32px; }
       <div class="org-label">アーキテクチャ図ギャラリー →</div>
     </a>
 
+    <a href="./drawio/index.html" class="card" style="border:2px solid #8b5cf6;">
+      <div class="org-name">draw.io ダイアグラム</div>
+      <div class="org-label">ER図・フロー・シーケンス図 →</div>
+    </a>
     <a href="./daily-digest/index.html" class="card" style="border:2px solid #198754;">
       <div class="org-name">日次ダイジェスト</div>
       <div class="org-label">技術・小売ニュース巡回 →</div>

--- a/plugins/cc-sier/skills/company-drawio/SKILL.md
+++ b/plugins/cc-sier/skills/company-drawio/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: company-drawio
+description: >
+  draw.io MCP Server を使用してアプリケーション構成図・ER図・フローチャート・
+  シーケンス図等の汎用ダイアグラムを生成する。
+  「ER図」「フローチャート」「シーケンス図」「業務フロー」「draw.io」
+  「ネットワーク図」「C4モデル」と言われたときに使用する。
+  ※ AWS構成図は /company-diagram を使用すること。
+---
+
+# draw.io ダイアグラム生成 Skill
+
+draw.io MCP Server（`@drawio/mcp`）を使い、
+汎用ダイアグラムを生成して GitHub Pages に公開する。
+
+---
+
+## 1. 起動
+
+1. `.companies/.active` から org-slug を取得
+2. `git config user.name` で operator を取得
+3. ユーザーの依頼から図の種類を判定
+
+## 2. AWS Diagram MCP との使い分け
+
+| 用途 | 使用Skill |
+|------|----------|
+| AWS構成図（AWSアイコン付き） | `/company-diagram` |
+| ER図・テーブル設計 | **本Skill（/company-drawio）** |
+| フローチャート・業務フロー | **本Skill** |
+| シーケンス図 | **本Skill** |
+| ネットワーク図（非AWS） | **本Skill** |
+| C4モデル・システム概要図 | **本Skill** |
+| 組織図・階層構造 | **本Skill** |
+
+## 3. draw.io MCP ツールの使い分け
+
+| ツール | 入力形式 | 推奨用途 |
+|--------|---------|---------|
+| `open_drawio_mermaid` | Mermaid記法 | フローチャート、シーケンス図、ER図、状態遷移図 |
+| `open_drawio_csv` | CSV | 組織図、ネットワークトポロジ、階層構造 |
+| `open_drawio_xml` | draw.io XML | 精密なレイアウトが必要な図、複雑なアーキテクチャ図 |
+
+**選択基準**:
+- シンプルなフロー・シーケンス図 → `open_drawio_mermaid`（最も簡潔）
+- 階層・ツリー構造 → `open_drawio_csv`（表形式でノード定義）
+- 精密な配置・スタイル制御 → `open_drawio_xml`（完全なレイアウト制御）
+
+## 4. ダイアグラム生成フロー
+
+### 4.1 ヒアリング（必要に応じて）
+
+```
+Q1: どんな図を作りますか？（ER図、フローチャート、シーケンス図等）
+Q2: 含めたい要素は？（テーブル名、処理ステップ、アクター等）
+Q3: 図の名前は？（英語kebab-case推奨）
+```
+
+### 4.2 ダイアグラム生成
+
+1. 依頼内容から最適なツール（mermaid/csv/xml）を選択
+2. ダイアグラムコンテンツを作成
+3. MCP ツールを呼び出し（ブラウザでdraw.ioエディタが開く）
+4. ソースコンテンツを `.drawio` ファイルとして保存
+
+### 4.3 ファイル配置
+
+```
+docs/drawio/
+├── index.html                        ← 一覧ページ（カードグリッド）
+├── {filename}.html                   ← 詳細ページ（draw.ioビューア埋め込み）
+├── {filename}.drawio                 ← draw.io XMLソース
+└── {filename}.png                    ← エクスポート画像（任意）
+
+.companies/{org-slug}/docs/drawio/
+└── {filename}.md                     ← ソースメタデータ・Mermaid/XMLコード
+```
+
+## 5. ページ構成
+
+### 5.1 一覧ページ（index.html）のカードテンプレート
+
+`<div class="grid">` 内に追記する:
+```html
+<a href="./{filename}.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">{アイコン}</div>
+    <div class="card-title">{図タイトル}</div>
+    <div class="card-meta">
+      <span class="tag tag-project">{案件名}</span>
+      <span class="tag tag-type">{図の種類}</span>
+    </div>
+    <div class="card-desc">{1行の説明}</div>
+    <div class="card-date">{YYYY-MM-DD}</div>
+  </div>
+</a>
+```
+
+件数表示（`<p class="count">` 内の右側の数字のみ）も更新する。
+左側の数字（`<span id="match-count">`）はJSが自動制御するため変更不要。
+
+**注意**: 一覧ページには検索・フィルタ・ページネーション機能が実装済み。
+カード追加時にこの範囲を編集・削除しないこと。カードは `<div class="grid">` 内にのみ追記する。
+
+### 5.2 詳細ページ（{filename}.html）の構成
+
+**以下のセクションは必須**:
+
+1. **draw.ioビューア** — iframe でdraw.io Viewerを埋め込み、インライン表示
+2. **概要** — 図の目的・対象システム・スコープ
+3. **構成要素** — テーブル形式（要素名 / 種類 / 説明）
+4. **設計のポイント** — 設計判断・トレードオフ（2〜4項目）
+
+共通要素:
+- ヘッダー: タイトル、タグ（案件名・図の種類）、生成日
+- 「draw.ioで編集」ボタン（エディタURLへのリンク）
+- 「一覧に戻る」リンク
+
+### 5.3 draw.io Viewer 埋め込み
+
+詳細ページにdraw.ioの図をインライン表示するには、以下のiframeを使用:
+
+```html
+<div class="diagram-container">
+  <iframe src="https://viewer.diagrams.net/?tags={}&highlight=0000ff&nav=1&title={filename}.drawio#R{URLエンコードされたXML}"
+          width="100%" height="500" frameborder="0" style="border-radius:8px;"></iframe>
+</div>
+```
+
+**注意**: XMLが大きい場合はURLが長くなるため、.drawioファイルへのリンクで代替する:
+```html
+<div class="diagram-container">
+  <a href="./{filename}.drawio" class="edit-btn" target="_blank">draw.io で開く</a>
+</div>
+```
+
+### 5.4 図の種類別アイコン
+
+カードに表示するアイコン（絵文字）:
+
+| 図の種類 | アイコン | tag-type色 |
+|---------|---------|-----------|
+| ER図 | 🗄️ | `#8b5cf6`（紫） |
+| フローチャート | 🔀 | `#3b82f6`（青） |
+| シーケンス図 | 🔄 | `#22c55e`（緑） |
+| ネットワーク図 | 🌐 | `#06b6d4`（シアン） |
+| 業務フロー | 📋 | `#f59e0b`（オレンジ） |
+| C4モデル | 🏗️ | `#ef4444`（赤） |
+| 組織図 | 👥 | `#6b7280`（グレー） |
+| その他 | 📊 | `#6b7280`（グレー） |
+
+## 6. タスクログと Issue 作成
+
+構成図の生成はファイル生成を伴う作業のため、必ずtask-logを記録する。
+
+### 6.1 タスクログ記録
+
+task-id: `YYYYMMDD-HHMMSS-drawio-{name}`
+
+### 6.2 Issue 作成
+
+タスク完了時に `gh issue create` で Issue を作成する。ラベル:
+- `org:{org-slug}`
+- `mode:direct`
+- `type:feat`
+- `dept:secretary`
+
+## 7. Git ワークフロー
+
+```
+1. ブランチ: {org-slug}/feat/{YYYY-MM-DD}-add-drawio-{name}
+2. git add docs/drawio/ .companies/{org-slug}/
+3. コミット: feat: draw.io図を追加（{name}）[{org-slug}] by {operator}
+4. PR作成 → URL報告
+5. main に戻る
+```
+
+## 8. GitHub Pages 連携
+
+- ダイアグラムは `docs/drawio/` に配置（GitHub Pages 公開対象）
+- トップページ `docs/index.html` に紫枠のカードで自動リンク
+- `/company-dashboard` 実行時も `generate-dashboard.sh` が `docs/drawio/index.html` を検出してカードを維持
+
+## 9. 前提条件
+
+| 項目 | 要件 |
+|------|------|
+| MCP Server | `drawio`（`@drawio/mcp`）が `.mcp.json` に設定済み |
+| Node.js | インストール済み |
+| npx | インストール済み |


### PR DESCRIPTION
## Summary
- draw.io MCP Server でER図・フローチャート・シーケンス図等を生成し GitHub Pages に公開する新Skill `/company-drawio` を追加
- ギャラリーページ（検索・フィルタ・ページネーション付き）を `docs/drawio/` に作成
- ポータルトップに紫枠カードを追加
- ダッシュボード再生成時にカードが上書きされない仕組みを `generate-dashboard.sh` に実装

## 作成ファイル
| ファイル | 内容 |
|---------|------|
| `.claude/skills/company-drawio/SKILL.md` | Skill定義（ツール使い分け・テンプレート・ワークフロー） |
| `plugins/cc-sier/skills/company-drawio/SKILL.md` | Plugin版 |
| `docs/drawio/index.html` | ギャラリーページ（0件の空状態対応済み） |
| `docs/index.html` | ポータルに紫枠カード追加 |
| `.claude/hooks/generate-dashboard.sh` | drawioカード自動検出を追加 |

## AWS Diagram MCP との使い分け
| 用途 | Skill |
|------|-------|
| AWS構成図（AWSアイコン） | `/company-diagram` |
| ER図・フロー・シーケンス図・C4等 | `/company-drawio` |

## ダッシュボード上書き防止
`generate-dashboard.sh` に `docs/drawio/index.html` の存在チェックを追加。
ダッシュボード再生成時も紫枠カードが自動で維持される。

## Test plan
- [ ] ポータルに紫枠の「draw.io ダイアグラム」カードが表示されること
- [ ] ギャラリーページの空状態メッセージが正しく表示されること
- [ ] `/company-dashboard` 実行後もdrawioカードが消えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)