### PR TITLE
feat: draw.io Enterprise MDM & Data Insights（AWS公式アイコン版）

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260329-143000-drawio-enterprise-mdm-insights.md
+++ b/.companies/domain-tech-collection/.task-log/20260329-143000-drawio-enterprise-mdm-insights.md
@@ -1,0 +1,26 @@
+# タスクログ: draw.io Enterprise MDM & Data Insights（AWS公式アイコン版）
+
+- **task-id**: 20260329-143000-drawio-enterprise-mdm-insights
+- **開始日時**: 2026-03-29 14:30
+- **ステータス**: completed
+- **モード**: direct
+- **担当部署**: secretary
+- **Subagent**: secretary (direct)
+- **オペレーター**: SAS-Sasao
+
+## 依頼内容
+
+既存のPython Diagrams版 enterprise-mdm-insights をdraw.io XML形式（AWS公式アイコン付き）で再作成。
+
+## 成果物
+
+- `docs/drawio/enterprise-mdm-insights.drawio` — draw.io XML（AWS公式アイコン付き）
+- `docs/drawio/enterprise-mdm-insights.html` — 詳細ページ（Mermaidプレビュー）
+- `docs/drawio/index.html` — カード追加（6件目）
+- `.companies/domain-tech-collection/docs/drawio/enterprise-mdm-insights.md` — メタデータ
+
+## judge
+
+- 品質: 4/5 — AWS公式アイコン20サービス、7層構成、エッジ貫通レビュー通過
+- 完成度: 4/5 — 元図の全コンポーネントを再現、draw.ioで編集可能
+- reward: 0.8

--- a/.companies/domain-tech-collection/docs/drawio/enterprise-mdm-insights.md
+++ b/.companies/domain-tech-collection/docs/drawio/enterprise-mdm-insights.md
@@ -1,0 +1,48 @@
+# Enterprise MDM & Data Insights Architecture（draw.io AWS公式アイコン版）
+
+## メタデータ
+
+| 項目 | 値 |
+|------|-----|
+| ファイル名 | enterprise-mdm-insights.drawio |
+| 図の種類 | C4モデル（AWS公式アイコン付き） |
+| ツール | open_drawio_xml |
+| 作成日 | 2026-03-29 |
+| 作成者 | SAS-Sasao |
+| 元図 | [Python Diagrams版](../../docs/diagrams/enterprise-mdm-insights.html) |
+
+## 概要
+
+Python Diagrams で生成した Enterprise MDM & Data Insights Architecture を、
+draw.io XML 形式（AWS公式アイコン付き）で再作成したもの。
+draw.io デスクトップアプリや Web 版で直接編集可能。
+
+## 構成（20サービス・7層）
+
+### データソース層
+- Salesforce CRM、SAP / Legacy DB
+
+### 取り込み層
+- Amazon AppFlow（SaaS API連携）
+- Amazon EventBridge（イベント駆動）
+- Kinesis Data Firehose（ストリーム配信）
+- AWS DMS（CDC差分レプリケーション）
+
+### ストレージ層（3ゾーン）
+- S3 Raw Zone → S3 Staged Zone → S3 Golden Zone (SSOT)
+
+### MDM処理層
+- AWS Entity Resolution（ファジーマッチング名寄せ）
+- Glue Data Quality（DQDLルール検証・品質ゲート）
+
+### 分析・可視化層
+- Amazon Redshift Serverless（DWH分析）
+- Amazon Athena（アドホックSQL）
+- Amazon QuickSight（BIダッシュボード）
+- Amazon Bedrock RAG（自然言語インサイト）
+
+### オーケストレーション
+- AWS Step Functions（パイプライン自動化）
+
+### ガバナンス層
+- Glue Data Catalog / Lake Formation / KMS / CloudWatch / CloudTrail

--- a/docs/drawio/enterprise-mdm-insights.drawio
+++ b/docs/drawio/enterprise-mdm-insights.drawio
@@ -1,0 +1,262 @@
+<mxGraphModel dx="1900" dy="1100" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1800" pageHeight="1050" background="#FFFFFF">
+<root>
+<mxCell id="0"/>
+<mxCell id="1" parent="0"/>
+
+<!-- Title -->
+<mxCell id="title" value="Enterprise MDM &amp; Data Insights Architecture" style="text;html=1;fontSize=16;fontStyle=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#232F3E;" vertex="1" parent="1">
+  <mxGeometry x="350" y="5" width="600" height="30" as="geometry"/>
+</mxCell>
+<mxCell id="subtitle" value="CRM/ERP 分散データを MDM で統合し、分析インサイトを提供" style="text;html=1;fontSize=10;fontStyle=2;align=center;fillColor=none;strokeColor=none;fontColor=#5A6C86;" vertex="1" parent="1">
+  <mxGeometry x="400" y="30" width="500" height="18" as="geometry"/>
+</mxCell>
+
+<!-- Legend -->
+<mxCell id="leg-ing" value="" style="endArrow=none;html=1;strokeColor=#1E3A5F;strokeWidth=3;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1340" y="17" as="sourcePoint"/><mxPoint x="1370" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-ing-t" value="Ingestion" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#1E3A5F;" vertex="1" parent="1">
+  <mxGeometry x="1375" y="8" width="60" height="18" as="geometry"/>
+</mxCell>
+<mxCell id="leg-mdm" value="" style="endArrow=none;html=1;strokeColor=#B7312C;strokeWidth=3;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1450" y="17" as="sourcePoint"/><mxPoint x="1480" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-mdm-t" value="MDM" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#B7312C;" vertex="1" parent="1">
+  <mxGeometry x="1485" y="8" width="40" height="18" as="geometry"/>
+</mxCell>
+<mxCell id="leg-ana" value="" style="endArrow=none;html=1;strokeColor=#1565C0;strokeWidth=3;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1540" y="17" as="sourcePoint"/><mxPoint x="1570" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-ana-t" value="Analytics" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#1565C0;" vertex="1" parent="1">
+  <mxGeometry x="1575" y="8" width="55" height="18" as="geometry"/>
+</mxCell>
+<mxCell id="leg-gov" value="" style="endArrow=none;html=1;strokeColor=#6A1B9A;strokeWidth=3;dashed=1;" edge="1" parent="1">
+  <mxGeometry relative="1" as="geometry"><mxPoint x="1645" y="17" as="sourcePoint"/><mxPoint x="1675" y="17" as="targetPoint"/></mxGeometry>
+</mxCell>
+<mxCell id="leg-gov-t" value="Governance" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#6A1B9A;" vertex="1" parent="1">
+  <mxGeometry x="1680" y="8" width="70" height="18" as="geometry"/>
+</mxCell>
+
+<!-- AWS Cloud boundary -->
+<mxCell id="aws-cloud" value="AWS Cloud" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;container=0;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" vertex="1" parent="1">
+  <mxGeometry x="210" y="55" width="1570" height="930" as="geometry"/>
+</mxCell>
+
+<!-- Section backgrounds -->
+<mxCell id="sec-ingest" value="取り込み" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#CE93D8;fontStyle=1;fontSize=10;fontColor=#6A1B9A;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="265" y="70" width="130" height="590" as="geometry"/>
+</mxCell>
+<mxCell id="sec-raw" value="Raw Zone" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#FFCC80;fontStyle=1;fontSize=10;fontColor=#E65100;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="440" y="280" width="120" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-staged" value="Staged Zone" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#BDBDBD;fontStyle=1;fontSize=10;fontColor=#616161;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="700" y="280" width="120" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-mdm" value="MDM" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#EF9A9A;fontStyle=1;fontSize=10;fontColor=#B71C1C;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="850" y="260" width="220" height="240" as="geometry"/>
+</mxCell>
+<mxCell id="sec-golden" value="Golden Zone (SSOT)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#FFF176;fontStyle=1;fontSize=10;fontColor=#F57F17;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1080" y="280" width="140" height="160" as="geometry"/>
+</mxCell>
+<mxCell id="sec-analytics" value="分析" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#90CAF9;fontStyle=1;fontSize=10;fontColor=#1565C0;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1250" y="170" width="140" height="380" as="geometry"/>
+</mxCell>
+<mxCell id="sec-vis" value="可視化" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#A5D6A7;fontStyle=1;fontSize=10;fontColor=#1B5E20;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1420" y="260" width="140" height="200" as="geometry"/>
+</mxCell>
+<mxCell id="sec-ai" value="生成AI" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E0F7FA;strokeColor=#80DEEA;fontStyle=1;fontSize=10;fontColor=#00695C;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="1120" y="530" width="130" height="190" as="geometry"/>
+</mxCell>
+<mxCell id="sec-gov" value="ガバナンス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#CE93D8;fontStyle=1;fontSize=10;fontColor=#6A1B9A;verticalAlign=top;arcSize=8;opacity=50;" vertex="1" parent="1">
+  <mxGeometry x="430" y="730" width="870" height="140" as="geometry"/>
+</mxCell>
+
+<!-- Data Sources (outside cloud) -->
+<mxCell id="sec-source" value="データソース" style="text;html=1;fontSize=11;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#5A6C86;align=center;" vertex="1" parent="1">
+  <mxGeometry x="30" y="105" width="140" height="20" as="geometry"/>
+</mxCell>
+<mxCell id="src-crm" value="Salesforce&lt;br&gt;CRM" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#5A6C86;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.traditional_server;" vertex="1" parent="1">
+  <mxGeometry x="76" y="200" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="src-erp" value="SAP /&lt;br&gt;Legacy DB" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#5A6C86;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.traditional_server;" vertex="1" parent="1">
+  <mxGeometry x="76" y="420" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Ingestion Layer -->
+<mxCell id="appflow" value="Amazon&lt;br&gt;AppFlow" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.appflow;" vertex="1" parent="1">
+  <mxGeometry x="301" y="130" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="eventbridge" value="Amazon&lt;br&gt;EventBridge" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.eventbridge;" vertex="1" parent="1">
+  <mxGeometry x="301" y="260" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="firehose" value="Kinesis&lt;br&gt;Data Firehose" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.kinesis_data_firehose;" vertex="1" parent="1">
+  <mxGeometry x="301" y="390" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="dms" value="AWS DMS&lt;br&gt;(CDC)" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C925D1;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.database_migration_service;" vertex="1" parent="1">
+  <mxGeometry x="301" y="530" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Storage: Raw Zone -->
+<mxCell id="s3-raw" value="S3&lt;br&gt;Raw Zone" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="476" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Processing: Glue ETL -->
+<mxCell id="glue-etl" value="AWS Glue&lt;br&gt;ETL" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue;" vertex="1" parent="1">
+  <mxGeometry x="591" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Storage: Staged Zone -->
+<mxCell id="s3-staged" value="S3&lt;br&gt;Staged Zone" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="736" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- MDM Processing -->
+<mxCell id="ann-mdm1" value="ファジーマッチング" style="text;html=1;fontSize=8;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#B71C1C;align=center;" vertex="1" parent="1">
+  <mxGeometry x="858" y="310" width="90" height="16" as="geometry"/>
+</mxCell>
+<mxCell id="entity-res" value="AWS Entity&lt;br&gt;Resolution" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.entity_resolution;" vertex="1" parent="1">
+  <mxGeometry x="880" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="ann-mdm2" value="DQDL品質ゲート" style="text;html=1;fontSize=8;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#B71C1C;align=center;" vertex="1" parent="1">
+  <mxGeometry x="978" y="310" width="90" height="16" as="geometry"/>
+</mxCell>
+<mxCell id="glue-dq" value="Glue Data&lt;br&gt;Quality" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue_data_quality;" vertex="1" parent="1">
+  <mxGeometry x="1000" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Storage: Golden Zone -->
+<mxCell id="s3-golden" value="S3&lt;br&gt;Golden Zone" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=1;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.bucket;" vertex="1" parent="1">
+  <mxGeometry x="1116" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Analytics -->
+<mxCell id="redshift" value="Redshift&lt;br&gt;Serverless" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.redshift;" vertex="1" parent="1">
+  <mxGeometry x="1296" y="240" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="athena" value="Amazon&lt;br&gt;Athena" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.athena;" vertex="1" parent="1">
+  <mxGeometry x="1296" y="440" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Visualization -->
+<mxCell id="quicksight" value="Amazon&lt;br&gt;QuickSight" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.quicksight;" vertex="1" parent="1">
+  <mxGeometry x="1466" y="340" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- AI -->
+<mxCell id="bedrock" value="Amazon&lt;br&gt;Bedrock (RAG)" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#01A88D;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.bedrock;" vertex="1" parent="1">
+  <mxGeometry x="1160" y="600" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Orchestration -->
+<mxCell id="ann-orch" value="オーケストレーション" style="text;html=1;fontSize=9;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#E7157B;align=center;" vertex="1" parent="1">
+  <mxGeometry x="530" y="580" width="120" height="16" as="geometry"/>
+</mxCell>
+<mxCell id="step-fn" value="Step&lt;br&gt;Functions" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.step_functions;" vertex="1" parent="1">
+  <mxGeometry x="580" y="600" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- Governance Layer -->
+<mxCell id="glue-catalog" value="Glue&lt;br&gt;Data Catalog" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue_data_catalog;" vertex="1" parent="1">
+  <mxGeometry x="520" y="790" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="lake-formation" value="Lake&lt;br&gt;Formation" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lake_formation;" vertex="1" parent="1">
+  <mxGeometry x="700" y="790" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="kms" value="AWS&lt;br&gt;KMS" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#DD344C;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.key_management_service;" vertex="1" parent="1">
+  <mxGeometry x="920" y="790" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="cloudwatch" value="Amazon&lt;br&gt;CloudWatch" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch;" vertex="1" parent="1">
+  <mxGeometry x="1100" y="790" width="48" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="cloudtrail" value="AWS&lt;br&gt;CloudTrail" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudtrail;" vertex="1" parent="1">
+  <mxGeometry x="1260" y="790" width="48" height="48" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Source to Ingestion (gray) -->
+<mxCell id="e-crm-af" value="" style="html=1;strokeColor=#5A6C86;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="src-crm" target="appflow" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-erp-dms" value="" style="html=1;strokeColor=#5A6C86;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="src-erp" target="dms" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Ingestion chain (dark blue) -->
+<mxCell id="e-af-eb" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="appflow" target="eventbridge" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-eb-fh" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="eventbridge" target="firehose" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-dms-raw" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="dms" target="s3-raw" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-fh-raw" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="firehose" target="s3-raw" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Processing (dark blue) -->
+<mxCell id="e-raw-etl" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-raw" target="glue-etl" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-etl-stg" value="" style="html=1;strokeColor=#1E3A5F;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="glue-etl" target="s3-staged" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: MDM flow (red) -->
+<mxCell id="e-stg-er" value="名寄せ" style="html=1;strokeColor=#B7312C;strokeWidth=2;endArrow=block;endFill=1;fontSize=9;fontColor=#B7312C;" edge="1" source="s3-staged" target="entity-res" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-er-dq" value="品質Gate" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#B7312C;strokeWidth=2;endArrow=block;endFill=1;fontSize=9;fontColor=#B7312C;" edge="1" source="entity-res" target="glue-dq" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-dq-gld" value="" style="html=1;strokeColor=#B7312C;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="glue-dq" target="s3-golden" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Analytics (blue) -->
+<mxCell id="e-gld-rs" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-golden" target="redshift" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-gld-ath" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="s3-golden" target="athena" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-rs-qs" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="redshift" target="quicksight" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-ath-qs" value="" style="html=1;strokeColor=#1565C0;strokeWidth=2;endArrow=block;endFill=1;" edge="1" source="athena" target="quicksight" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGE: Golden to Bedrock (exit bottom to avoid Athena) -->
+<mxCell id="e-gld-br" value="RAG" style="html=1;strokeColor=#01A88D;strokeWidth=2;endArrow=block;endFill=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=9;fontColor=#01A88D;" edge="1" source="s3-golden" target="bedrock" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Governance (purple dashed) -->
+<mxCell id="e-etl-cat" value="スキーマ登録" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="glue-etl" target="glue-catalog" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-er-cat" value="" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;" edge="1" source="entity-res" target="glue-catalog" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-cat-lf" value="メタデータ" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="glue-catalog" target="lake-formation" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-lf-ath" value="アクセス制御" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="lake-formation" target="athena" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-lf-rs" value="アクセス制御" style="html=1;strokeColor=#6A1B9A;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#6A1B9A;" edge="1" source="lake-formation" target="redshift" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<!-- EDGES: Orchestration (pink dashed) -->
+<mxCell id="e-sfn-etl" value="パイプライン制御" style="html=1;strokeColor=#E7157B;strokeWidth=2;endArrow=block;endFill=1;dashed=1;fontSize=9;fontColor=#E7157B;" edge="1" source="step-fn" target="glue-etl" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e-sfn-er" value="" style="html=1;strokeColor=#E7157B;strokeWidth=2;endArrow=block;endFill=1;dashed=1;" edge="1" source="step-fn" target="entity-res" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+</root>
+</mxGraphModel>

--- a/docs/drawio/enterprise-mdm-insights.html
+++ b/docs/drawio/enterprise-mdm-insights.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Enterprise MDM & Data Insights Architecture (draw.io) - ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --red:#ef4444; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1100px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) { .tag-project { background:#78350f; color:#fde68a; } }
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; color:var(--text); }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.note { background:#fffbe6; border:1px solid #fde68a; border-radius:8px; padding:12px 16px;
+        font-size:.85rem; margin:16px 0; }
+@media (prefers-color-scheme: dark) { .note { background:#422006; border-color:#78350f; } }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+.ref-link { display:inline-block; margin-top:12px; padding:8px 16px; background:#f3e5f5; color:#6a1b9a;
+            border-radius:8px; text-decoration:none; font-size:.85rem; font-weight:600; }
+.ref-link:hover { background:#e1bee7; }
+@media (prefers-color-scheme: dark) { .ref-link { background:#4a148c; color:#ce93d8; } .ref-link:hover { background:#6a1b9a; } }
+</style>
+</head>
+<body>
+<a href="./" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>Enterprise MDM & Data Insights Architecture（draw.io AWS公式アイコン版）</h1>
+<div class="meta">
+  <span class="tag tag-project">MDMアーキテクチャ</span>
+  <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+</div>
+<p class="date">作成日: 2026-03-29 / 作成者: SAS-Sasao</p>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+graph LR
+  subgraph SRC["データソース"]
+    CRM["Salesforce CRM"]
+    ERP["SAP / Legacy DB"]
+  end
+  subgraph ING["取り込み"]
+    AF["Amazon AppFlow"]
+    EB["Amazon EventBridge"]
+    FH["Kinesis Data Firehose"]
+    DMS["AWS DMS CDC"]
+  end
+  subgraph RAW["Raw Zone"]
+    S3R["S3 Raw Zone"]
+  end
+  subgraph PROC["処理"]
+    GETL["AWS Glue ETL"]
+  end
+  subgraph STG["Staged Zone"]
+    S3S["S3 Staged Zone"]
+  end
+  subgraph MDM["MDM"]
+    ER["Entity Resolution"]
+    DQ["Glue Data Quality"]
+  end
+  subgraph GLD["Golden Zone SSOT"]
+    S3G["S3 Golden Zone"]
+  end
+  subgraph ANA["分析"]
+    RS["Redshift Serverless"]
+    ATH["Amazon Athena"]
+  end
+  subgraph VIS["可視化"]
+    QS["Amazon QuickSight"]
+  end
+  subgraph AI["生成AI"]
+    BR["Amazon Bedrock RAG"]
+  end
+  CRM --> AF --> EB --> FH --> S3R
+  ERP --> DMS --> S3R
+  S3R --> GETL --> S3S
+  S3S --> ER --> DQ --> S3G
+  S3G --> RS --> QS
+  S3G --> ATH --> QS
+  S3G --> BR
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./enterprise-mdm-insights.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+  </div>
+</div>
+
+<div class="note">
+  Python Diagrams 版は <a href="../diagrams/enterprise-mdm-insights.html">こちら</a>。
+  本ページは draw.io XML 形式（AWS公式アイコン付き）の編集可能版です。
+</div>
+
+<h2>概要</h2>
+<p>分散エンタープライズシステム（CRM/ERP）のマスターデータ統合に特化したアーキテクチャ。
+AppFlow/DMS で取り込んだデータを Glue ETL でクレンジングし、Entity Resolution によるファジーマッチング名寄せと
+Glue Data Quality による品質ゲートを経て Golden Zone（Single Source of Truth）を構築。
+Redshift Serverless / Athena / QuickSight による分析インサイトと Bedrock RAG による自然言語インサイトを提供する。</p>
+
+<h2>構成要素</h2>
+<table>
+<tr><th>要素名</th><th>AWSサービス</th><th>レイヤー</th><th>説明</th></tr>
+<tr><td>SaaS連携</td><td>Amazon AppFlow</td><td>取り込み</td><td>Salesforce等のSaaS APIからデータ抽出</td></tr>
+<tr><td>イベント駆動</td><td>Amazon EventBridge</td><td>取り込み</td><td>データ到着イベントのルーティング</td></tr>
+<tr><td>ストリーム配信</td><td>Kinesis Data Firehose</td><td>取り込み</td><td>バッファリング付きS3配信</td></tr>
+<tr><td>CDC複製</td><td>AWS DMS</td><td>取り込み</td><td>SAP/レガシーDBの差分レプリケーション</td></tr>
+<tr><td>Raw Zone</td><td>Amazon S3</td><td>ストレージ</td><td>ソースデータ原本保持</td></tr>
+<tr><td>クレンジング</td><td>AWS Glue ETL</td><td>処理</td><td>データクレンジング・正規化</td></tr>
+<tr><td>Staged Zone</td><td>Amazon S3</td><td>ストレージ</td><td>クレンジング済みデータ</td></tr>
+<tr><td>名寄せ</td><td>AWS Entity Resolution</td><td>MDM</td><td>ファジーマッチングによるエンティティ統合</td></tr>
+<tr><td>品質ゲート</td><td>Glue Data Quality</td><td>MDM</td><td>DQDLルールによる品質検証</td></tr>
+<tr><td>Golden Zone</td><td>Amazon S3</td><td>ストレージ</td><td>統合済みマスターデータ（SSOT）</td></tr>
+<tr><td>DWH分析</td><td>Redshift Serverless</td><td>分析</td><td>高性能クエリ・レポート</td></tr>
+<tr><td>アドホック分析</td><td>Amazon Athena</td><td>分析</td><td>サーバーレスSQL分析</td></tr>
+<tr><td>BI可視化</td><td>Amazon QuickSight</td><td>可視化</td><td>ダッシュボード・レポート</td></tr>
+<tr><td>自然言語AI</td><td>Amazon Bedrock (RAG)</td><td>生成AI</td><td>ビジネスユーザー向け自然言語インサイト</td></tr>
+<tr><td>パイプライン制御</td><td>AWS Step Functions</td><td>オーケストレーション</td><td>取り込みからGolden Zoneまでの自動化</td></tr>
+<tr><td>メタデータ</td><td>Glue Data Catalog</td><td>ガバナンス</td><td>スキーマ管理・メタデータ統合</td></tr>
+<tr><td>アクセス制御</td><td>AWS Lake Formation</td><td>ガバナンス</td><td>列/行レベルのアクセス制御</td></tr>
+<tr><td>暗号化</td><td>AWS KMS</td><td>ガバナンス</td><td>全リソース暗号化キー管理</td></tr>
+<tr><td>監視</td><td>Amazon CloudWatch</td><td>ガバナンス</td><td>パイプライン監視・アラート</td></tr>
+<tr><td>監査</td><td>AWS CloudTrail</td><td>ガバナンス</td><td>API監査ログ</td></tr>
+</table>
+
+<h2>設計のポイント</h2>
+<ul>
+  <li><strong>Entity Resolution活用</strong> - 異なるシステム間のファジーマッチング名寄せにより、重複のないゴールデンレコードを構築</li>
+  <li><strong>Glue Data Quality ゲート</strong> - DQDLルール定義による品質検証を自動化。品質基準未達データはGolden Zoneに進まない</li>
+  <li><strong>3段階ゾーン構成</strong> - Raw/Staged/Golden の Medallion Architecture でデータ品質を段階的に向上</li>
+  <li><strong>Step Functions オーケストレーション</strong> - 取り込みから名寄せまで全フェーズをステートマシンで自動制御</li>
+  <li><strong>Bedrock RAG 統合</strong> - Golden Zone データをベクトル化し、ビジネスユーザーが自然言語でインサイトを取得可能</li>
+</ul>
+
+<p class="updated">Powered by draw.io MCP Server / AWS公式アイコン</p>
+
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: true, theme: 'neutral', securityLevel: 'loose' });
+</script>
+</body>
+</html>

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 5 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 6 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -126,6 +126,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
       <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
     </div>
     <div class="card-desc">Medallion Architecture（Bronze/Silver/Gold）＋AWS公式アイコン付きdraw.io編集版</div>
+    <div class="card-date">2026-03-29</div>
+  </div>
+</a>
+<a href="./enterprise-mdm-insights.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🏗️</div>
+    <div class="card-title">Enterprise MDM & Data Insights（AWS公式アイコン版）</div>
+    <div class="card-meta">
+      <span class="tag tag-project">MDMアーキテクチャ</span>
+      <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+    </div>
+    <div class="card-desc">CRM/ERP→AppFlow/DMS→Glue ETL→Entity Resolution→Golden Zone→Redshift/Athena/Bedrock RAG</div>
     <div class="card-date">2026-03-29</div>
   </div>
 </a>


### PR DESCRIPTION
## Summary
- Python Diagrams版 `enterprise-mdm-insights` を draw.io XML形式（AWS公式アイコン付き）で再作成
- 20のAWSサービス、7層構成（データソース→取り込み→Raw/Staged/Golden→分析→可視化/AI→ガバナンス）
- エッジ貫通レビュー通過（実ノード貫通0件）

## draw.io エディタ
https://app.diagrams.net/?grid=0&pv=0&border=10&edit=_blank

## 成果物
- `docs/drawio/enterprise-mdm-insights.drawio` — draw.io XML
- `docs/drawio/enterprise-mdm-insights.html` — 詳細ページ
- `docs/drawio/index.html` — カード追加（6件目）

## Test plan
- [ ] draw.io XMLをダウンロードしてエディタで開けること
- [ ] HTMLページのMermaidプレビューが正しくレンダリングされること
- [ ] 一覧ページに新しいカードが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)