### PR TITLE
docs: 日次活動レポート 2026-04-02

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-04-02-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-04-02-today.md
@@ -1,0 +1,72 @@
+# domain-tech-collection 活動レポート — 本日（2026-04-02）
+
+> 生成日時: 2026-04-02T10:20:00 | 生成者: SAS-Sasao | 期間: 2026-04-02
+
+## エグゼクティブサマリー
+
+本日は日次ダイジェスト（wf-daily-digest）をAgent Teamsで実行し、技術系55件・小売系51件の計106件の記事を19ソースから収集した。品質ゲート全項目パス、Judge評価14/15（reward: 0.93）の高品質な成果物を生成。ダイジェストHTMLも更新し、GitHub Pagesで公開済み。本日の注目トピックはaxiosサプライチェーン攻撃、アスクルランサムウェア復旧、MCPの本番展開フェーズ突入の3点。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 1 回 |
+| ツール実行数（合計） | 75 回 |
+| 作成・編集ファイル数 | 3 件 |
+| 完了タスク数 | 1 件 |
+| 新規オープンIssue数 | 1 件（+ interaction-log 1件） |
+| クローズIssue数 | 0 件 |
+
+## 完了タスク
+
+- **[agent-teams]** 日次ダイジェスト 2026-04-02 → 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-04-02.md`
+  - 巡回ソース: 19件（成功15 / 部分成功2 / 失敗2）
+  - 収集記事数: 技術55件 + 小売51件 = 106件
+  - Judge評価: completeness 5/5, accuracy 4/5, clarity 5/5 = 14/15
+  - reward: 0.93
+  - PR: #199（マージ済み）
+
+## 進行中タスク
+
+なし
+
+## 作成・更新された成果物
+
+### daily-digest/
+- `docs/daily-digest/2026-04-02.md` — 日次ダイジェスト（106件、A章技術+B章小売+C章クロスドメイン分析+D章メタデータ）
+
+### GitHub Pages
+- `docs/daily-digest/index.html` — ダイジェストHTML更新（12ダイジェスト / 641記事累計）
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- #200 [domain-tech-collection] 日次ダイジェスト 2026-04-02（106件収集）
+
+### 関連PR（本日）
+- #199 feat: 日次ダイジェスト 2026-04-02（106件収集）— マージ済み
+
+## 会話トピック
+
+### セッション別の依頼内容
+- **セッション a866768f**（43発言 / 57応答 / 75ツール実行）
+  - /company 起動 → domain-tech-collection で作業継続を選択
+  - 「日次ダイジェストの対応をしたい」→ wf-daily-digest ワークフロー実行
+  - 「OKマージしたからmain以外のローカルブランチ削除して」→ ブランチ削除
+  - /company-digest-html → ダイジェストHTML生成・GitHub Pages更新
+  - /company-report → 本レポート生成
+
+### ファイル生成を伴わなかったやり取り
+- 組織選択UI（/company 起動時の対話的選択）
+- ブランチ削除の依頼（git操作のみ）
+
+## 次のアクション候補
+
+1. **NTTデータテックブログのURL確認**（根拠: 巡回メタデータでDNS解決失敗。ドメイン変更の可能性があり info-source-master.md の更新が必要）
+2. **ITmedia小売カテゴリの代替ソース検討**（根拠: 2日連続で最新記事取得不可。ソースマスタの見直し推奨）
+3. **ロジスティクス・トゥデイの取得方法改善**（根拠: JS動的レンダリングでWebFetch不可が継続。WebSearch補完またはRSSフィード活用を検討）
+4. **月次ソースマスタ更新（wf-source-master-refresh）の実行検討**（根拠: 4月に入り、3月分の情報価値に基づくソース優先度見直しのタイミング）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 日次活動レポート（2026-04-02）を生成
- 完了タスク: 日次ダイジェスト（106件収集、Judge 14/15）
- セッション1回、ツール実行75回

## Test plan
- [ ] レポート内容の妥当性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)