### PR TITLE
docs: 活動レポート 2026-03-29 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.case-bank/index.json
+++ b/.companies/domain-tech-collection/.case-bank/index.json
@@ -1,7 +1,7 @@
 {
   "org_slug": "domain-tech-collection",
-  "updated_at": "2026-03-29T12:07:04",
-  "case_count": 39,
+  "updated_at": "2026-03-29T13:40:34",
+  "case_count": 41,
   "failure_patterns": [
     {
       "subagent": "general",
@@ -1353,6 +1353,66 @@
       "outcome": {
         "files_written": [],
         "started": "2026-03-29T11:45:00"
+      }
+    },
+    {
+      "id": "20260329-125754-drawio-proposal-automation-c4",
+      "state": {
+        "request_keywords": [
+          "SIer提案書自動化ツールのC4モデル",
+          "L1",
+          "System",
+          "Context",
+          "L2",
+          "Container",
+          "L3",
+          "Component"
+        ],
+        "request_head": "SIer提案書自動化ツールのC4モデル（L1 System Context / L2 Container / L3 Co",
+        "org_slug": "domain-tech-collection"
+      },
+      "action": {
+        "subagent": "",
+        "mode": "",
+        "artifact_count": 1
+      },
+      "reward": null,
+      "judge": null,
+      "outcome": {
+        "files_written": [
+          ".companies/domain-tech-collection/docs/drawio/proposal-automation-c4.md"
+        ],
+        "started": ""
+      }
+    },
+    {
+      "id": "20260329-132734-drawio-modern-data-lakehouse",
+      "state": {
+        "request_keywords": [
+          "既存のAWS",
+          "Diagram",
+          "MCP版",
+          "Modern",
+          "Data",
+          "Lakehouse構成図をdraw.io編集可能な形式で再生成",
+          "AWS公式アイコン",
+          "mxgraph.aws4"
+        ],
+        "request_head": "既存のAWS Diagram MCP版 Modern Data Lakehouse構成図をdraw.io編集可能な形式で",
+        "org_slug": "domain-tech-collection"
+      },
+      "action": {
+        "subagent": "",
+        "mode": "",
+        "artifact_count": 1
+      },
+      "reward": null,
+      "judge": null,
+      "outcome": {
+        "files_written": [
+          ".companies/domain-tech-collection/docs/drawio/modern-data-lakehouse.md"
+        ],
+        "started": ""
       }
     }
   ],

--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-29-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-29-today.md
@@ -1,0 +1,129 @@
+# domain-tech-collection 活動レポート — 本日 (2026-03-29)
+
+> 生成日時: 2026-03-29 22:30 | 生成者: SAS-Sasao | 期間: 2026-03-29
+
+## エグゼクティブサマリー
+
+本日は **draw.io MCP Server の導入とSkill化（/company-drawio）** を軸に、大規模なダイアグラム生成基盤の構築を完了した。draw.io MCPの追加から始まり、Skill定義、ギャラリーページ、XMLダウンロード機能、エッジ貫通レビュースクリプトまでを一気通貫で整備。その基盤を活用し、コンビニ店舗作業フロー・エンタープライズデータアーキテクチャ・人材データ統合C4モデル・SIer提案書自動化ツールC4モデル・Modern Data Lakehouse draw.io版の5つのダイアグラムを生成した。また日次ダイジェストのフォーマット統一（テーブル形式・テーマ別分類）も実施し、品質ゲートに明文化した。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 5 回 |
+| コミット数 | 40 件 |
+| 作成・編集ファイル数 | 45 件 |
+| 完了タスク数 | 9 件 |
+| 進行中タスク数 | 0 件 |
+| 新規オープンIssue数 | 5 件 |
+| クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+| # | モード | リクエスト概要 | 主な成果物 |
+|---|--------|---------------|-----------|
+| 1 | agent-teams | 日次ダイジェスト巡回 | `docs/daily-digest/2026-03-29.md` |
+| 2 | direct | drawio MCP Server追加 | `.mcp.json`, `masters/mcp-services.md` |
+| 3 | direct | draw.io Skill化（/company-drawio） | `SKILL.md`, `docs/drawio/index.html`, `docs/index.html` |
+| 4 | direct | コンビニ店舗スタッフ1日の作業フロー | `docs/drawio/cvs-daily-workflow.md`, `.html`, `.drawio` |
+| 5 | direct | エンタープライズデータアーキテクチャ（MDM中心） | `docs/drawio/enterprise-data-arch.md`, `.drawio` |
+| 6 | direct | C4モデル 人材・パートナーデータ統合 | `docs/drawio/talent-data-arch.md`, `.drawio` |
+| 7 | direct | AWS構成図 人材データ統合（IaCコード付き） | `docs/diagrams/talent-data-arch-aws.md`, `.yaml` |
+| 8 | direct | SIer提案書自動化ツールC4（L1/L2/L3） | `docs/drawio/proposal-automation-c4.md`, `.drawio` |
+| 9 | direct | Modern Data Lakehouse draw.io版（AWS公式アイコン） | `docs/drawio/modern-data-lakehouse.md`, `.drawio` |
+
+## 進行中タスク
+
+なし
+
+## 作成・更新された成果物
+
+### draw.io ダイアグラム（新規5件）
+- `docs/drawio/cvs-daily-workflow.md` — コンビニ店舗スタッフ1日の作業フロー
+- `docs/drawio/enterprise-data-arch.md` — エンタープライズデータアーキテクチャ（MDM中心）
+- `docs/drawio/talent-data-arch.md` — C4モデル 人材・パートナーデータ統合
+- `docs/drawio/proposal-automation-c4.md` — SIer提案書自動化ツールC4
+- `docs/drawio/modern-data-lakehouse.md` — Modern Data Lakehouse AWS公式アイコン版
+
+### AWS構成図（新規1件）
+- `docs/diagrams/talent-data-arch-aws.md` — 人材データ統合アーキテクチャAWS実装版
+
+### 日次ダイジェスト
+- `docs/daily-digest/2026-03-29.md` — フォーマットをテーブル形式・テーマ別分類に統一
+
+### Skill・基盤整備
+- `/company-drawio` Skill新規作成（SKILL.md + references/review-drawio.js）
+- draw.ioギャラリーページ（`docs/drawio/index.html`）— 検索・フィルタ・ページネーション付き
+- ポータルサイトにdraw.ioカード追加（`docs/index.html`）
+- エッジ貫通レビュースクリプト（`review-drawio.js`）
+- 日次ダイジェストフォーマットテンプレートを品質ゲートに明文化
+- READMEにダイアグラムSkill使い分けガイドを追加
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- #145 日次ダイジェスト 2026-03-29
+- #149 コンビニ店舗スタッフの1日の作業フロー（draw.io業務フロー）
+- #151 エンタープライズデータアーキテクチャ図（MDM中心）
+- #155 draw.io C4モデル 人材・パートナーデータ統合アーキテクチャ
+- #157 AWS構成図 人材データ統合アーキテクチャ（C4→AWS実装）
+
+### クローズされたIssue（本日）
+なし
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション c2c7c424**（18発言）
+  - README.mdにポータルサイトの説明追記
+  - ダイアグラム生成時の凡例フィールド追加要望
+  - AI駆動開発ナレッジプラットフォームのアーキテクチャ図作成依頼
+  - ダイアグラム一覧ページにメタデータ検索・ページネーション機能追加
+  - 日次ダイジェスト巡回作業
+  - ダイジェストフォーマットの3/27・3/28との統一指示
+  - drawio MCP Server追加
+  - draw.io MCP動作確認
+  - draw.io MCPを使用したSKILL化（/company-drawio）の設計・実装依頼
+
+- **セッション cec6af75**（38発言）
+  - /company-drawio有効化の確認・修正
+  - コンビニ店舗スタッフ1日の作業フロー作成（ドメイン知識参照）
+  - PR本文にdraw.ioエディタURLを記載するルール追加
+  - draw.io詳細ページのプレビュー方式検討（Mermaid.js + draw.io編集ボタン）
+  - Mermaidプレビューの文字化け修正（絵文字・\n禁止ルール確立）
+  - エンタープライズデータアーキテクチャ（MDM中心）作成
+  - XMLダウンロード機能の追加・draw.io編集ボタン削除
+  - エッジ貫通レビュースクリプトの設計・実装
+  - MDMエッジ貫通7件の手動修正
+  - エッジ設計方針の確立（層間は直線、層内のみorthogonal）
+
+- **セッション 6a58f9d8**（9発言）
+  - C4モデル 人材・パートナーデータ統合アーキテクチャ作成
+  - C4モデルのAWSサービス具体化版作成
+  - /company-drawioのREADME・ガイド追加
+
+- **セッション 97de67af**（16発言）
+  - SIer提案書自動化ツールのC4モデル（L1/L2/L3）作成
+  - Modern Data LakehouseのAWS公式アイコン付きdraw.io版作成
+
+- **セッション 2218aa52**（6発言）
+  - /company-diagramと/company-drawioの連携可能性調査
+  - AWS構成図をdraw.ioで編集可能にする方式検討（案A+C: SVG+CSV方式）
+  - READMEにダイアグラムSkill使い分けガイド追加
+
+### ファイル生成を伴わなかったやり取り
+- /company-diagramにXMLダウンロード機能を追加する技術的実現可能性の調査・壁打ち（案A+C方式の深掘り）
+- draw.io詳細ページのプレビュー方式の比較検討（SVGプレビュー vs Mermaid.js vs draw.io編集）
+
+## 次のアクション候補
+
+1. **draw.ioエッジ貫通の自動修正強化** — 現在はレビュースクリプトで検出のみ。自動修正（waypoint再配置）の実装が望まれる（根拠: cec6af75セッションでの手動修正の手間）
+2. **/company-diagramへのSVG+CSV方式の実装** — AWS構成図の人間編集可能化。案A+Cの方針が確認済み（根拠: 2218aa52セッションでの調査結果）
+3. **オープンIssueの棚卸し** — #145〜#157の5件が本日オープン。クローズ条件の確認と対応（根拠: 本日クローズ0件）
+4. **draw.ioギャラリーの充実** — 現在5件。既存のAWS構成図（serverless-web-app, data-fabric等）のdraw.io版追加でポートフォリオ拡充
+5. **ストコンAWS移行案件の知識収集再開** — 本日はdraw.io基盤構築に集中。WBS上の調査タスクへの復帰
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-29 の活動レポートを生成
- 5セッション / 9完了タスク / 40コミット / 45ファイル変更
- draw.io MCP導入・Skill化・ダイアグラム5件生成が本日の主軸

## 関連Issue
- #162

## Test plan
- [ ] レポートファイルの内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)