### PR TITLE
feat: 日次ダイジェスト 2026-04-01 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260401-001500-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260401-001500-daily-digest.md
@@ -1,0 +1,61 @@
+---
+task_id: "20260401-001500-daily-digest"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "agent-teams"
+started: "2026-04-01T00:15:00"
+completed: "2026-04-01T00:25:00"
+request: "日次ダイジェストの作成"
+issue_number: null
+pr_number: null
+---
+
+## 実行計画
+- **実行モード**: agent-teams（wf-daily-digest）
+- **アサインされたロール**: secretary（統合）, tech-researcher（技術巡回）, retail-domain-researcher（小売巡回）
+- **参照したマスタ**: workflows.md（wf-daily-digest）, info-source-master.md, quality-gates/by-type/daily-digest.md
+- **判断理由**: wf-daily-digestワークフローに一致。Agent Teams構成で技術系・小売系ソースを並列巡回。
+
+## エージェント作業ログ
+
+### [2026-04-01 00:15] secretary
+受付: 日次ダイジェスト作成依頼
+
+### [2026-04-01 00:15] secretary
+判断: agent-teams、wf-daily-digestに従い技術・小売の並列巡回
+
+### [2026-04-01 00:16] secretary → tech-researcher (general-purpose)
+委譲: 技術系ソース17件の巡回（優先度「高」5件 + 「中」12件）
+
+### [2026-04-01 00:16] secretary → retail-domain-researcher (general-purpose)
+委譲: 小売ドメイン系ソース13件の巡回（優先度「高」3件 + 「中」8件 + 業界団体2件）
+
+### [2026-04-01 00:19] retail-domain-researcher (general-purpose)
+完了: 小売系13ソース巡回完了（成功8/一部取得2/失敗3、総記事数55件）
+
+### [2026-04-01 00:20] tech-researcher (general-purpose)
+完了: 技術系17ソース巡回完了（成功9/一部取得4/失敗4、総記事数94件）。一部WebFetch応答待ちで停止したが主要ソース取得済み。
+
+### [2026-04-01 00:25] secretary
+成果物: .companies/domain-tech-collection/docs/daily-digest/2026-04-01.md
+
+### [2026-04-01 00:25] secretary
+完了: 統合ダイジェスト生成。技術41件+小売33件=74件を採用。品質ゲートチェック実施。
+
+## 成果物
+| ファイル | 作成者 | パス |
+|---------|--------|------|
+| 日次ダイジェスト 2026-04-01 | secretary | .companies/domain-tech-collection/docs/daily-digest/2026-04-01.md |
+
+## judge
+
+### 評価基準: completeness / accuracy / clarity
+
+| 軸 | スコア | 根拠 |
+|----|--------|------|
+| completeness | 4/5 | 優先度「高」ソースは全て巡回済み。Snowflake/Databricks/NRF等一部失敗あるが影響は限定的。月初の業界団体統計も確認済み。 |
+| accuracy | 4/5 | 全記事にソースURLを記載。WebFetchで実際に取得したURLのみ使用。一部ソースはWebSearch経由で間接取得。 |
+| clarity | 5/5 | 品質ゲートのフォーマットテンプレートに準拠。テーマ別分類・テーブル形式・C章パラグラフ形式を遵守。 |
+
+**総合**: 4.3/5 — 巡回網羅性は十分。JS動的レンダリング系サイト（Snowflake/Databricks/ロジスティクス・トゥデイ）の取得は構造的課題として残る。

--- a/.companies/domain-tech-collection/.task-log/20260401-001500-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260401-001500-daily-digest.md
@@ -7,8 +7,8 @@ mode: "agent-teams"
 started: "2026-04-01T00:15:00"
 completed: "2026-04-01T00:25:00"
 request: "日次ダイジェストの作成"
-issue_number: null
-pr_number: null
+issue_number: 188
+pr_number: 187
 ---
 
 ## 実行計画

--- a/.companies/domain-tech-collection/docs/daily-digest/2026-04-01.md
+++ b/.companies/domain-tech-collection/docs/daily-digest/2026-04-01.md
@@ -1,0 +1,224 @@
+# 日次ダイジェスト 2026-04-01
+
+> **組織**: ドメイン知識や技術スタック収集PJT (`domain-tech-collection`)
+> **生成方式**: Agent Teams（wf-daily-digest）
+> **巡回ソース数**: 30件（成功16件 / 一部取得4件 / 失敗10件）
+> **オペレーター**: SAS-Sasao
+
+---
+
+## 本日のハイライト
+
+1. **axiosがサプライチェーン攻撃の被害に — npmメンテナアカウント乗っ取りでマルウェア配布** — 3ソースが一斉報道。OSSサプライチェーンセキュリティの緊急課題（[Zenn](https://zenn.dev/gunta/articles/0152eadf05d173)、[Qiita](https://qiita.com/kawabe0201/items/b51cd76daa2fec5029f1)、[はてブ](https://blog.flatt.tech/entry/axios_compromise)）
+2. **Claude Codeソースコード流出 — npmソースマップに51万行が公開状態** — Anthropic製CLIツールのソースが意図せず公開された事件が話題に（[はてブ](https://ai-heartland.com/news/claude-code-source-leak/)、[Hacker News](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/)）
+3. **OpenAI、$852B評価額で資金調達を完了** — AI業界の巨額バリュエーション更新（[Hacker News](https://www.cnbc.com/2026/03/31/openai-funding-round-ipo.html)）
+4. **4月1日施行：改正物流効率化法・食料システム法** — 小売・食品業界に直接影響、事業者の8割が「対応は負担」と回答（[日本食糧新聞](https://news.nissyoku.co.jp/news/shinoda20260331112147443)、[ECのミカタ](https://ecnomikata.com/ecnews/50013/)）
+5. **しまむら EC売上51%増の196億円、TOKYO BASE EC売上23%増** — 脱クーポン・ストア統合でEC好調決算が相次ぐ（[ネットショップ担当者フォーラム](https://netshop.impress.co.jp/n/2026/04/01/15843)、[ネットショップ担当者フォーラム](https://netshop.impress.co.jp/n/2026/04/01/15842)）
+
+---
+
+## A章. 技術スタック
+
+### A1. AI駆動開発・エージェント
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Claude Codeで100個のSkillを育てた全記録](https://zenn.dev/takuyanagai0213/articles/claude-code-100-skills-full-record) | Zenn | 4ヶ月間のコンテキストエンジニアリング実践でSkillを100個育成した経験記録。 |
+| 2 | [完全自律のコーディングパイプラインを作った](https://zenn.dev/theaktky/articles/5f9f18c34950c1) | Zenn | AIを活用した完全自動化コード生成パイプラインの実装事例。 |
+| 3 | [自己進化する運用エージェントの設計と実装](https://zenn.dev/aws_japan/articles/self-evolving-ops-agent-multi-layer-memory) | Zenn | 3層メモリ構造でAIが自己改善するAIOpsシステムの設計概要。 |
+| 4 | [Claude Code Agent Teamsで複数AIが同時に動く — 導入から実践まで完全ガイド](https://qiita.com/nogataka/items/d18bd9ee62e72f24395d) | Qiita | 複数AIエージェントを連携させる実装ガイドと活用事例。 |
+| 5 | [100行のCLAUDE.mdより35行が効く理由 — 公式仕様で解く設定の最適化](https://qiita.com/nogataka/items/d6c83ea50b82e1c2602c) | Qiita | Claude使用時の効果的なプロンプト設定を公式仕様から分析。 |
+| 6 | [Claude Codeで「成長するAI秘書」を作ってみた](https://dev.classmethod.jp/articles/ai-secretary/) | DevelopersIO | Claude Codeとオーケストレーションを活用した事業企画業務自動化AI秘書の開発事例。 |
+| 7 | [Claude Code 開発者のための完全ガイド](https://zenn.dev/417/articles/c15af4f4106a9f) | はてブ | 会話管理・MCP機能・プランモードなど開発者向け実践的機能の網羅的解説。 |
+| 8 | [Architectural Governance at AI Speed](https://www.infoq.com/articles/architectural-governance-ai-speed/) | InfoQ | AI開発加速時代におけるアーキテクチャガバナンスの維持手法を論考。 |
+
+### A2. AI・ML・LLM
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Introducing Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | Anthropic | エージェンティックコーディング・コンピュータ操作・金融タスクで業界最高性能を達成。 |
+| 2 | [Introducing Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | Anthropic | コーディング・エージェント・プロフェッショナル業務でフロンティア性能を提供。 |
+| 3 | [Claude is a space to think](https://www.anthropic.com/news/claude-is-a-space-to-think) | Anthropic | Claudeを広告なしに保つ方針と、その理由を説明。 |
+| 4 | [Claude on Mars](https://www.anthropic.com/mars) | Anthropic | NASAのPerseveranceローバーで初のAI支援走行を実施、400メートルを走破。 |
+| 5 | [What 81,000 people want from AI](https://www.anthropic.com/81k-interviews) | Anthropic | 81,000人のClaude.aiユーザーへの大規模定性調査結果を公開。 |
+| 6 | [Show HN: 1-Bit Bonsai, the First Commercially Viable 1-Bit LLMs](https://prismml.com/) | Hacker News | 商用展開可能な超高効率1ビットLLMを発表。 |
+| 7 | [AIネイティブな時代への準備](https://qiita.com/jw-automation/items/c24b6e3d879176b27dff) | Qiita | ノーコード/ローコードがAI時代のボトルネックになる可能性を考察。 |
+| 8 | [Amazon Bedrock Flowsでレシピ提案システム](https://dev.classmethod.jp/articles/amazon-bedrock-flows-recipe-suggestion/) | DevelopersIO | 冷蔵庫の食材とスーパーチラシからレシピを提案するAIシステムの実装例。 |
+
+### A3. クラウド・インフラ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [AWS Security Agentのペネトレーションテスト機能がGA](https://dev.classmethod.jp/articles/aws-security-agent-ondemand-penetration/) | DevelopersIO | AWS Security Agentのオンデマンドペネトレーションテスト機能が一般提供開始。 |
+| 2 | [AWS DevOps Agentが一般提供に](https://dev.classmethod.jp/articles/aws-devops-agent-ga/) | DevelopersIO | DevOps自動化ツールであるAWS DevOps Agentの正式リリース。 |
+| 3 | [Cloud NATのTCP TIME_WAITタイムアウト変更](https://dev.classmethod.jp/articles/cloud-nat-tcp-timewait-timeout-default-changed/) | DevelopersIO | Google CloudのCloud NATでTCPタイムアウトが120秒から30秒に変更。 |
+| 4 | [AWS SCPをAzure Policyで再現](https://dev.classmethod.jp/articles/202603-azure-policy-deny-large-vm-sizes/) | DevelopersIO | AWSのService Control PolicyをAzure Policyで実装する方法。 |
+| 5 | [Workload Identity連携で複数GCPプロジェクトアクセス](https://dev.classmethod.jp/articles/workload-identity-federation-access-multiple-gcp-projects/) | DevelopersIO | Google CloudのWorkload Identity連携を活用した複数プロジェクト統一アクセス。 |
+| 6 | [実験して入門するKubernetes：Pod起動の裏側を追う](https://future-architect.github.io/articles/20260325a/) | フューチャー技術ブログ | KubernetesのPod生成の仕組みを実験を通じて解説。 |
+| 7 | [AWS Observability が Kiro Power として利用可能に](https://aws.amazon.com/jp/about-aws/whats-new/2026/02/aws-observability-kiro-power/) | AWS What's New | CloudWatchとApplication Signalsを統合し、AIエージェントがインフラ問題を迅速に調査可能に。 |
+| 8 | [Ministack — LocalStackの代替OSS](https://ministack.org/) | Hacker News | ローカルAWSサービスエミュレーションの新しいOSS代替ツール。 |
+
+### A4. データ基盤・DWH
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Modern Data Stack情報まとめ（2026年4月1日号）](https://dev.classmethod.jp/articles/modern-data-stack-info-summary-20260401/) | DevelopersIO | モダンデータスタック関連情報の月次集約レポート。 |
+| 2 | [dbt Labs + Fivetran: Open data infrastructure for analytics and AI](https://www.getdbt.com/blog/dbt-labs-and-fivetran-merge-announcement) | dbt Blog | dbt LabsとFivetranが統合し、オープンデータインフラストラクチャを形成。 |
+| 3 | [The era of open data infrastructure](https://www.getdbt.com/blog/dbt-labs-and-fivetran-product-vision) | dbt Blog | dbt×Fivetran統合がAI・Apache Iceberg時代の転換点となる戦略分析。 |
+| 4 | [Amazon CloudWatch Application Signalsの新機能](https://dev.classmethod.jp/articles/cloudwatch-application-signals-adds-slo-capabilities/) | DevelopersIO | CloudWatchアプリケーション監視にSLO・パフォーマンスレポート機能追加。 |
+| 5 | [Pythonで実装して理解する RDBパフォーマンスチューニング入門](https://qiita.com/take-yoda/items/ecc6e9b174b2e5e97406) | Qiita | フルスキャンとインデックスの仕組みをPythonで実装しながら学ぶ解説。 |
+
+### A5. 開発プラクティス・設計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Goにはなぜ例外がないのか](https://zenn.dev/tokium_dev/articles/2026-03-30-go-errors) | Zenn | Go言語の例外処理設計哲学とエラーハンドリングの特徴解析。 |
+| 2 | [BCE を意識して Go のコードを高速化する](https://zenn.dev/mattn/articles/5860d73d292f32) | Zenn | CPUキャッシュ効率を考慮したGo言語の最適化テクニック。 |
+| 3 | [ログ設計：基礎から応用まで](https://zenn.dev/sun_asterisk/articles/665f05f1b584dd) | Zenn | 基礎から応用まで網羅した実践的なログシステム設計ガイド。 |
+| 4 | [Event-Driven Patterns for Cloud-Native Banking](https://www.infoq.com/articles/event-driven-banking-architecture/) | InfoQ | 銀行システムにおけるイベント駆動アーキテクチャの利点と課題を実践パターンで解説。 |
+| 5 | [Spec Driven Development: When Architecture Becomes Executable](https://www.infoq.com/articles/spec-driven-development/) | InfoQ | アーキテクチャ仕様を実行可能にし、設計と実装のギャップを埋める手法。 |
+| 6 | [API GatewayとLambdaで実装するプライベートなMCPサーバー](https://future-architect.github.io/articles/20260324a/) | フューチャー技術ブログ | AWS上でLambda+APIGatewayによるカスタムMCPサーバー実装方法。 |
+
+### A6. セキュリティ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [【緊急】axios がサプライチェーン攻撃 2026.03.31](https://zenn.dev/gunta/articles/0152eadf05d173) | Zenn | npm人気HTTPライブラリaxiosがメンテナアカウント乗っ取りでマルウェア配布された緊急レポート。 |
+| 2 | [サプライチェーン攻撃から身を守るために最低限設定しておきたいこと](https://zenn.dev/dely_jp/articles/supply-chain-kowai) | Zenn | パッケージマネージャ設定で防げる攻撃対策方法を実務的に解説。 |
+| 3 | [axios ソフトウェアサプライチェーン攻撃の概要と対応指針](https://blog.flatt.tech/entry/axios_compromise) | はてブ | axios事件の技術的詳細分析と実践的な対応手順を専門家視点で解説。 |
+| 4 | [Claude Codeのソースコード流出 — npmソースマップに51万行が丸見え](https://ai-heartland.com/news/claude-code-source-leak/) | はてブ | Anthropicが自社CLIツールのソースコード51万行以上をnpmで誤公開した事件の解説。 |
+| 5 | [え、プルリクに広告？Copilotの広告自動挿入問題が大炎上](https://softantenna.com/blog/github-copilot-ads/) | はてブ | Copilotが150万件以上のPRに無断で広告文を挿入していた問題の批判と対応。 |
+| 6 | [情報処理技術者試験の見直し検討状況](https://www.ipa.go.jp/shiken/syllabus/henkou/2025/20260331.html) | はてブ | 「データマネジメント試験」新設などIPA国家試験の大規模見直し、AI時代の人材育成重視に転換。 |
+
+---
+
+## B章. 小売ドメイン
+
+### B1. 業態変革・新店
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [首都圏でも攻勢？PPIHの食品強化型新フォーマット「ロビン・フッド」の可能性](https://diamond-rm.net/management/businessplan/540599/) | ダイヤモンドCS | 中京エリアのピアゴリニューアル新業態が首都圏展開を視野に。 |
+| 2 | [東海地方の老舗有力スーパー・カネスエ、大型リブランディングの深謀](https://diamond-rm.net/management/businessplan/541168/) | ダイヤモンドCS | 名古屋の有力SMが大規模ブランド再構築を発表。 |
+| 3 | [2026年のショッピングセンター開業計画を分析 — ますます主流になるNSC](https://diamond-rm.net/management/businessplan/540604/) | ダイヤモンドCS | 近隣型SC開発の拡大トレンドを検証。 |
+| 4 | [カインズ／埼玉県に「八潮店」今秋オープン、八潮市に初出店](https://www.ryutsuu.biz/store/s033173.html) | 流通ニュース | カインズが埼玉県八潮市に新店舗を今秋開設予定。 |
+| 5 | [ケンタッキー／4月に神奈川・大阪・兵庫・岡山・沖縄で計7店舗を新規オープン](https://www.ryutsuu.biz/store/s033042.html) | 流通ニュース | ケンタッキーが4月に複数地域で7店舗を一括展開。 |
+| 6 | [日高屋、初の関東圏外店「新潟駅万代店」がオープン](https://news.nissyoku.co.jp/flash/1274291) | 日本食糧新聞 | 日高屋が初めて関東圏外に出店。 |
+
+### B2. 経営・人事戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [【DCS最新号】4月1日号は「小売業のES向上経営」](https://diamond-rm.net/store/540735/) | ダイヤモンドCS | 従業員満足度向上による経営改善特集号。 |
+| 2 | [イトーヨーカドー／イラン情勢踏まえ包材の削減を検討、買いだめは「短期間で終息」](https://www.ryutsuu.biz/strategy/s033143.html) | 流通ニュース | イトーヨーカドーがイラン情勢対応で包材削減検討。 |
+| 3 | [コンビニで4連続勝利、新商品のミンティア大復活 — ロッテが261億円の赤字から急速回復する秘訣](https://www.itmedia.co.jp/business/articles/2603/31/news012.html) | ITmedia | ロッテが新商品ミンティアで売上回復を実現。 |
+
+### B3. PB・商品戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [イトーヨーカドー／低価格PB「セブン・ザ・プライス」商品3割拡充、売上目標20％増](https://www.ryutsuu.biz/commodity/s033142.html) | 流通ニュース | 低価格帯PB約400アイテムに拡充し売上20%増を目指す。 |
+| 2 | [2年連続で過去最高売上を達成 ハーゲンダッツのマーケティング戦略に迫る](https://diamond-rm.net/management/527680/) | ダイヤモンドCS | プレミアムアイス市場で連続増収を達成した販売戦略を解析。 |
+| 3 | [つゆ市場、冷凍にヒットの兆し — 参入相次ぎ活性化へ](https://news.nissyoku.co.jp/news/yoshiokau20260331083417907) | 日本食糧新聞 | つゆ市場で冷凍タイプの開発が相次ぎ消費者需要拡大。 |
+| 4 | [顧客と「唯一無二の関係性」を築き、ファンコミュニティを「経営のエンジン」に！](https://diamond-rm.net/technology/dx/540477/) | ダイヤモンドCS | カインズが推進するCRM戦略とファンコミュニティ構築。 |
+
+### B4. EC・デジタル
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [しまむらの2026年2月期EC売上は196億円で51%増、オンラインストア統合で集客力向上](https://netshop.impress.co.jp/n/2026/04/01/15843) | ネットショップ担当者F | オンラインストア統合でEC売上51%増を達成。 |
+| 2 | [TOKYO BASEの2026年1月期は増収増益。EC売上は「クーポン」「割引き」やめて23%増](https://netshop.impress.co.jp/n/2026/04/01/15842) | ネットショップ担当者F | 割引施策廃止でEC売上23%増を実現。 |
+| 3 | [26か国・地域に広がる「BUYMA」の越境EC展開](https://netshop.impress.co.jp/e/2026/04/01/15803) | ネットショップ担当者F | BUYMAが26カ国で越境EC展開、言語・決済課題を克服。 |
+| 4 | [セブンが「7NOW モバイルオーダー」を全国で開始](https://diamond-rm.net/management/541064/) | ダイヤモンドCS | セブン-イレブンがモバイルオーダーを全国展開。 |
+| 5 | [OpenAIのエージェントコマース戦略。「ChatGPT」の買い物をアップデート](https://netshop.impress.co.jp/n/2026/03/31/15838) | ネットショップ担当者F | ChatGPTの買い物機能が会話型検索と比較表示に対応。 |
+| 6 | [アテニアはなぜ「AI接客」を実装したのか](https://ecnomikata.com/original_news/49996/) | ECのミカタ | 美容ブランドがAI接客機能を導入した背景と戦略。 |
+| 7 | [地方部のネットスーパーで「恵方巻」が1日3000本も売れた理由](https://diamond-rm.net/ec-epayment/net-super/540588/) | ダイヤモンドCS | 季節商品の販売成功事例から学ぶネットスーパー戦略。 |
+| 8 | [LINEヤフー「Yahoo!ショッピング」、悪質事業者の排除・不正操作の防止対策](https://netshop.impress.co.jp/n/2026/03/31/15836) | ネットショップ担当者F | Yahoo!ショッピングが不正操作対策を強化。 |
+| 9 | [W2、次世代戦略「メディアコマース」を体系化した定義書を公開](https://ecnomikata.com/ecnews/50012/) | ECのミカタ | EC競争構造を再定義する「メディアコマース」戦略の定義書が公開。 |
+
+### B5. 決算・統計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [経済産業省／2月の商業動態統計、小売業販売額は0.2％減の12兆1550億円](https://www.ryutsuu.biz/sales/s033149.html) | 流通ニュース | 2月小売業販売額がわずかに減少。 |
+| 2 | [スーパーマーケット／2月の販売額1兆3001億円、2.9％増に](https://www.ryutsuu.biz/sales/s033148.html) | 流通ニュース | 2月SM販売額が2.9%増の1兆3001億円。 |
+| 3 | [ドラッグストア／2月の販売額5.6％増7445億円、食品が2627億円](https://www.ryutsuu.biz/sales/s033147.html) | 流通ニュース | 2月DgS販売額が5.6%増、食品部門が好調。 |
+| 4 | [スーパーマーケット／2月既存店売上ライフ2.4％増、ヤオコー3.3％増](https://www.ryutsuu.biz/sales/s033179.html) | 流通ニュース | 2月SM既存店売上でライフ・ヤオコーが好調。 |
+| 5 | [令和8年2月度チェーンストア販売統計](https://www.jcsa.gr.jp/public/statistics2026_02.html) | 日本チェーンストア協会 | 2月度月次販売統計を公表（3/25発表）。 |
+| 6 | [コンビニエンスストア統計調査2月度](https://www.jfa-fc.or.jp/particle/320.html) | 日本FC協会 | CVS2月度統計調査データ（3/23公開）。 |
+| 7 | [コメの民間在庫1.5倍に＝2月末、販売が停滞](https://news.nissyoku.co.jp/flash/1274297) | 日本食糧新聞 | 2月末時点でコメの民間在庫が1.5倍に増加。 |
+| 8 | [デリバリーとスーパー、「食料品消費税率ゼロ」の恩恵を受けるのはどちらか？](https://diamond-rm.net/management/businessplan/540116/) | ダイヤモンドCS | 税制変更が流通業態に与える影響を分析。 |
+
+### B6. 物流・規制
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [食品界、4月からの変化 — 持続的供給支える2法施行](https://news.nissyoku.co.jp/news/shinoda20260331112147443) | 日本食糧新聞 | 改正物流効率化法と食料システム法の施行で食品業界の供給体制が変化。 |
+| 2 | [「改正物流効率化法への対応」約8割が「負担」と回答](https://ecnomikata.com/ecnews/50013/) | ECのミカタ | 物流事業者の8割が改正法対応に負担を感じている調査結果。 |
+| 3 | [日本郵便、EC取引の不正対策強化でYTGATEと業務提携](https://netshop.impress.co.jp/n/2026/03/31/15832) | ネットショップ担当者F | 日本郵便がEC不正対策で決済最適化支援を開始。 |
+
+---
+
+## C章. クロスドメイン分析
+
+### 1. OSSサプライチェーンセキュリティ — 小売システムへの波及リスク
+
+axiosのサプライチェーン攻撃は、npmエコシステム全体の信頼性を揺るがす事件である。axiosはEC系フロントエンド・バックエンドで広く利用されており、小売企業のECサイト・決済システム・在庫管理APIに直接影響し得る。SIerとしては、クライアントの依存パッケージ監査（SCA）導入を積極的に提案すべきタイミングであり、lockfileの厳格管理やpre-install hooksの設定を推奨する。
+
+### 2. AIエージェントコマースの台頭 — 小売EC戦略の再定義
+
+OpenAIのChatGPT買い物機能アップデートと、AI接客導入（アテニア）、セブンのモバイルオーダー全国展開が同時期に発生している。AIが商品推薦・購買・決済まで一貫して行う「エージェンティックコマース」が現実化しつつあり、従来のSEO最適化やリスティング広告中心のEC戦略が根本的に変わる可能性がある。SIerはAI対応の商品データ基盤（構造化カタログ）とAPIファーストのEC構成を提案する必要がある。
+
+### 3. 物流2法施行とデータ基盤需要
+
+4月1日施行の改正物流効率化法・食料システム法は、物流の可視化・効率化を法的に義務付ける方向性を持つ。dbt+Fivetranの統合によるオープンデータインフラの進展と組み合わせると、小売・食品企業の物流データ基盤構築案件が増加する見込み。SIerは物流KPIダッシュボード、リアルタイムSC可視化の提案機会として捉えるべき。
+
+### 4. EC好決算と脱クーポン戦略 — CRM/データ分析の重要性
+
+しまむらのEC売上51%増（ストア統合）とTOKYO BASEのEC売上23%増（脱クーポン・脱割引）は、いずれも短期的な値引き施策ではなく、顧客体験・ブランド価値の向上が成長ドライバーであることを示す。カインズのCRM・ファンコミュニティ戦略も同方向。SIerにとってはCDP（Customer Data Platform）導入・顧客分析基盤構築の提案材料となる。
+
+---
+
+## D章. 巡回メタデータ
+
+### 技術系ソース
+
+| # | ソース | ステータス | 取得記事数 | 備考 |
+|---|--------|-----------|-----------|------|
+| 1 | Zenn | ✅ 成功 | 10件 | トレンド記事を取得 |
+| 2 | Qiita | ✅ 成功 | 10件 | トレンド記事を取得 |
+| 3 | はてなブックマーク IT | ✅ 成功 | 10件 | 人気エントリを取得 |
+| 4 | DevelopersIO | ✅ 成功 | 10件 | 最新記事を取得 |
+| 5 | AWS What's New | ⚠️ 一部取得 | 10件 | RSS経由で取得（動的ページのため直接取得不可） |
+| 6 | InfoQ | ✅ 成功 | 10件 | 最新記事を取得 |
+| 7 | The New Stack | ⚠️ 一部取得 | 5件 | WebSearch経由で概要のみ取得 |
+| 8 | Hacker News | ✅ 成功 | 10件 | フロントページを取得 |
+| 9 | dbt Blog | ✅ 成功 | 5件 | 最新記事を取得 |
+| 10 | Snowflake Blog | ❌ 失敗 | 0件 | JS動的レンダリングのためコンテンツ取得不可 |
+| 11 | Databricks Blog | ❌ 失敗 | 0件 | 取得不可 |
+| 12 | フューチャー技術ブログ | ✅ 成功 | 5件 | 最新記事を取得 |
+| 13 | NTTデータ テックブログ | ❌ 失敗 | 0件 | WebSearch結果なし |
+| 14 | Anthropic News | ✅ 成功 | 5件 | 最新記事を取得 |
+| 15 | OpenAI Blog | ⚠️ 一部取得 | 2件 | WebSearch経由で概要のみ |
+| 16 | HashiCorp Blog | ⚠️ 一部取得 | 2件 | WebSearch経由で概要のみ |
+| 17 | AWS Architecture Blog | ❌ 失敗 | 0件 | JS動的レンダリングのためコンテンツ取得不可 |
+
+### 小売ドメイン系ソース
+
+| # | ソース | ステータス | 取得記事数 | 備考 |
+|---|--------|-----------|-----------|------|
+| 18 | 流通ニュース | ✅ 成功 | 9件 | 3/31記事を中心に取得 |
+| 19 | ダイヤモンド・チェーンストア | ✅ 成功 | 10件 | 3/31〜4/1記事を取得 |
+| 20 | ネットショップ担当者フォーラム | ✅ 成功 | 10件 | 3/31〜4/1記事を取得 |
+| 21 | 日本食糧新聞 | ✅ 成功 | 6件 | リダイレクト対応後に取得 |
+| 22 | ITmedia ビジネスオンライン | ⚠️ 一部取得 | 4件 | 小売サブトップ取得不可、ビジネストップから抽出 |
+| 23 | Retail Dive | ❌ 失敗 | 0件 | HTTP 403 Forbidden |
+| 24 | NRF Blog | ❌ 失敗 | 0件 | JS動的レンダリング |
+| 25 | ECのミカタ | ✅ 成功 | 6件 | 3/31〜4/1記事を取得 |
+| 26 | ロジスティクス・トゥデイ | ❌ 失敗 | 0件 | JS動的レンダリング |
+| 27 | セブン＆アイ ニュースリリース | ⚠️ 一部取得 | 3件 | 3〜4月リリース未掲載、2月分まで |
+| 28 | ZOZO テックブログ | ❌ 失敗 | 0件 | WebFetchパーミッション拒否 |
+| 29 | 日本チェーンストア協会 | ✅ 成功 | 3件 | 2月度統計確認（月初チェック） |
+| 30 | 日本フランチャイズチェーン協会 | ✅ 成功 | 4件 | CVS2月度統計確認（月初チェック） |
+
+**総記事数**: 技術94件 + 小売55件 = 149件（うちダイジェスト採用: 技術41件 + 小売33件 = 74件）


### PR DESCRIPTION
## Summary
- 日次ダイジェスト 2026-04-01 を Agent Teams（wf-daily-digest）で生成
- 技術系17ソース + 小売系13ソース = 30ソースを並列巡回
- 採用記事数: 技術41件 + 小売33件 = 74件

## ハイライト
1. **axiosサプライチェーン攻撃** — npm人気パッケージがメンテナ乗っ取りでマルウェア配布
2. **Claude Codeソースコード流出** — npmソースマップに51万行が公開状態
3. **OpenAI $852B評価額で資金調達完了**
4. **改正物流効率化法・食料システム法 4/1施行** — 事業者8割が負担と回答
5. **しまむらEC売上51%増、TOKYO BASE EC売上23%増** — 脱クーポン戦略でEC好決算

## 品質ゲート
- [x] 全記事がMDリンク形式
- [x] ヘッダー・ハイライト・A章・B章・C章・D章の構成確認
- [x] judge評価: 4.3/5

## Test plan
- [ ] MDリンクが全記事に設定されていることを確認
- [ ] D章の巡回メタデータが全ソースを網羅していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)