### PR TITLE
feat: データドリブン意思決定基盤 UMLコンポーネント図

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260329-120000-drawio-data-driven-decision-arch.md
+++ b/.companies/domain-tech-collection/.task-log/20260329-120000-drawio-data-driven-decision-arch.md
@@ -1,0 +1,42 @@
+---
+task-id: 20260329-120000-drawio-data-driven-decision-arch
+org: domain-tech-collection
+mode: direct
+dept: secretary
+type: feat
+operator: SAS-Sasao
+subagent: none (direct orchestration)
+status: completed
+reward: 0.82
+judge_summary: "要件充足9/10, 図品質8/10, UML準拠7/10, HTML品質9/10"
+created: 2026-03-29
+---
+
+# draw.io図生成: データドリブン意思決定基盤 UMLコンポーネント図
+
+## 依頼内容
+
+UML方式で、ERP・CRM・SKILL_HUB・SharePoint・Redmineから情報を収集し、
+MDM・データレイク・DWHで蓄積、BIツール・AI/MLで分析して
+経営者・PM・管理職、マーケティング部、営業部がデータドリブンな意思決定を行える仕組みの図を作成。
+
+## 実施内容
+
+1. draw.io XMLで5層UMLコンポーネント図を設計（open_drawio_xml使用）
+2. 層間エッジは直線、層内エッジはorthogonalEdgeStyleで貫通回避
+3. レビュースクリプト通過確認
+4. HTML詳細ページ（Mermaid.jsプレビュー＋draw.ioダウンロード）
+5. index.html にカード追加
+6. ソースメタデータ .md 作成
+
+## 成果物
+
+- `docs/drawio/data-driven-decision-arch.drawio` - draw.io XMLソース
+- `docs/drawio/data-driven-decision-arch.html` - 詳細ページ
+- `.companies/domain-tech-collection/docs/drawio/data-driven-decision-arch.md` - メタデータ
+
+## SKILL_HUBの特記事項
+
+- 社内マスタデータ管理WebApp
+- SmartHR連携（社員情報同期）、Backlog連携（PJ管理統合）
+- RDB（リレーショナル）+ VectorDB（生成AI用）の2ストア構成

--- a/.companies/domain-tech-collection/docs/drawio/data-driven-decision-arch.md
+++ b/.companies/domain-tech-collection/docs/drawio/data-driven-decision-arch.md
@@ -1,0 +1,36 @@
+---
+title: データドリブン意思決定基盤 UMLコンポーネント図
+type: C4モデル
+project: データ基盤
+created: 2026-03-29
+author: SAS-Sasao
+tool: open_drawio_xml
+---
+
+# データドリブン意思決定基盤 UMLコンポーネント図
+
+## 概要
+
+ERP・CRM・SKILL_HUB・SharePoint・Redmineから情報を収集し、
+MDM・データレイク・DWHで蓄積、BI・AI/MLで分析して
+経営者・マーケティング・営業がデータドリブンな意思決定を行う5層アーキテクチャ。
+
+## 構成
+
+| レイヤー | コンポーネント |
+|---------|-------------|
+| データソース | ERP, CRM, SKILL_HUB(WebApp/RDB+VectorDB/SmartHR+Backlog連携), SharePoint, Redmine |
+| データ収集・統合 | ETL/データ連携基盤 |
+| データ蓄積 | MDM, DWH, データレイク |
+| 分析・活用 | BIツール, AI/MLエンジン |
+| 利用者 | 経営者・PM・管理職, マーケティング部, 営業部 |
+
+## draw.io XML (open_drawio_xml)
+
+draw.io XML形式で生成。5層のswimlaneコンテナに各コンポーネントを配置。
+層間エッジは直線、層内エッジ（MDM→DWH、データレイク→DWH）はorthogonalEdgeStyle。
+
+## ファイル
+
+- HTML: [docs/drawio/data-driven-decision-arch.html](../../../docs/drawio/data-driven-decision-arch.html)
+- draw.io: [docs/drawio/data-driven-decision-arch.drawio](../../../docs/drawio/data-driven-decision-arch.drawio)

--- a/docs/drawio/data-driven-decision-arch.drawio
+++ b/docs/drawio/data-driven-decision-arch.drawio
@@ -1,0 +1,128 @@
+<mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="900">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+
+    <mxCell id="title" value="&lt;font style=&quot;font-size:16px&quot;&gt;&lt;b&gt;データドリブン意思決定基盤 &amp;mdash; UML コンポーネント図&lt;/b&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontSize=16;" vertex="1" parent="1">
+      <mxGeometry x="200" y="5" width="700" height="35" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="L1" value="&lt;b&gt;データソース&lt;/b&gt;" style="swimlane;startSize=28;fillColor=#dbeafe;strokeColor=#3b82f6;fontStyle=0;fontSize=13;rounded=1;arcSize=6;html=1;" vertex="1" parent="1">
+      <mxGeometry x="20" y="50" width="1060" height="170" as="geometry"/>
+    </mxCell>
+    <mxCell id="erp" value="&lt;b&gt;ERP&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;&amp;laquo;system&amp;raquo;&lt;br/&gt;会計・販売・在庫&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2563eb;fontColor=#ffffff;strokeColor=#1e40af;arcSize=15;" vertex="1" parent="L1">
+      <mxGeometry x="20" y="47" width="140" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="crm" value="&lt;b&gt;CRM&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;&amp;laquo;system&amp;raquo;&lt;br/&gt;顧客・商談管理&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2563eb;fontColor=#ffffff;strokeColor=#1e40af;arcSize=15;" vertex="1" parent="L1">
+      <mxGeometry x="215" y="47" width="140" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="skill" value="&lt;b&gt;SKILL_HUB&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;&amp;laquo;WebApp&amp;raquo; マスタデータ管理&lt;br/&gt;RDB + VectorDB（生成AI）&lt;br/&gt;SmartHR連携 / Backlog連携&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e40af;fontColor=#ffffff;strokeColor=#1e3a5f;arcSize=10;" vertex="1" parent="L1">
+      <mxGeometry x="411" y="35" width="240" height="95" as="geometry"/>
+    </mxCell>
+    <mxCell id="sp" value="&lt;b&gt;SharePoint&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;&amp;laquo;system&amp;raquo;&lt;br/&gt;ドキュメント管理&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2563eb;fontColor=#ffffff;strokeColor=#1e40af;arcSize=15;" vertex="1" parent="L1">
+      <mxGeometry x="705" y="47" width="140" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="rm" value="&lt;b&gt;Redmine&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;&amp;laquo;system&amp;raquo;&lt;br/&gt;チケット管理&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2563eb;fontColor=#ffffff;strokeColor=#1e40af;arcSize=15;" vertex="1" parent="L1">
+      <mxGeometry x="900" y="47" width="140" height="65" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="L2" value="&lt;b&gt;データ収集・統合&lt;/b&gt;" style="swimlane;startSize=28;fillColor=#fef3c7;strokeColor=#f59e0b;fontStyle=0;fontSize=13;rounded=1;arcSize=6;html=1;" vertex="1" parent="1">
+      <mxGeometry x="20" y="250" width="1060" height="90" as="geometry"/>
+    </mxCell>
+    <mxCell id="etl" value="&lt;b&gt;ETL / データ連携基盤&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f59e0b;fontColor=#ffffff;strokeColor=#d97706;arcSize=30;" vertex="1" parent="L2">
+      <mxGeometry x="150" y="35" width="760" height="35" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="L3" value="&lt;b&gt;データ蓄積&lt;/b&gt;" style="swimlane;startSize=28;fillColor=#dcfce7;strokeColor=#22c55e;fontStyle=0;fontSize=13;rounded=1;arcSize=6;html=1;" vertex="1" parent="1">
+      <mxGeometry x="20" y="370" width="1060" height="120" as="geometry"/>
+    </mxCell>
+    <mxCell id="mdm" value="&lt;b&gt;MDM&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;マスタデータ管理&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#16a34a;fontColor=#ffffff;strokeColor=#15803d;arcSize=15;" vertex="1" parent="L3">
+      <mxGeometry x="70" y="40" width="200" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="dwh" value="&lt;b&gt;DWH&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;データウェアハウス&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#16a34a;fontColor=#ffffff;strokeColor=#15803d;arcSize=15;" vertex="1" parent="L3">
+      <mxGeometry x="380" y="40" width="200" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="dl" value="&lt;b&gt;データレイク&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;Raw / 非構造化データ&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#16a34a;fontColor=#ffffff;strokeColor=#15803d;arcSize=15;" vertex="1" parent="L3">
+      <mxGeometry x="720" y="40" width="200" height="55" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="L4" value="&lt;b&gt;分析・活用&lt;/b&gt;" style="swimlane;startSize=28;fillColor=#ede9fe;strokeColor=#8b5cf6;fontStyle=0;fontSize=13;rounded=1;arcSize=6;html=1;" vertex="1" parent="1">
+      <mxGeometry x="20" y="520" width="1060" height="120" as="geometry"/>
+    </mxCell>
+    <mxCell id="bi" value="&lt;b&gt;BIツール&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;ダッシュボード・レポート&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#7c3aed;fontColor=#ffffff;strokeColor=#6d28d9;arcSize=15;" vertex="1" parent="L4">
+      <mxGeometry x="140" y="40" width="250" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="aiml" value="&lt;b&gt;AI / ML エンジン&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;予測分析・自然言語処理&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#7c3aed;fontColor=#ffffff;strokeColor=#6d28d9;arcSize=15;" vertex="1" parent="L4">
+      <mxGeometry x="570" y="40" width="250" height="55" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="L5" value="&lt;b&gt;利用者（データドリブン意思決定）&lt;/b&gt;" style="swimlane;startSize=28;fillColor=#ffedd5;strokeColor=#f97316;fontStyle=0;fontSize=13;rounded=1;arcSize=6;html=1;" vertex="1" parent="1">
+      <mxGeometry x="20" y="670" width="1060" height="120" as="geometry"/>
+    </mxCell>
+    <mxCell id="exec" value="&lt;b&gt;経営者・PM・管理職&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;KPI・戦略立案&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ea580c;fontColor=#ffffff;strokeColor=#c2410c;arcSize=15;" vertex="1" parent="L5">
+      <mxGeometry x="70" y="40" width="230" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="mkt" value="&lt;b&gt;マーケティング部&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;顧客分析・施策最適化&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ea580c;fontColor=#ffffff;strokeColor=#c2410c;arcSize=15;" vertex="1" parent="L5">
+      <mxGeometry x="390" y="40" width="200" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="sales" value="&lt;b&gt;営業部&lt;/b&gt;&lt;hr size=&quot;1&quot;/&gt;&lt;font style=&quot;font-size:10px&quot;&gt;リードスコアリング・予測&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ea580c;fontColor=#ffffff;strokeColor=#c2410c;arcSize=15;" vertex="1" parent="L5">
+      <mxGeometry x="720" y="40" width="200" height="55" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="e1" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="erp" target="etl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e2" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="crm" target="etl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e3" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="skill" target="etl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e4" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="sp" target="etl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e5" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="rm" target="etl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="e6" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="etl" target="mdm" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e7" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="etl" target="dwh" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e8" style="strokeColor=#64748b;endArrow=block;endFill=1;" edge="1" source="etl" target="dl" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="e9" value="マスタ" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#15803d;fontColor=#15803d;fontSize=9;endArrow=block;endFill=1;" edge="1" source="mdm" target="dwh" parent="L3">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e10" value="ETL" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#15803d;fontColor=#15803d;fontSize=9;endArrow=block;endFill=1;" edge="1" source="dl" target="dwh" parent="L3">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="e11" value="構造化データ" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="dwh" target="bi" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e12" value="特徴量" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="dwh" target="aiml" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e13" value="非構造化データ" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="dl" target="aiml" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="e14" value="ダッシュボード" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="bi" target="exec" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e15" value="レポート" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="bi" target="mkt" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e16" value="顧客分析" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="aiml" target="mkt" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e17" value="予測・スコアリング" style="strokeColor=#64748b;fontColor=#64748b;fontSize=9;endArrow=block;endFill=1;" edge="1" source="aiml" target="sales" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>

--- a/docs/drawio/data-driven-decision-arch.html
+++ b/docs/drawio/data-driven-decision-arch.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>データドリブン意思決定基盤 UMLコンポーネント図 - draw.io ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --red:#ef4444; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1100px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) { .tag-project { background:#78350f; color:#fde68a; } }
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; color:var(--text); }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.note { background:#fffbe6; border:1px solid #fde68a; border-radius:8px; padding:12px 16px;
+        font-size:.85rem; margin:16px 0; }
+@media (prefers-color-scheme: dark) { .note { background:#422006; border-color:#78350f; } }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+</style>
+</head>
+<body>
+<a href="./" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>データドリブン意思決定基盤 UML コンポーネント図</h1>
+<div class="meta">
+  <span class="tag tag-project">データ基盤</span>
+  <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+</div>
+<p class="date">作成日: 2026-03-29 / 作成者: SAS-Sasao</p>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+graph TD
+    subgraph SRC["データソース"]
+        ERP["ERP<br>会計・販売・在庫"]
+        CRM["CRM<br>顧客・商談管理"]
+        SKILL["SKILL_HUB<br>マスタデータ管理 WebApp<br>RDB+VectorDB 生成AI<br>SmartHR/Backlog連携"]
+        SP["SharePoint<br>ドキュメント管理"]
+        RM["Redmine<br>チケット管理"]
+    end
+    subgraph INT["データ収集・統合"]
+        ETL["ETL / データ連携基盤"]
+    end
+    subgraph STR["データ蓄積"]
+        MDM["MDM<br>マスタデータ管理"]
+        DWH["DWH<br>データウェアハウス"]
+        DL["データレイク<br>Raw/非構造化データ"]
+    end
+    subgraph ANA["分析・活用"]
+        BI["BIツール<br>ダッシュボード・レポート"]
+        AI["AI/MLエンジン<br>予測分析・NLP"]
+    end
+    subgraph USR["利用者 データドリブン意思決定"]
+        EXEC["経営者・PM・管理職<br>KPI・戦略立案"]
+        MKT["マーケティング部<br>顧客分析・施策最適化"]
+        SALES["営業部<br>リードスコアリング"]
+    end
+    ERP --> ETL
+    CRM --> ETL
+    SKILL --> ETL
+    SP --> ETL
+    RM --> ETL
+    ETL --> MDM
+    ETL --> DWH
+    ETL --> DL
+    MDM -->|マスタ| DWH
+    DL -->|ETL| DWH
+    DWH -->|構造化データ| BI
+    DWH -->|特徴量| AI
+    DL -->|非構造化データ| AI
+    BI -->|ダッシュボード| EXEC
+    BI -->|レポート| MKT
+    AI -->|顧客分析| MKT
+    AI -->|予測・スコアリング| SALES
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./data-driven-decision-arch.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+  </div>
+</div>
+
+<h2>概要</h2>
+<p>
+  社内の複数システム（ERP、CRM、SKILL_HUB、SharePoint、Redmine）から情報を収集し、
+  ETL/データ連携基盤を経由してMDM・データレイク・DWHへ蓄積。
+  BIツールとAI/MLエンジンで分析し、経営者・PM・管理職、マーケティング部、営業部が
+  データドリブンな意思決定を行える仕組みを5層のUMLコンポーネント図として表現。
+</p>
+
+<div class="note">
+  <strong>SKILL_HUB について:</strong>
+  社内のマスタデータ管理Webアプリケーション。SmartHRと連携して社員情報を同期し、
+  Backlogと連携してプロジェクト管理情報を統合。リレーショナルDB（マスタ管理）と
+  VectorDB（生成AI用途）の2種類のデータストアを使用。
+</div>
+
+<h2>構成要素</h2>
+<table>
+  <thead>
+    <tr><th>レイヤー</th><th>要素</th><th>種別</th><th>説明</th></tr>
+  </thead>
+  <tbody>
+    <tr><td rowspan="5">データソース</td><td>ERP</td><td>External System</td><td>会計・販売・在庫データの提供元</td></tr>
+    <tr><td>CRM</td><td>External System</td><td>顧客情報・商談データの提供元</td></tr>
+    <tr><td>SKILL_HUB</td><td>WebApp</td><td>マスタデータ管理（RDB+VectorDB）、SmartHR/Backlog連携</td></tr>
+    <tr><td>SharePoint</td><td>External System</td><td>ドキュメント・ナレッジの提供元</td></tr>
+    <tr><td>Redmine</td><td>External System</td><td>チケット・プロジェクト情報の提供元</td></tr>
+    <tr><td>データ収集・統合</td><td>ETL/データ連携基盤</td><td>Integration</td><td>各ソースからの抽出・変換・ロード処理</td></tr>
+    <tr><td rowspan="3">データ蓄積</td><td>MDM</td><td>Master Data Mgmt</td><td>マスタデータの品質管理・ゴールデンレコード生成</td></tr>
+    <tr><td>DWH</td><td>Data Warehouse</td><td>構造化データの集約・分析用モデル</td></tr>
+    <tr><td>データレイク</td><td>Data Lake</td><td>Raw/非構造化データの一元保管</td></tr>
+    <tr><td rowspan="2">分析・活用</td><td>BIツール</td><td>BI Platform</td><td>ダッシュボード・定型レポートの生成</td></tr>
+    <tr><td>AI/MLエンジン</td><td>AI/ML</td><td>予測分析・自然言語処理・リードスコアリング</td></tr>
+    <tr><td rowspan="3">利用者</td><td>経営者・PM・管理職</td><td>Person</td><td>KPIモニタリング・戦略立案</td></tr>
+    <tr><td>マーケティング部</td><td>Person</td><td>顧客分析・施策最適化</td></tr>
+    <tr><td>営業部</td><td>Person</td><td>リードスコアリング・売上予測</td></tr>
+  </tbody>
+</table>
+
+<h2>設計のポイント</h2>
+<ul>
+  <li><strong>5層アーキテクチャ</strong> --- データソース→収集・統合→蓄積→分析→利用者の5層構成。各層の責務を明確に分離し、コンポーネント単位での入れ替え・拡張を容易にする。</li>
+  <li><strong>MDMによるマスタデータ品質担保</strong> --- 複数ソースからの重複・不整合をMDMで統合し、ゴールデンレコードをDWHへ供給。データドリブン意思決定の品質基盤となる。</li>
+  <li><strong>データレイク＋DWHのハイブリッド蓄積</strong> --- 構造化データはDWHで分析最適化、非構造化データ（ドキュメント・チケット）はデータレイクに保管しAI/MLで活用。VectorDBとの連携で生成AI対応も可能。</li>
+  <li><strong>SKILL_HUBの中核的位置づけ</strong> --- SmartHR（社員情報）とBacklog（PJ管理）を統合するWebApp。RDBでマスタ管理、VectorDBで生成AIナレッジ検索を実現する社内データハブ。</li>
+</ul>
+
+<p class="updated">Generated by /company-drawio &mdash; draw.io MCP Server</p>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: true, theme: 'default', securityLevel: 'loose' });
+</script>
+</body>
+</html>

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 7 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 8 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -81,6 +81,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <!-- ▲ 検索・フィルタ ここまで -->
 
 <div class="grid">
+<a href="./data-driven-decision-arch.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🏗️</div>
+    <div class="card-title">データドリブン意思決定基盤 UMLコンポーネント図</div>
+    <div class="card-meta">
+      <span class="tag tag-project">データ基盤</span>
+      <span class="tag tag-type" style="background:#ef4444;">C4モデル</span>
+    </div>
+    <div class="card-desc">ERP/CRM/SKILL_HUB/SharePoint/Redmine→ETL→MDM/DWH/データレイク→BI/AI/ML→意思決定者</div>
+    <div class="card-date">2026-03-29</div>
+  </div>
+</a>
 <a href="./btob-sales-c4.html" class="card">
   <div class="card-body">
     <div class="card-icon">🏗️</div>


### PR DESCRIPTION
## Summary

- ERP/CRM/SKILL_HUB/SharePoint/Redmine → ETL → MDM/DWH/データレイク → BI/AI/ML → 利用者の5層UMLコンポーネント図を draw.io XML で作成
- SKILL_HUB の特徴（SmartHR連携・Backlog連携・RDB+VectorDB・生成AI対応）を図中に明記
- HTML詳細ページ（Mermaid.jsプレビュー＋draw.ioダウンロード）、index.htmlカード追加

## 成果物

| ファイル | 内容 |
|---------|------|
| `docs/drawio/data-driven-decision-arch.drawio` | draw.io XMLソース |
| `docs/drawio/data-driven-decision-arch.html` | 詳細ページ |
| `docs/drawio/index.html` | カード追加（8件目） |

## draw.io エディタ

https://app.diagrams.net/?grid=0&pv=0&border=10&edit=_blank#create=%7B%22type%22%3A%22xml%22%2C%22compressed%22%3Atrue%7D

## Test plan

- [ ] GitHub Pages で HTML詳細ページが正常表示されること
- [ ] Mermaid.js プレビューがレンダリングされること
- [ ] draw.io XML ダウンロードが機能すること
- [ ] index.html の検索・フィルタで新カードが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)