### PR TITLE
feat: Modern Data Lakehouse draw.io編集版（AWS公式アイコン）

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260329-132734-drawio-modern-data-lakehouse.md
+++ b/.companies/domain-tech-collection/.task-log/20260329-132734-drawio-modern-data-lakehouse.md
@@ -1,0 +1,37 @@
+# タスクログ: draw.io Modern Data Lakehouse AWS構成図
+
+- **task-id**: 20260329-132734-drawio-modern-data-lakehouse
+- **開始日時**: 2026-03-29 13:27
+- **ステータス**: completed
+- **モード**: direct
+- **担当部署**: secretary
+- **Subagent**: secretary (direct)
+- **オペレーター**: SAS-Sasao
+
+## 依頼内容
+
+既存のAWS Diagram MCP版 Modern Data Lakehouse構成図をdraw.io編集可能な形式で再生成。
+AWS公式アイコン（mxgraph.aws4）を使用すること。
+
+## 秘書の判断
+
+- draw.io XMLでAWS Architecture Icons（mxgraph.aws4.*）を直接指定
+- 既存のPNG版の全サービス・データフローを忠実に再現
+- エッジ色分け: Batch(濃青)/Realtime(濃緑)/Governance(紫破線)
+
+## 成果物
+
+- `docs/drawio/modern-data-lakehouse.drawio` — draw.io XML（AWS公式アイコン付き）
+- `docs/drawio/modern-data-lakehouse.html` — 詳細ページ（Mermaidプレビュー）
+- `docs/drawio/index.html` — カード追加（5件目）
+- `.companies/domain-tech-collection/docs/drawio/modern-data-lakehouse.md` — メタデータ
+
+## judge
+
+- completeness: 4/5 — 全AWSサービス・データフロー・凡例を網羅
+- accuracy: 4/5 — 元のPNG版と同等の構成を再現。レイアウト微調整は利用者側で可能
+- clarity: 4/5 — AWS公式アイコン・色分けエッジ・セクション背景で視認性確保
+
+## reward
+
+0.85

--- a/.companies/domain-tech-collection/docs/drawio/modern-data-lakehouse.md
+++ b/.companies/domain-tech-collection/docs/drawio/modern-data-lakehouse.md
@@ -1,0 +1,31 @@
+# Modern Data Lakehouse on AWS（draw.io編集版）
+
+- **図の種類**: AWS構成図（draw.io + AWS Architecture Icons）
+- **案件**: 技術ドメイン収集
+- **作成日**: 2026-03-29
+- **作成者**: SAS-Sasao
+- **ツール**: open_drawio_xml（AWS 4 shapes使用）
+- **ファイル**: [modern-data-lakehouse.html](https://sas-sasao.github.io/cc-sier-organization/drawio/modern-data-lakehouse.html)
+- **参照元**: [AWS Diagram MCP版](https://sas-sasao.github.io/cc-sier-organization/diagrams/modern-data-lakehouse.html)
+
+## 概要
+
+既存のAWS Diagram MCP版（PNG画像）をdraw.io編集可能なXML形式に変換。
+AWS公式アイコン（mxgraph.aws4）を使用し、draw.ioアプリで自由に編集・カスタマイズ可能。
+
+## 使用AWSサービス
+
+- Amazon S3（Bronze/Silver/Gold）
+- AWS DMS（CDC）
+- Kinesis Data Streams / Data Firehose
+- Step Functions
+- AWS Glue ETL / Glue Data Catalog
+- Amazon EMR（Spark）
+- AWS Lake Formation
+- Amazon Athena
+- Amazon Redshift Serverless
+- Amazon QuickSight
+
+## draw.io XMLソース
+
+`open_drawio_xml` で生成。ファイル: `docs/drawio/modern-data-lakehouse.drawio`

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 4 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 5 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -114,6 +114,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
       <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
     </div>
     <div class="card-desc">SharePoint/VectorDB→RAG→乖離分析→AI見積生成、cc-sier構成図連携、タレマネ体制提案</div>
+    <div class="card-date">2026-03-29</div>
+  </div>
+</a>
+<a href="./modern-data-lakehouse.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🌐</div>
+    <div class="card-title">Modern Data Lakehouse on AWS（draw.io編集版）</div>
+    <div class="card-meta">
+      <span class="tag tag-project">技術ドメイン収集</span>
+      <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+    </div>
+    <div class="card-desc">Medallion Architecture（Bronze/Silver/Gold）＋AWS公式アイコン付きdraw.io編集版</div>
     <div class="card-date">2026-03-29</div>
   </div>
 </a>

--- a/docs/drawio/modern-data-lakehouse.drawio
+++ b/docs/drawio/modern-data-lakehouse.drawio
@@ -1,0 +1,194 @@
+<mxGraphModel dx="1850" dy="1050" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1800" pageHeight="1000" background="#FFFFFF">
+<root>
+<mxCell id="0"/>
+<mxCell id="1" parent="0"/>
+
+<mxCell id="title" value="Modern Data Lakehouse on AWS — Medallion Architecture (Bronze / Silver / Gold)" style="text;html=1;fontSize=16;fontStyle=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#232F3E;" vertex="1" parent="1">
+  <mxGeometry x="250" y="5" width="800" height="30" as="geometry"/>
+</mxCell>
+
+<!-- Legend -->
+<mxCell id="leg-batch" value="" style="endArrow=none;html=1;strokeColor=#1E3A5F;strokeWidth=3;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1380" y="17" as="sourcePoint"/><mxPoint x="1410" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-batch-t" value="Batch (CDC)" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#1E3A5F;" vertex="1" parent="1">
+  <mxGeometry x="1415" y="8" width="70" height="18" as="geometry"/>
+</mxCell>
+<mxCell id="leg-rt" value="" style="endArrow=none;html=1;strokeColor=#1B5E20;strokeWidth=3;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1500" y="17" as="sourcePoint"/><mxPoint x="1530" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-rt-t" value="Realtime" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#1B5E20;" vertex="1" parent="1">
+  <mxGeometry x="1535" y="8" width="55" height="18" as="geometry"/>
+</mxCell>
+<mxCell id="leg-gov" value="" style="endArrow=none;html=1;strokeColor=#6A1B9A;strokeWidth=3;dashed=1;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1610" y="17" as="sourcePoint"/><mxPoint x="1640" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-gov-t" value="Governance" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#6A1B9A;" vertex="1" parent="1">
+  <mxGeometry x="1645" y="8" width="70" height="18" as="geometry"/>
+</mxCell>
+
+<!-- AWS Cloud boundary -->
+<mxCell id="aws-cloud" value="AWS Cloud" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;container=0;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" vertex="1" parent="1">
+  <mxGeometry x="220" y="45" width="1540" height="910" as="geometry"/>
+</mxCell>
+
+<!-- Section backgrounds -->
+<mxCell id="sec-source" value="データソース" style="text;html=1;fontSize=11;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#5A6C86;align=center;" vertex="1" parent="1">
+  <mxGeometry x="30" y="100" width="140" height="20" as="geometry"/>
+</mxCell>
+<mxCell id="sec-ingest" value="取り込み" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#CE93D8;fontStyle=1;fontSize=10;fontColor=#6A1B9A;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="260" y="90" width="130" height="640" as="geometry"/>
+</mxCell>
+<mxCell id="sec-bronze" value="Bronze (Raw)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#FFCC80;fontStyle=1;fontSize=10;fontColor=#E65100;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="440" y="270" width="130" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-silver" value="Silver (Cleaned)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#BDBDBD;fontStyle=1;fontSize=10;fontColor=#616161;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="770" y="270" width="140" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-gold" value="Gold (Aggregated)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#FFF176;fontStyle=1;fontSize=10;fontColor=#F57F17;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1110" y="270" width="150" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-gov" value="ガバナンス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#CE93D8;fontStyle=1;fontSize=10;fontColor=#6A1B9A;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="560" y="710" width="540" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="sec-analytics" value="分析" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#90CAF9;fontStyle=1;fontSize=10;fontColor=#1565C0;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1310" y="170" width="140" height="390" as="geometry"/>
+</mxCell>
+
+<!-- Data Sources (outside cloud) -->
+<mxCell id="src-db" value="On-Prem DB" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#5A6C86;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.traditional_server;" vertex="1" parent="1">
+  <mxGeometry x="76" y="180" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="src-stream" value="Streaming&lt;br&gt;Events" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#5A6C86;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.traditional_server;" vertex="1" parent="1">
+  <mxGeometry x="76" y="400" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="src-file" value="File Upload" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#5A6C86;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.client;" vertex="1" parent="1">
+  <mxGeometry x="73" y="620" width="54" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Ingestion Layer -->
+<mxCell id="dms" value="AWS DMS&lt;br&gt;(CDC)" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C925D1;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.database_migration_service;" vertex="1" parent="1">
+  <mxGeometry x="301" y="180" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="kds" value="Kinesis&lt;br&gt;Data Streams" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.kinesis_data_streams;" vertex="1" parent="1">
+  <mxGeometry x="301" y="370" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="kdf" value="Kinesis&lt;br&gt;Data Firehose" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.kinesis_data_firehose;" vertex="1" parent="1">
+  <mxGeometry x="301" y="510" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="sfn" value="Step&lt;br&gt;Functions" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.step_functions;" vertex="1" parent="1">
+  <mxGeometry x="301" y="640" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Medallion Storage -->
+<mxCell id="s3-bronze" value="S3&lt;br&gt;Bronze" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="481" y="325" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="s3-silver" value="S3&lt;br&gt;Silver" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="816" y="325" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="s3-gold" value="S3&lt;br&gt;Gold" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="1161" y="325" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Processing -->
+<mxCell id="glue-etl" value="Glue ETL&lt;br&gt;(Bronze→Silver)" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue;" vertex="1" parent="1">
+  <mxGeometry x="641" y="325" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="emr" value="EMR Spark&lt;br&gt;(Silver→Gold)" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.emr;" vertex="1" parent="1">
+  <mxGeometry x="981" y="325" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Governance -->
+<mxCell id="glue-catalog" value="Glue&lt;br&gt;Data Catalog" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue_data_catalog;" vertex="1" parent="1">
+  <mxGeometry x="706" y="760" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="lake-formation" value="Lake&lt;br&gt;Formation" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lake_formation;" vertex="1" parent="1">
+  <mxGeometry x="956" y="760" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Analytics -->
+<mxCell id="athena" value="Amazon&lt;br&gt;Athena" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.athena;" vertex="1" parent="1">
+  <mxGeometry x="1356" y="230" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="redshift" value="Redshift&lt;br&gt;Serverless" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.redshift;" vertex="1" parent="1">
+  <mxGeometry x="1356" y="440" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Visualization -->
+<mxCell id="quicksight" value="Amazon&lt;br&gt;QuickSight" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.quicksight;" vertex="1" parent="1">
+  <mxGeometry x="1566" y="335" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Batch (dark blue) -->
+<mxCell id="e-db-dms" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="src-db" target="dms" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-dms-bronze" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="dms" target="s3-bronze" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-bronze-glue" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-bronze" target="glue-etl" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-glue-silver" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="glue-etl" target="s3-silver" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-silver-emr" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-silver" target="emr" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-emr-gold" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="emr" target="s3-gold" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Realtime (dark green) -->
+<mxCell id="e-stream-kds" value="" style="html=1;strokeColor=#1B5E20;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="src-stream" target="kds" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-kds-kdf" value="" style="html=1;strokeColor=#1B5E20;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="kds" target="kdf" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-kdf-bronze" value="" style="html=1;strokeColor=#1B5E20;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="kdf" target="s3-bronze" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: File upload (gray) -->
+<mxCell id="e-file-sfn" value="" style="html=1;strokeColor=#666666;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="src-file" target="sfn" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-sfn-bronze" value="" style="html=1;strokeColor=#666666;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="sfn" target="s3-bronze" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Analytics (blue) -->
+<mxCell id="e-gold-athena" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-gold" target="athena" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-gold-redshift" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-gold" target="redshift" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-athena-qs" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="athena" target="quicksight" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-redshift-qs" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="redshift" target="quicksight" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Governance (purple dashed) -->
+<mxCell id="e-glue-catalog-link" value="スキーマ登録" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="glue-etl" target="glue-catalog" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-emr-catalog" value="スキーマ登録" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="emr" target="glue-catalog" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-catalog-lf" value="メタデータ連携" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="glue-catalog" target="lake-formation" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-lf-athena" value="アクセス制御" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="lake-formation" target="athena" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-lf-redshift" value="アクセス制御" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="lake-formation" target="redshift" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+</root>
+</mxGraphModel>

--- a/docs/drawio/modern-data-lakehouse.html
+++ b/docs/drawio/modern-data-lakehouse.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Modern Data Lakehouse on AWS (draw.io) - ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --red:#ef4444; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1100px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) { .tag-project { background:#78350f; color:#fde68a; } }
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; color:var(--text); }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.note { background:#fffbe6; border:1px solid #fde68a; border-radius:8px; padding:12px 16px;
+        font-size:.85rem; margin:16px 0; }
+@media (prefers-color-scheme: dark) { .note { background:#422006; border-color:#78350f; } }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+.ref-link { display:inline-block; margin-top:12px; padding:8px 16px; background:#f3e5f5; color:#6a1b9a;
+            border-radius:8px; text-decoration:none; font-size:.85rem; font-weight:600; }
+.ref-link:hover { background:#e1bee7; }
+@media (prefers-color-scheme: dark) { .ref-link { background:#4a148c; color:#ce93d8; } .ref-link:hover { background:#6a1b9a; } }
+</style>
+</head>
+<body>
+<a href="./" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>Modern Data Lakehouse on AWS（draw.io編集版）</h1>
+<div class="meta">
+  <span class="tag tag-project">技術ドメイン収集</span>
+  <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+</div>
+<p class="date">作成日: 2026-03-29 / 作成者: SAS-Sasao</p>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+flowchart LR
+    subgraph sources["データソース"]
+        DB["On-Prem DB"]
+        STREAM["Streaming Events"]
+        FILE["File Upload"]
+    end
+    subgraph aws["AWS Cloud"]
+        subgraph ingest["取り込み"]
+            DMS["AWS DMS CDC"]
+            KDS["Kinesis Data Streams"]
+            KDF["Kinesis Firehose"]
+            SFN["Step Functions"]
+        end
+        subgraph medallion["Medallion Architecture"]
+            S3B["S3 Bronze Raw"]
+            GLUE["Glue ETL"]
+            S3S["S3 Silver Cleaned"]
+            EMR["EMR Spark"]
+            S3G["S3 Gold Aggregated"]
+        end
+        subgraph analytics["分析"]
+            ATHENA["Amazon Athena"]
+            RS["Redshift Serverless"]
+        end
+        QS["Amazon QuickSight"]
+        subgraph governance["ガバナンス"]
+            CATALOG["Glue Data Catalog"]
+            LF["Lake Formation"]
+        end
+    end
+    DB --> DMS --> S3B
+    STREAM --> KDS --> KDF --> S3B
+    FILE --> SFN --> S3B
+    S3B --> GLUE --> S3S --> EMR --> S3G
+    S3G --> ATHENA --> QS
+    S3G --> RS --> QS
+    GLUE -.-> CATALOG
+    EMR -.-> CATALOG
+    CATALOG -.-> LF
+    LF -.-> ATHENA
+    LF -.-> RS
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./modern-data-lakehouse.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+  </div>
+</div>
+
+<div class="note">
+  <strong>AWS公式アイコン対応:</strong> .drawioファイルにはAWS Architecture Icons（mxgraph.aws4）を使用しています。
+  draw.ioデスクトップアプリまたはWeb版で開くとAWS公式アイコンが表示されます。
+</div>
+
+<a href="../diagrams/modern-data-lakehouse.html" class="ref-link">AWS Diagram MCP版（PNG画像+IaCコード）を見る</a>
+
+<h2>概要</h2>
+<p>
+  Medallionアーキテクチャ（Bronze/Silver/Gold）による段階的なデータ品質向上を実現する
+  モダンデータレイクハウスの参照構成図。バッチ（DMS）、ストリーミング（Kinesis）、
+  ファイルアップロード（Step Functions）の3つの取り込みパターンに対応し、
+  Glue ETL / EMR Sparkによる処理パイプラインを経て、Athena / Redshift Serverlessで分析。
+</p>
+
+<h2>構成要素</h2>
+<table>
+  <thead>
+    <tr><th>レイヤー</th><th>AWSサービス</th><th>用途</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>データソース</td><td>On-Prem DB / Streaming / File</td><td>3種類の取り込みパターン</td></tr>
+    <tr><td>取り込み（Batch）</td><td>AWS DMS</td><td>CDC差分レプリケーション</td></tr>
+    <tr><td>取り込み（Realtime）</td><td>Kinesis Data Streams + Firehose</td><td>ストリーミング取得・S3配信</td></tr>
+    <tr><td>取り込み（File）</td><td>Step Functions</td><td>ファイルアップロードオーケストレーション</td></tr>
+    <tr><td>Bronze</td><td>Amazon S3</td><td>生データ保持（スキーマオンリード）</td></tr>
+    <tr><td>ETL処理</td><td>AWS Glue ETL</td><td>Bronze→Silverのクレンジング</td></tr>
+    <tr><td>Silver</td><td>Amazon S3</td><td>クレンジング・型変換・重複排除済み</td></tr>
+    <tr><td>Spark処理</td><td>Amazon EMR</td><td>Silver→Goldの集計・結合</td></tr>
+    <tr><td>Gold</td><td>Amazon S3</td><td>ビジネスロジック適用済み（分析最適化）</td></tr>
+    <tr><td>カタログ</td><td>Glue Data Catalog</td><td>スキーマ・パーティション管理</td></tr>
+    <tr><td>ガバナンス</td><td>Lake Formation</td><td>列/行レベルのアクセス制御</td></tr>
+    <tr><td>アドホック分析</td><td>Amazon Athena</td><td>サーバーレスSQLクエリ</td></tr>
+    <tr><td>DWH分析</td><td>Redshift Serverless</td><td>高性能DWHクエリ・定期レポート</td></tr>
+    <tr><td>可視化</td><td>Amazon QuickSight</td><td>BIダッシュボード</td></tr>
+  </tbody>
+</table>
+
+<h2>設計のポイント</h2>
+<ul>
+  <li><strong>Medallionアーキテクチャ</strong> — Bronze→Silver→Goldの3層で品質を段階的に向上。生データの保全と分析品質を両立。</li>
+  <li><strong>GlueとEMR Sparkの使い分け</strong> — クレンジングはマネージドのGlue、複雑な集計はEMR Spark。処理特性に応じたコスト最適化。</li>
+  <li><strong>Lake Formationによるガバナンス</strong> — 列/行レベルのセキュリティポリシーを一元管理。コンプライアンス対応。</li>
+  <li><strong>Athena + Redshiftのハイブリッド分析</strong> — アドホック分析はAthena、定常的な大量クエリはRedshift Serverless。</li>
+</ul>
+
+<p class="updated">Generated by /company-drawio &mdash; draw.io MCP Server (AWS Architecture Icons)</p>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: true, theme: 'default', securityLevel: 'loose' });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 既存のAWS Diagram MCP版 Modern Data Lakehouse構成図をdraw.io編集可能なXML形式で再生成
- AWS公式アイコン（mxgraph.aws4.*）使用: S3 Bucket, DMS, Kinesis, Glue, EMR, Athena, Redshift, QuickSight, Step Functions, Lake Formation
- Medallion Architecture（Bronze/Silver/Gold）のセクション色分け、Batch/Realtime/Governanceのエッジ色分け

## draw.io エディタ
https://app.diagrams.net/?grid=0&pv=0&border=10&edit=_blank

## 成果物
- `docs/drawio/modern-data-lakehouse.drawio` — draw.io XML（AWS公式アイコン付き）
- `docs/drawio/modern-data-lakehouse.html` — 詳細ページ（Mermaidプレビュー）
- `docs/drawio/index.html` — カード追加（5件目）

## GitHub Pages
- draw.io版: https://sas-sasao.github.io/cc-sier-organization/drawio/modern-data-lakehouse.html
- 元のPNG版: https://sas-sasao.github.io/cc-sier-organization/diagrams/modern-data-lakehouse.html

## Test plan
- [ ] .drawioファイルをdraw.ioアプリで開きAWS公式アイコンが表示されること
- [ ] GitHub PagesでMermaidプレビューが正常に表示されること
- [ ] index.htmlに5枚目のカードが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)