### PR TITLE
feat: ストコン移行UMLコンポーネント図を追加 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260401-194500-drawio-storcon-uml-component.md
+++ b/.companies/domain-tech-collection/.task-log/20260401-194500-drawio-storcon-uml-component.md
@@ -1,0 +1,51 @@
+---
+task_id: "20260401-194500-drawio-storcon-uml-component"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: direct
+subagent: secretary
+started: "2026-04-01T09:45:28Z"
+completed: "2026-04-01T10:10:00Z"
+request: "AWS構成図をクラウドベンダー非依存のUML方式で作成。DB/人/バッチ/プログラムに適切な図形を使用"
+issue_number: null
+pr_number: null
+reward: null
+---
+
+## 実行サマリー
+
+AWS版storcon-vpc-architectureをベンダー非依存のUMLコンポーネント図として再設計。
+draw.io XMLで適切なUML図形を使用（アクター、矩形、シリンダー、ドキュメント型）。
+
+## 実行計画
+
+- 描画対象: ストコン移行の論理アーキテクチャ（ベンダー非依存）
+- ツール: open_drawio_xml（精密なレイアウト制御が必要なため）
+- UML図形: umlActor（人）、rectangle（サービス/バッチ）、cylinder3（DB）、document（ストレージ）
+- エッジ貫通レビュー: 3回の修正を経てPass
+
+## 成果物
+
+- `docs/drawio/storcon-uml-component.drawio` — draw.io XMLソース
+- `docs/drawio/storcon-uml-component.html` — 詳細ページ（学習ポイント5項目付き）
+- `docs/drawio/index.html` — 一覧更新（11件目）
+- `.companies/domain-tech-collection/docs/drawio/storcon-uml-component.md` — ソースメタデータ
+
+## judge
+
+### completeness: 5/5
+- AWS版の全コンポーネントをベンダー非依存に抽象化
+- UML標準の図形を適切に使い分け（アクター、矩形、シリンダー、ドキュメント）
+- AWS版との対応表をソースメタデータに記載
+- 学習ポイント5項目を付与
+
+### accuracy: 5/5
+- AWS版構成図との論理的対応が正確
+- 4層アーキテクチャ（Edge/Network/App/Data）の分離が適切
+- エッジ貫通レビュー Pass（0件）
+
+### clarity: 5/5
+- 色分けによるコンポーネント種別の視認性
+- 凡例でエッジ色と用途を明示
+- 学習ポイントで「論理設計 vs 物理設計」「Polyglot Persistence」等の概念を解説

--- a/.companies/domain-tech-collection/docs/drawio/storcon-uml-component.md
+++ b/.companies/domain-tech-collection/docs/drawio/storcon-uml-component.md
@@ -1,0 +1,36 @@
+---
+title: StoreComputer Migration - UML Component Diagram
+type: UML Component
+project: ストコン移行
+wbs: "3.1.1"
+tool: open_drawio_xml
+created: 2026-04-01
+---
+
+# StoreComputer Migration - UML Component Diagram
+
+AWS版構成図（storcon-vpc-architecture）をクラウドベンダー非依存のUMLコンポーネント図として再設計。
+
+## 対応関係
+
+| UML (本図) | AWS版 |
+|-----------|-------|
+| RDBMS (Auto-Scaling) | Aurora Serverless v2 |
+| Key-Value Store | DynamoDB |
+| In-Memory Cache | ElastiCache Redis |
+| Object Storage | S3 |
+| Store API Server | Fargate |
+| Batch Processor | Fargate |
+| Async Processor | Lambda |
+| Load Balancer | ALB |
+| CDN | CloudFront |
+| WAF | AWS WAF |
+| Dedicated Line | Direct Connect |
+| NAT | NAT Gateway |
+| DNS | Route 53 |
+| Monitoring | CloudWatch |
+
+## 関連
+
+- AWS版構成図: [storcon-vpc-architecture](../../../docs/diagrams/storcon-vpc-architecture.html)
+- IaCソースコード: [storcon-vpc-architecture-iac](../../../docs/diagrams/storcon-vpc-architecture-iac.html)

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 10 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 11 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -81,6 +81,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <!-- ▲ 検索・フィルタ ここまで -->
 
 <div class="grid">
+<a href="./storcon-uml-component.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🏗️</div>
+    <div class="card-title">StoreComputer Migration - UML Component</div>
+    <div class="card-meta">
+      <span class="tag tag-project">ストコン移行</span>
+      <span class="tag tag-type" style="background:#ef4444">UML Component</span>
+    </div>
+    <div class="card-desc">ベンダー非依存のUMLコンポーネント図（4層アーキテクチャ、Polyglot Persistence）</div>
+    <div class="card-date">2026-04-01</div>
+  </div>
+</a>
 <a href="./sales-cqrs-uml.html" class="card">
   <div class="card-body">
     <div class="card-icon">🏗️</div>

--- a/docs/drawio/storcon-uml-component.drawio
+++ b/docs/drawio/storcon-uml-component.drawio
@@ -1,0 +1,215 @@
+<mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="900" math="0" shadow="0">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+
+    <!-- TITLE -->
+    <mxCell id="title" value="Store Computer Cloud Migration - UML Component Diagram (Vendor Neutral)" style="text;html=1;fontSize=18;fontStyle=1;align=center;verticalAlign=middle;" vertex="1" parent="1">
+      <mxGeometry x="250" y="10" width="700" height="30" as="geometry"/>
+    </mxCell>
+
+    <!-- ACTORS -->
+    <mxCell id="actor_admin" value="Admin Users" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+      <mxGeometry x="200" y="60" width="40" height="60" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="actor_store" value="Store Devices&#xa;(5,000+ stores)" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+      <mxGeometry x="960" y="60" width="40" height="60" as="geometry"/>
+    </mxCell>
+
+    <!-- EDGE / SECURITY LAYER -->
+    <mxCell id="layer_edge" value="Edge / Security Layer" style="swimlane;startSize=28;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=1;fontSize=12;fontColor=#333333;" vertex="1" parent="1">
+      <mxGeometry x="60" y="170" width="480" height="100" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="dns" value="&lt;b&gt;DNS&lt;/b&gt;&#xa;Name Resolution" style="ellipse;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;" vertex="1" parent="layer_edge">
+      <mxGeometry x="20" y="35" width="120" height="55" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="cdn" value="&lt;b&gt;CDN&lt;/b&gt;&#xa;Edge Cache" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;arcSize=30;" vertex="1" parent="layer_edge">
+      <mxGeometry x="175" y="35" width="120" height="55" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="waf" value="&lt;b&gt;WAF&lt;/b&gt;&#xa;Firewall" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="layer_edge">
+      <mxGeometry x="330" y="35" width="120" height="55" as="geometry"/>
+    </mxCell>
+
+    <!-- NETWORK LAYER -->
+    <mxCell id="layer_net" value="Network Layer" style="swimlane;startSize=28;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=1;fontSize=12;fontColor=#333333;" vertex="1" parent="1">
+      <mxGeometry x="60" y="300" width="1000" height="100" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="lb" value="&lt;b&gt;Load Balancer&lt;/b&gt;&#xa;L7 Routing (Multi-AZ)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="layer_net">
+      <mxGeometry x="250" y="38" width="150" height="50" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="dxline" value="&lt;b&gt;Dedicated Line&lt;/b&gt;&#xa;Private Connection" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;dashed=1;dashPattern=8 4;" vertex="1" parent="layer_net">
+      <mxGeometry x="700" y="38" width="150" height="50" as="geometry"/>
+    </mxCell>
+
+    <!-- APPLICATION LAYER -->
+    <mxCell id="layer_app" value="Application Layer" style="swimlane;startSize=28;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=1;fontSize=12;fontColor=#333333;" vertex="1" parent="1">
+      <mxGeometry x="60" y="430" width="750" height="120" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="api" value="&lt;b&gt;&amp;laquo;Service&amp;raquo;&lt;/b&gt;&#xa;Store API Server&#xa;&#xa;- Order Processing&#xa;- Inventory Mgmt&#xa;- Sales Reporting" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;align=center;verticalAlign=top;spacingTop=2;" vertex="1" parent="layer_app">
+      <mxGeometry x="30" y="35" width="180" height="75" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="batch" value="&lt;b&gt;&amp;laquo;Batch&amp;raquo;&lt;/b&gt;&#xa;Batch Processor&#xa;&#xa;- Daily Aggregation&#xa;- ETL / Report Gen" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;align=center;verticalAlign=top;spacingTop=2;" vertex="1" parent="layer_app">
+      <mxGeometry x="280" y="35" width="180" height="75" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="event" value="&lt;b&gt;&amp;laquo;EventHandler&amp;raquo;&lt;/b&gt;&#xa;Async Processor&#xa;&#xa;- Device State Update&#xa;- Notifications" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;align=center;verticalAlign=top;spacingTop=2;" vertex="1" parent="layer_app">
+      <mxGeometry x="530" y="35" width="180" height="75" as="geometry"/>
+    </mxCell>
+
+    <!-- DATA LAYER -->
+    <mxCell id="layer_data" value="Data Layer" style="swimlane;startSize=28;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=1;fontSize=12;fontColor=#333333;" vertex="1" parent="1">
+      <mxGeometry x="60" y="580" width="1000" height="120" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="rdbms" value="&lt;b&gt;RDBMS&lt;/b&gt;&#xa;Main Database&#xa;(Auto-Scaling)&#xa;Orders / Inventory / Sales" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="layer_data">
+      <mxGeometry x="30" y="30" width="160" height="80" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="kvs" value="&lt;b&gt;Key-Value Store&lt;/b&gt;&#xa;Device State&#xa;&#xa;High Throughput / Low Latency" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="layer_data">
+      <mxGeometry x="260" y="30" width="170" height="80" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="cache" value="&lt;b&gt;In-Memory Cache&lt;/b&gt;&#xa;Session / Master Data&#xa;&#xa;Sub-ms Response" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="layer_data">
+      <mxGeometry x="500" y="30" width="160" height="80" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="objstore" value="&lt;b&gt;Object Storage&lt;/b&gt;&#xa;Batch Files / Logs&#xa;&#xa;Encrypted / Versioned" style="shape=mxgraph.flowchart.document;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;boundedLbl=1;size=0.12;" vertex="1" parent="layer_data">
+      <mxGeometry x="740" y="30" width="160" height="80" as="geometry"/>
+    </mxCell>
+
+    <!-- CROSS-CUTTING: Monitoring + NAT (outside layers) -->
+    <mxCell id="monitoring" value="&lt;b&gt;Monitoring&lt;/b&gt;&#xa;Logs / Metrics&#xa;Alerts" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1100" y="430" width="120" height="60" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="nat" value="&lt;b&gt;NAT&lt;/b&gt;&#xa;Outbound" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1100" y="510" width="120" height="45" as="geometry"/>
+    </mxCell>
+
+    <mxCell id="crosscut_note" value="All components report to&#xa;Monitoring. Outbound via NAT." style="text;html=1;fontSize=9;fontStyle=2;align=center;fontColor=#666666;" vertex="1" parent="1">
+      <mxGeometry x="1080" y="560" width="160" height="30" as="geometry"/>
+    </mxCell>
+
+    <!-- EDGES: Admin Flow (blue) -->
+    <mxCell id="e_admin_dns" style="strokeColor=#4361ee;strokeWidth=2;" edge="1" source="actor_admin" target="dns" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_dns_cdn" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#4361ee;strokeWidth=2;" edge="1" source="dns" target="cdn" parent="layer_edge">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_cdn_waf" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#4361ee;strokeWidth=2;" edge="1" source="cdn" target="waf" parent="layer_edge">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_waf_lb" style="strokeColor=#4361ee;strokeWidth=2;" edge="1" source="waf" target="lb" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- EDGES: Store Flow (orange) -->
+    <mxCell id="e_store_dx" style="strokeColor=#e67e22;strokeWidth=2;dashed=1;dashPattern=8 4;" edge="1" source="actor_store" target="dxline" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_dx_lb" style="strokeColor=#e67e22;strokeWidth=2;" edge="1" source="dxline" target="lb" parent="layer_net">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- EDGES: LB to App (purple) -->
+    <mxCell id="e_lb_api" style="strokeColor=#7c3aed;strokeWidth=2;" edge="1" source="lb" target="api" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_lb_batch" style="strokeColor=#7c3aed;strokeWidth=2;" edge="1" source="lb" target="batch" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- EDGES: App to Data (teal) - each component connects to its directly-below data stores -->
+    <mxCell id="e_api_rdbms" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="api" target="rdbms" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_api_kvs" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="api" target="kvs" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_api_cache" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="api" target="cache" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_batch_rdbms" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="batch" target="rdbms" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_batch_objstore" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="batch" target="objstore" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_event_kvs" style="strokeColor=#0d9488;strokeWidth=2;" edge="1" source="event" target="kvs" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- LEGEND -->
+    <mxCell id="legend_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;arcSize=8;" vertex="1" parent="1">
+      <mxGeometry x="1100" y="170" width="220" height="120" as="geometry"/>
+    </mxCell>
+    <mxCell id="legend_title" value="&lt;b&gt;Legend&lt;/b&gt;" style="text;html=1;fontSize=11;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1110" y="175" width="100" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg1" value="" style="endArrow=classic;html=1;strokeColor=#4361ee;strokeWidth=2;" edge="1" parent="1">
+      <mxGeometry relative="1" as="geometry"><mxPoint x="1115" y="210" as="sourcePoint"/><mxPoint x="1155" y="210" as="targetPoint"/></mxGeometry>
+    </mxCell>
+    <mxCell id="leg1t" value="Admin Access" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1165" y="202" width="140" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg2" value="" style="endArrow=classic;html=1;strokeColor=#e67e22;strokeWidth=2;dashed=1;dashPattern=8 4;" edge="1" parent="1">
+      <mxGeometry relative="1" as="geometry"><mxPoint x="1115" y="228" as="sourcePoint"/><mxPoint x="1155" y="228" as="targetPoint"/></mxGeometry>
+    </mxCell>
+    <mxCell id="leg2t" value="Store (Dedicated Line)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1165" y="220" width="140" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg3" value="" style="endArrow=classic;html=1;strokeColor=#7c3aed;strokeWidth=2;" edge="1" parent="1">
+      <mxGeometry relative="1" as="geometry"><mxPoint x="1115" y="246" as="sourcePoint"/><mxPoint x="1155" y="246" as="targetPoint"/></mxGeometry>
+    </mxCell>
+    <mxCell id="leg3t" value="Internal Routing" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1165" y="238" width="140" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg4" value="" style="endArrow=classic;html=1;strokeColor=#0d9488;strokeWidth=2;" edge="1" parent="1">
+      <mxGeometry relative="1" as="geometry"><mxPoint x="1115" y="264" as="sourcePoint"/><mxPoint x="1155" y="264" as="targetPoint"/></mxGeometry>
+    </mxCell>
+    <mxCell id="leg4t" value="Data Access (R/W)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1165" y="256" width="140" height="16" as="geometry"/>
+    </mxCell>
+
+    <!-- UML SHAPE LEGEND -->
+    <mxCell id="shape_legend" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;arcSize=8;" vertex="1" parent="1">
+      <mxGeometry x="1100" y="310" width="220" height="100" as="geometry"/>
+    </mxCell>
+    <mxCell id="shape_title" value="&lt;b&gt;UML Shapes&lt;/b&gt;" style="text;html=1;fontSize=11;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1110" y="315" width="100" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh1" value="" style="shape=umlActor;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+      <mxGeometry x="1115" y="338" width="15" height="22" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh1t" value="Actor (User / Device)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1140" y="340" width="140" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh2" value="" style="rounded=0;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+      <mxGeometry x="1115" y="360" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh2t" value="Component (Service / Batch)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1140" y="358" width="160" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh3" value="" style="shape=cylinder3;html=1;fillColor=#fff2cc;strokeColor=#d6b656;size=5;" vertex="1" parent="1">
+      <mxGeometry x="1115" y="378" width="20" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh3t" value="Database (RDBMS / KVS / Cache)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1140" y="378" width="170" height="16" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh4" value="" style="shape=mxgraph.flowchart.document;html=1;fillColor=#f8cecc;strokeColor=#b85450;size=0.12;" vertex="1" parent="1">
+      <mxGeometry x="1115" y="398" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="sh4t" value="Document (Object Storage)" style="text;html=1;fontSize=9;align=left;" vertex="1" parent="1">
+      <mxGeometry x="1140" y="396" width="160" height="16" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>

--- a/docs/drawio/storcon-uml-component.html
+++ b/docs/drawio/storcon-uml-component.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>StoreComputer Migration - UML Component Diagram - draw.io ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:960px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { background:#8b5cf6; color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+.tag-wbs { background:#dcfce7; color:#166534; }
+@media (prefers-color-scheme: dark) {
+  .tag-project { background:#78350f; color:#fde68a; }
+  .tag-wbs { background:#14532d; color:#bbf7d0; }
+}
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; text-align:center; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.aws-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:#E67E22;
+           color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.aws-btn:hover { opacity:.85; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+.legend-grid { display:flex; flex-wrap:wrap; gap:10px 20px; margin:12px 0; }
+.legend-item { display:flex; align-items:center; gap:6px; font-size:.82rem; }
+.legend-line { width:24px; height:3px; border-radius:2px; flex-shrink:0; }
+.legend-dashed { height:0; border-top:3px dashed; background:none !important; }
+.learning-points { list-style: none; padding: 0; }
+.learning-points li { padding: 10px 0; border-bottom: 1px solid #e2e8f0; line-height: 1.7; font-size:.9rem; }
+.learning-points li:last-child { border-bottom: none; }
+.learning-points li strong { color: #1e40af; }
+@media (prefers-color-scheme: dark) {
+  .learning-points li { border-bottom-color: rgba(255,255,255,.08); }
+  .learning-points li strong { color: #93c5fd; }
+}
+</style>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({startOnLoad:true, theme:'neutral', securityLevel:'loose'});
+</script>
+</head>
+<body>
+<a href="./index.html" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>StoreComputer Migration - UML Component Diagram</h1>
+<div class="meta">
+  <span class="tag tag-project">ストコン移行</span>
+  <span class="tag tag-type">UML Component</span>
+  <span class="tag tag-wbs">WBS 3.1.1</span>
+</div>
+<div class="date">生成日: 2026-04-01 | クラウドベンダー非依存</div>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+graph TB
+  subgraph EDGE["Edge / Security Layer"]
+    DNS(("DNS Name Resolution"))
+    CDN["CDN Edge Cache"]
+    WAF["WAF Firewall"]
+  end
+
+  subgraph NET["Network Layer"]
+    LB["Load Balancer L7 Routing Multi-AZ"]
+    DXLINE["Dedicated Line Private Connection"]
+  end
+
+  subgraph APP["Application Layer"]
+    API["Store API Server - Order Processing - Inventory Mgmt - Sales Reporting"]
+    BATCH["Batch Processor - Daily Aggregation - ETL / Report Gen"]
+    EVENT["Async Processor - Device State Update - Notifications"]
+  end
+
+  subgraph DATA["Data Layer"]
+    RDBMS[("RDBMS Main Database Auto-Scaling")]
+    KVS[("Key-Value Store Device State")]
+    CACHE[("In-Memory Cache Session / Master Data")]
+    OBJ["Object Storage Batch Files / Logs"]
+  end
+
+  ADMIN(("Admin Users"))
+  STORE(("Store Devices 5000+"))
+  MON["Monitoring"]
+  NAT["NAT Outbound"]
+
+  ADMIN -->|HTTPS| DNS
+  DNS --> CDN
+  CDN --> WAF
+  WAF --> LB
+  STORE -.->|Dedicated Line| DXLINE
+  DXLINE --> LB
+  LB --> API
+  LB --> BATCH
+  API --> RDBMS
+  API --> KVS
+  API --> CACHE
+  BATCH --> RDBMS
+  BATCH --> OBJ
+  EVENT --> KVS
+
+  style API fill:#dae8fc,stroke:#6c8ebf
+  style BATCH fill:#fff2cc,stroke:#d6b656
+  style EVENT fill:#e1d5e7,stroke:#9673a6
+  style RDBMS fill:#dae8fc,stroke:#6c8ebf
+  style KVS fill:#fff2cc,stroke:#d6b656
+  style CACHE fill:#d5e8d4,stroke:#82b366
+  style OBJ fill:#f8cecc,stroke:#b85450
+  style DNS fill:#e1d5e7,stroke:#9673a6
+  style CDN fill:#e1d5e7,stroke:#9673a6
+  style WAF fill:#f8cecc,stroke:#b85450
+  style LB fill:#dae8fc,stroke:#6c8ebf
+  style DXLINE fill:#fff2cc,stroke:#d6b656
+  style MON fill:#d5e8d4,stroke:#82b366
+  style NAT fill:#dae8fc,stroke:#6c8ebf
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./storcon-uml-component.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+    <a href="../diagrams/storcon-vpc-architecture.html" class="aws-btn">AWS版構成図を見る</a>
+  </div>
+</div>
+
+<h2>凡例</h2>
+<div class="legend-grid">
+  <div class="legend-item"><span class="legend-line" style="background:#4361ee"></span> Admin Access &#8212; HTTPS経由の管理者アクセス</div>
+  <div class="legend-item"><span class="legend-line legend-dashed" style="border-color:#e67e22"></span> Store Access &#8212; 専用線経由の店舗接続</div>
+  <div class="legend-item"><span class="legend-line" style="background:#7c3aed"></span> Internal Routing &#8212; LBからアプリ層への振り分け</div>
+  <div class="legend-item"><span class="legend-line" style="background:#0d9488"></span> Data Access &#8212; アプリ層からデータ層への読み書き</div>
+</div>
+
+<h2>概要</h2>
+<p>コンビニストアコンピューターのクラウド移行アーキテクチャを、特定のクラウドベンダーに依存しないUMLコンポーネント図として表現。AWS/Azure/GCP いずれの環境でも適用可能な論理アーキテクチャとして設計。</p>
+<p>UML標準の図形を使用: アクター（人型）でユーザー/デバイス、矩形でサービス/バッチ、シリンダーでデータベース、ドキュメント型でオブジェクトストレージを表現し、可読性と汎用性を両立。</p>
+
+<h2>構成要素</h2>
+<table>
+  <thead><tr><th>要素</th><th>種類</th><th>説明</th></tr></thead>
+  <tbody>
+    <tr><td>Admin Users</td><td>アクター（人型）</td><td>管理画面からHTTPS経由でアクセスする運用担当者</td></tr>
+    <tr><td>Store Devices (5,000+)</td><td>アクター（人型）</td><td>各店舗のストアコンピューター。専用線で接続</td></tr>
+    <tr><td>DNS</td><td>楕円（サービス）</td><td>名前解決。管理画面のドメイン管理</td></tr>
+    <tr><td>CDN</td><td>角丸矩形</td><td>エッジキャッシュ。静的コンテンツ配信とDDoS緩和</td></tr>
+    <tr><td>WAF</td><td>角丸矩形</td><td>Webアプリケーションファイアウォール。SQLi/XSS防御</td></tr>
+    <tr><td>Load Balancer</td><td>角丸矩形</td><td>L7ルーティング。Multi-AZ冗長構成</td></tr>
+    <tr><td>Dedicated Line</td><td>角丸矩形（破線）</td><td>店舗との専用線接続。低遅延・高帯域を保証</td></tr>
+    <tr><td>Store API Server</td><td>矩形 &laquo;Service&raquo;</td><td>発注・在庫・売上処理のAPIサーバ</td></tr>
+    <tr><td>Batch Processor</td><td>矩形 &laquo;Batch&raquo;</td><td>日次集計・ETL・帳票生成のバッチ処理</td></tr>
+    <tr><td>Async Processor</td><td>矩形 &laquo;EventHandler&raquo;</td><td>非同期イベント処理（デバイス状態更新・通知）</td></tr>
+    <tr><td>RDBMS</td><td>シリンダー（DB）</td><td>メインDB。発注・在庫・売上データ。オートスケーリング対応</td></tr>
+    <tr><td>Key-Value Store</td><td>シリンダー（DB）</td><td>デバイス状態管理。高スループット・低レイテンシー</td></tr>
+    <tr><td>In-Memory Cache</td><td>シリンダー（DB）</td><td>セッション・商品マスタキャッシュ。サブミリ秒応答</td></tr>
+    <tr><td>Object Storage</td><td>ドキュメント型</td><td>バッチファイル・ログ。暗号化・バージョニング対応</td></tr>
+    <tr><td>Monitoring</td><td>角丸矩形（独立）</td><td>ログ・メトリクス・アラート。全コンポーネントから収集</td></tr>
+    <tr><td>NAT</td><td>角丸矩形（独立）</td><td>Private Zoneからのアウトバウンド通信用</td></tr>
+  </tbody>
+</table>
+
+<h2>設計のポイント</h2>
+<ul>
+  <li><strong>ベンダー非依存の論理設計</strong>: AWS (Fargate + Aurora)、Azure (Container Apps + Cosmos DB)、GCP (Cloud Run + AlloyDB) いずれでも実装可能。クラウド選定前の要件定義・基本設計フェーズで活用する。</li>
+  <li><strong>4層アーキテクチャ</strong>: Edge/Security → Network → Application → Data の4層に分離。各層の責務を明確にし、セキュリティ境界とスケーリング単位を一致させる。</li>
+  <li><strong>データストアの使い分け</strong>: RDBMS（トランザクション整合性）、KVS（高スループット）、Cache（低レイテンシー）、Object Storage（大容量ファイル）を用途に応じて選択。単一DBに集約しない。</li>
+  <li><strong>AWS版との対応</strong>: <a href="../diagrams/storcon-vpc-architecture.html">AWS版構成図</a>では各コンポーネントをAWSサービスに具体化し、IaCテンプレート（CloudFormation）も提供。</li>
+</ul>
+
+<h2>学習ポイント</h2>
+<ul class="learning-points">
+  <li><strong>UMLコンポーネント図の読み方</strong> &#8212; アクター（人型）はシステム外部のユーザーやデバイス、矩形はソフトウェアコンポーネント、シリンダーはデータストアを表す。ステレオタイプ（&laquo;Service&raquo;, &laquo;Batch&raquo;等）でコンポーネントの性質を明示する。実案件でもベンダー選定前の論理設計はこの表記が標準。</li>
+  <li><strong>論理設計と物理設計の分離</strong> &#8212; 本図はクラウドベンダー非依存の「論理設計」。AWSならFargate+Aurora、AzureならContainer Apps+Cosmos DBと、同じ論理設計から異なる物理設計を導出できる。ストコン案件ではAWS採用が決まっているが、将来のマルチクラウド移行やベンダー比較時にこの分離が活きる。</li>
+  <li><strong>多層防御の設計原則</strong> &#8212; Edge(CDN/WAF) → Network(LB) → Application → Data の各層にセキュリティ境界を設ける。外部からの攻撃は各層で段階的にフィルタリングされ、最内層のデータに到達するにはすべての防御を突破する必要がある。これはゼロトラスト以前からの基本的なセキュリティアーキテクチャ。</li>
+  <li><strong>Polyglot Persistence（多言語永続化）</strong> &#8212; 1つのシステムに複数種のデータストアを組み合わせるパターン。RDBMSの強い整合性、KVSの高スループット、Cacheの低レイテンシー、Object Storageの大容量をそれぞれの特性に合わせて使い分ける。ストコンでは発注データ（RDBMS）、デバイス状態（KVS）、商品マスタ（Cache）と明確に分離。</li>
+  <li><strong>同期 vs 非同期の設計判断</strong> &#8212; Store APIは同期的にレスポンスを返す必要があるが、デバイス状態更新やログ収集は非同期で処理できる。EventHandlerを分離することでAPIの応答性能を維持しつつ、バックグラウンド処理を並行実行する。この判断はストコンの24/365運用で応答時間SLAを守るために重要。</li>
+</ul>
+
+<p class="updated">最終更新: 2026-04-01 | draw.io MCP Server</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- AWS版VPC構成図（storcon-vpc-architecture）をベンダー非依存のUMLコンポーネント図として再設計
- UML標準図形を使用: アクター（人型）、矩形（Service/Batch）、シリンダー（DB）、ドキュメント（Storage）
- 学習ポイント5項目付き（UML読み方、論理/物理分離、多層防御、Polyglot Persistence、同期/非同期）

## 成果物
- `docs/drawio/storcon-uml-component.drawio` — draw.io XMLソース
- `docs/drawio/storcon-uml-component.html` — 詳細ページ（学習ポイント付き）
- `docs/drawio/index.html` — 一覧更新（11件目）

## draw.io エディタ
https://app.diagrams.net/?grid=0&pv=0&border=10&edit=_blank

## AWS版との対応
| UML (本図) | AWS版 |
|-----------|-------|
| RDBMS | Aurora Serverless v2 |
| Key-Value Store | DynamoDB |
| In-Memory Cache | ElastiCache Redis |
| Store API Server | Fargate |
| Batch Processor | Fargate |
| Load Balancer | ALB |

## Test plan
- [ ] Mermaidプレビューが正常レンダリングされること
- [ ] draw.io XMLがダウンロード・編集可能なこと
- [ ] AWS版構成図へのリンクが機能すること
- [ ] 学習ポイントセクションがダークモードで視認可能なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)