### PR TITLE
docs: 日次レポート 2026-03-30 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-03-30-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-03-30-today.md
@@ -1,0 +1,101 @@
+# domain-tech-collection 活動レポート — 2026-03-30（本日）
+
+> 生成日時: 2026-03-30T10:10:00 | 生成者: SAS-Sasao | 期間: 2026-03-30
+
+## エグゼクティブサマリー
+
+本日は3つの大きな成果を達成した。(1) 日次ニュースダイジェスト（技術36件+小売21件=57記事）をAgent Teamsのフォールバック運用で生成、(2) awslabs/agent-plugins（deploy-on-aws）からAWSサービス選定基準・コスト見積パターンを `/company-diagram` スキルに統合、(3) 既存の全12件のAWS構成図詳細ページにコスト概算セクション（Dev/Prod月額・USD+JPY両建て）を一括追加した。特にコスト概算の追加はSIer提案書作成時のコスト根拠として即座に活用可能な成果である。Agent Teamsの権限制約（SubagentのWebFetch不可）は既知課題として残存。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 1回（連続セッション、13スナップショット） |
+| ツール実行数（最終時点） | 169回 |
+| 作成・編集ファイル数 | 50+件 |
+| 完了タスク数 | 1件（タスクログ記録分） |
+| 新規オープンIssue数（本日） | 2件 (#174, #176) |
+| コミット数（本日 JST） | 7件 |
+
+## 完了タスク
+
+- **[agent-teams → secretary直接]** 日次ニュース巡回ダイジェスト 2026-03-30
+  - 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-03-30.md`
+  - Judge評価: completeness 4/5, accuracy 4/5, clarity 5/5（総合 4.3/5）
+  - reward: 0.85
+  - PR: #175（マージ済み）、Issue: #176
+
+## 進行中タスク
+
+なし（本日のタスクはすべて完了）
+
+## 作成・更新された成果物
+
+### 秘書室
+| ファイル | 種別 |
+|---------|------|
+| `docs/daily-digest/2026-03-30.md` | 日次ダイジェスト（技術36件+小売21件） |
+| `docs/daily-digest/index.html` | ダイジェストHTMLページ更新 |
+
+### プラグイン基盤（/company-diagram）
+| ファイル | 種別 |
+|---------|------|
+| `.claude/skills/company-diagram/references/aws-service-defaults.md` | 新規: AWSサービス選定基準 |
+| `.claude/skills/company-diagram/references/aws-cost-estimation.md` | 新規: コスト見積パターン |
+| `.claude/skills/company-diagram/SKILL.md` | 更新: コスト概算ステップ(3.4)追加 |
+
+### 構成図（docs/diagrams/）— コスト概算セクション追加
+| ファイル | コスト概算 |
+|---------|-----------|
+| `ai-dev-knowledge-platform.html` | Dev $97-247 / Prod $252-965 |
+| `data-driven-decision-platform.html` | Dev $228-449 / Prod $559-1,738 |
+| `data-fabric-architecture.html` | Dev $291-752 / Prod $802-2,590 |
+| `distributed-cqrs-architecture.html` | Dev $150-367 / Prod $492-1,275 |
+| `enterprise-mdm-insights.html` | Dev $190-380 / Prod $503-1,565 |
+| `modern-data-lakehouse.html` | Dev $213-491 / Prod $541-1,760 |
+| `modern-ml-pipeline.html` | Dev $176-498 / Prod $468-1,708 |
+| `serverless-web-app.html` | Dev $28-80 / Prod $86-351 |
+| `storcon-app-architecture.html` | Dev $166-275 / Prod $465-1,035 |
+| `storcon-cicd-pipeline.html` | Dev $85-158 / Prod $277-574 |
+| `storcon-dwh-architecture.html` | Dev $182-393 / Prod $443-1,260 |
+| `talent-data-arch-aws.html` | Dev $209-419 / Prod $569-1,350 |
+
+## Issue 動向
+
+### 新規オープン（本日）
+- #176 [domain-tech-collection] 日次ダイジェスト 2026-03-30
+- #174 [domain-tech-collection] インタラクションログ 2026-03-30
+
+### 関連Issue（interaction-log除外、本日以外）
+- #172 AWS構成図生成: Data-Driven Decision Platform on AWS
+- #170 draw.io図生成: データドリブン意思決定基盤 UMLコンポーネント図
+- #162 活動レポート 本日 (2026-03-29)
+
+## 会話トピック
+
+### セッション e7dea3ab（169ツール実行）
+
+主要な依頼内容:
+1. `/company` 起動 → domain-tech-collection で作業継続
+2. **ニュース巡回対応** → wf-daily-digest 実行、Agent Teams権限制約で秘書直接巡回
+3. **ダイジェストHTML生成** → `/company-digest-html` でGitHub Pages更新
+4. **awslabs/agent-plugins 調査** → deploy-on-aws 等6プラグインの評価
+5. **AWSサービス選定基準・コスト見積パターンの統合** → `/company-diagram` に references 2本追加
+6. **既存全構成図へのコスト概算一括追加** → 4並列エージェントで12件処理
+7. `/company-report` → 本レポート
+
+### ファイル生成を伴わなかったやり取り
+- awslabs/agent-plugins の調査・評価レポート（チャット回答のみ、成果物なし）
+- deploy-on-aws / migration-to-aws のストコン案件への適用可能性の議論
+
+## 次のアクション候補
+
+1. **Agent Teams WebFetch権限の解決**（根拠: 日次ダイジェストで毎回フォールバックが発生。tech-researcher / retail-domain-researcher にWebFetchを付与すべき）
+2. **awslabs/agent-plugins migration-to-aws の導入検討**（根拠: ストコンAWS移行案件（2026年6月〜）に直結。GCP→AWS移行の自動化が可能）
+3. **構成図コスト概算の定期更新フロー整備**（根拠: 為替レート変動・AWS価格改定時に概算値が陳腐化する。更新トリガーの仕組みが必要）
+4. **コスト概算を含むSIer提案書テンプレートの作成**（根拠: 本日追加したコスト概算データをクライアント向け提案書に転記するテンプレートがあると効率的）
+5. **sales-management-system のコスト概算フォーマット統一**（根拠: 既存のコストセクションが他12件と異なるフォーマット。USD+JPY両建てに統一すべき）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-03-30 の日次活動レポートを生成
- 日次ダイジェスト57記事 / awslabs/agent-plugins調査・統合 / 全12構成図へのコスト概算追加
- 7コミット / 169ツール実行 / 50+ファイル変更

## Test plan
- [ ] レポート内容が本日の活動と整合していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)