### PR TITLE
feat: Lambda vs Kappa アーキテクチャ比較図 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
+++ b/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
@@ -1,0 +1,54 @@
+---
+task_id: "20260403-110000-drawio-data-arch-comparison"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "direct"
+subagent: "secretary"
+started: "2026-04-03T11:00:00"
+completed: "2026-04-03T11:15:00"
+request: "カッパアーキテクチャとラムダアーキテクチャの詳細比較図をUML形式で作成"
+issue_number: null
+pr_number: null
+reward: 0.87
+judge_summary: "completeness 9/10, accuracy 9/10, clarity 8/10"
+---
+
+## 実行計画
+- **実行モード**: direct（秘書直接実行、/company-drawio Skill）
+- **アサインされたロール**: secretary（直接実行）
+- **参照したマスタ**: workflows.md（wf-drawio-architecture）
+- **判断理由**: draw.io構成図生成はwf-drawio-architectureワークフローに該当。XML形式で精密なレイアウト制御が必要な比較図のため直接実行
+
+## エージェント作業ログ
+
+### [2026-04-03 11:00] secretary
+受付: Lambda vs Kappa アーキテクチャ比較図の作成依頼
+
+### [2026-04-03 11:00] secretary
+判断: direct実行。open_drawio_xml でXML形式の精密レイアウト図を生成
+
+### [2026-04-03 11:05] secretary
+生成: draw.io XML作成。2つのswimlane（Lambda/Kappa）に全データフロー（ソース→Kafka→処理→蓄積→配信→利用者）を配置。UMLアクター、シリンダー、コンポーネントを適切に使用。比較サマリーテーブルを下部に配置。
+
+### [2026-04-03 11:08] secretary
+品質チェック: review-drawio.js でエッジ貫通チェック。初回13件検出→背景矩形をテキストラベルに変更、ノート位置を側面に移動→再チェックで残り2件→ラベル位置調整→最終チェック0件
+
+### [2026-04-03 11:10] secretary
+成果物: docs/drawio/data-arch-kappa-vs-lambda.drawio, .html, .companies/.../drawio/.md
+
+## 成果物
+| ファイル | 作成者 | パス |
+|---------|--------|------|
+| draw.io XML | secretary | docs/drawio/data-arch-kappa-vs-lambda.drawio |
+| 詳細HTMLページ | secretary | docs/drawio/data-arch-kappa-vs-lambda.html |
+| メタデータMD | secretary | .companies/domain-tech-collection/docs/drawio/data-arch-kappa-vs-lambda.md |
+
+## judge
+
+| 評価軸 | スコア | 根拠 |
+|--------|--------|------|
+| completeness | 9/10 | Lambda/Kappa全コンポーネントをUMLシェイプで網羅。比較サマリー・学習ポイント5項目も充実。 |
+| accuracy | 9/10 | 各ツールの役割・配置が正確。提唱者情報も正しい。 |
+| clarity | 8/10 | swimlane並列比較で構造明快。エッジ貫通0件。Batch/Speed視覚的グルーピングがやや弱い。 |
+| **total** | **0.87** | (9+9+8)/30 = 0.87 |

--- a/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
+++ b/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
@@ -8,8 +8,8 @@ subagent: "secretary"
 started: "2026-04-03T11:00:00"
 completed: "2026-04-03T11:15:00"
 request: "カッパアーキテクチャとラムダアーキテクチャの詳細比較図をUML形式で作成"
-issue_number: null
-pr_number: null
+issue_number: 207
+pr_number: 206
 reward: 0.87
 judge_summary: "completeness 9/10, accuracy 9/10, clarity 8/10"
 ---

--- a/.companies/domain-tech-collection/docs/drawio/data-arch-kappa-vs-lambda.md
+++ b/.companies/domain-tech-collection/docs/drawio/data-arch-kappa-vs-lambda.md
@@ -1,0 +1,28 @@
+# Lambda vs Kappa アーキテクチャ比較
+
+- **種類**: UML Architecture
+- **作成日**: 2026-04-03
+- **作成者**: SAS-Sasao
+- **ツール**: draw.io MCP (`open_drawio_xml`)
+- **draw.ioファイル**: [data-arch-kappa-vs-lambda.drawio](../../../docs/drawio/data-arch-kappa-vs-lambda.drawio)
+- **HTMLページ**: [data-arch-kappa-vs-lambda.html](../../../docs/drawio/data-arch-kappa-vs-lambda.html)
+
+## 概要
+
+大規模データ処理の2大アーキテクチャパターン（Lambda / Kappa）を同一キ��ンバス上で
+並列比較するUMLスタイルの構成図。UMLアクター、シリンダー（DB）、コンポーネント（処理エンジン）を
+適切に使い分け、全データフローを可視化。
+
+## 主要コンポーネント
+
+### Lambda Architecture
+- Apache Kafka (Message Broker)
+- Batch Layer: Hadoop HDFS → Apache Spark → Batch Views (Druid/HBase)
+- Speed Layer: Apache Flink/Storm → Real-time Views (Redis/Cassandra)
+- Serving Layer: Presto/Trino (Merge Views)
+
+### Kappa Architecture
+- Apache Kafka (Immutable Log / Long Retention)
+- Stream Processor: Apache Flink / Kafka Streams
+- Serving Store: Elasticsearch / Cassandra
+- Reprocessing: Log Replay from offset 0

--- a/docs/drawio/data-arch-kappa-vs-lambda.drawio
+++ b/docs/drawio/data-arch-kappa-vs-lambda.drawio
@@ -1,0 +1,188 @@
+<mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" math="0" shadow="0">
+<root>
+<mxCell id="0"/>
+<mxCell id="1" parent="0"/>
+<mxCell id="2" value="&lt;font style=&quot;font-size:16px&quot;&gt;&lt;b&gt;データアーキテクチャ比較: Lambda Architecture vs Kappa Architecture&lt;/b&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+<mxGeometry x="250" y="5" width="1100" height="35" as="geometry"/>
+</mxCell>
+<mxCell id="3" value="UMLシェイプ（アクター/シリンダー/コンポーネント）でデータ生成者 → 取込 → 処理 → 蓄積 → 配信 → 利用者の全フローを比較" style="text;html=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontSize=10;fontColor=#666666;" vertex="1" parent="1">
+<mxGeometry x="300" y="38" width="1000" height="22" as="geometry"/>
+</mxCell>
+
+<mxCell id="10" value="&lt;b&gt;Lambda Architecture&lt;/b&gt;" style="swimlane;startSize=32;fillColor=#dae8fc;strokeColor=#6c8ebf;rounded=1;html=1;fontSize=14;fontColor=#1a3a5c;arcSize=6;" vertex="1" parent="1">
+<mxGeometry x="15" y="80" width="760" height="700" as="geometry"/>
+</mxCell>
+<mxCell id="11" value="Data&lt;br&gt;Producer" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=9;" vertex="1" parent="10">
+<mxGeometry x="52" y="48" width="28" height="42" as="geometry"/>
+</mxCell>
+<mxCell id="12" value="IoT / Sensor" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="175" y="50" width="100" height="35" as="geometry"/>
+</mxCell>
+<mxCell id="13" value="Source DB" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="345" y="47" width="100" height="42" as="geometry"/>
+</mxCell>
+<mxCell id="14" value="Web / App" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="525" y="50" width="100" height="35" as="geometry"/>
+</mxCell>
+<mxCell id="15" value="&lt;b&gt;Apache Kafka&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Message Broker&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="10">
+<mxGeometry x="240" y="115" width="280" height="45" as="geometry"/>
+</mxCell>
+<mxCell id="16" value="&lt;b&gt;Batch Layer&lt;/b&gt;" style="text;html=1;align=left;verticalAlign=middle;fillColor=none;strokeColor=none;fontSize=12;fontColor=#e57373;" vertex="1" parent="10">
+<mxGeometry x="15" y="192" width="120" height="22" as="geometry"/>
+</mxCell>
+<mxCell id="17" value="&lt;b&gt;Speed Layer&lt;/b&gt;" style="text;html=1;align=right;verticalAlign=middle;fillColor=none;strokeColor=none;fontSize=12;fontColor=#ffb74d;" vertex="1" parent="10">
+<mxGeometry x="625" y="192" width="120" height="22" as="geometry"/>
+</mxCell>
+<mxCell id="18" value="&lt;b&gt;Hadoop HDFS&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Raw Data Store&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#bbdefb;strokeColor=#42a5f5;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="95" y="225" width="155" height="50" as="geometry"/>
+</mxCell>
+<mxCell id="19" value="&lt;b&gt;Apache Spark&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Batch Processing&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8e6c9;strokeColor=#66bb6a;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="105" y="305" width="135" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="20" value="&lt;b&gt;Batch Views&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Druid / HBase&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#bbdefb;strokeColor=#42a5f5;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="95" y="380" width="155" height="50" as="geometry"/>
+</mxCell>
+<mxCell id="21" value="&lt;b&gt;Apache Flink / Storm&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Stream Processing&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8e6c9;strokeColor=#66bb6a;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="460" y="225" width="170" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="22" value="&lt;b&gt;Real-time Views&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Redis / Cassandra&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#bbdefb;strokeColor=#42a5f5;fontSize=10;" vertex="1" parent="10">
+<mxGeometry x="460" y="305" width="170" height="50" as="geometry"/>
+</mxCell>
+<mxCell id="23" value="&lt;b&gt;Serving Layer&lt;/b&gt; — Merge Views&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;Query Engine: Presto / Trino&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1bee7;strokeColor=#8e24aa;fontSize=11;" vertex="1" parent="10">
+<mxGeometry x="195" y="495" width="370" height="45" as="geometry"/>
+</mxCell>
+<mxCell id="24" value="Batch + RT Views を統合してクエリ結果を返す（最終的整合性）" style="shape=note;whiteSpace=wrap;html=1;size=14;fillColor=#fffde7;strokeColor=#f9a825;fontSize=8;align=left;" vertex="1" parent="10">
+<mxGeometry x="580" y="490" width="165" height="48" as="geometry"/>
+</mxCell>
+<mxCell id="25" value="Data&lt;br&gt;Engineer" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=8;" vertex="1" parent="10">
+<mxGeometry x="130" y="570" width="25" height="38" as="geometry"/>
+</mxCell>
+<mxCell id="26" value="Data&lt;br&gt;Analyst" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=8;" vertex="1" parent="10">
+<mxGeometry x="365" y="570" width="25" height="38" as="geometry"/>
+</mxCell>
+<mxCell id="27" value="App / API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=9;" vertex="1" parent="10">
+<mxGeometry x="500" y="577" width="90" height="28" as="geometry"/>
+</mxCell>
+
+<mxCell id="40" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="11" target="15" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="41" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="12" target="15" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="42" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="13" target="15" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="43" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="14" target="15" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="44" style="endArrow=block;endFill=1;html=1;strokeColor=#e57373;strokeWidth=2;" edge="1" source="15" target="18" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="45" style="endArrow=block;endFill=1;html=1;strokeColor=#ffb74d;strokeWidth=2;" edge="1" source="15" target="21" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="46" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#555555;" edge="1" source="18" target="19" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="47" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#555555;" edge="1" source="19" target="20" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#555555;" edge="1" source="21" target="22" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="49" style="endArrow=block;endFill=1;html=1;strokeColor=#8e24aa;strokeWidth=2;" edge="1" source="20" target="23" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="50" style="endArrow=block;endFill=1;html=1;strokeColor=#8e24aa;strokeWidth=2;" edge="1" source="22" target="23" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="51" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="23" target="25" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="52" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="23" target="26" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="53" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="23" target="27" parent="10">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<mxCell id="100" value="&lt;b&gt;Kappa Architecture&lt;/b&gt;" style="swimlane;startSize=32;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;html=1;fontSize=14;fontColor=#1a3c1a;arcSize=6;" vertex="1" parent="1">
+<mxGeometry x="800" y="80" width="760" height="700" as="geometry"/>
+</mxCell>
+<mxCell id="111" value="Data&lt;br&gt;Producer" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=9;" vertex="1" parent="100">
+<mxGeometry x="52" y="48" width="28" height="42" as="geometry"/>
+</mxCell>
+<mxCell id="112" value="IoT / Sensor" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="100">
+<mxGeometry x="175" y="50" width="100" height="35" as="geometry"/>
+</mxCell>
+<mxCell id="113" value="Source DB" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="100">
+<mxGeometry x="345" y="47" width="100" height="42" as="geometry"/>
+</mxCell>
+<mxCell id="114" value="Web / App" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=10;" vertex="1" parent="100">
+<mxGeometry x="525" y="50" width="100" height="35" as="geometry"/>
+</mxCell>
+<mxCell id="101" value="&lt;b&gt;Apache Kafka&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Immutable Log / Long Retention&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="100">
+<mxGeometry x="190" y="120" width="380" height="55" as="geometry"/>
+</mxCell>
+<mxCell id="102" value="&lt;b&gt;Stream Processor&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Apache Flink / Kafka Streams&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8e6c9;strokeColor=#66bb6a;fontSize=11;" vertex="1" parent="100">
+<mxGeometry x="235" y="265" width="290" height="50" as="geometry"/>
+</mxCell>
+<mxCell id="103" value="&lt;b&gt;Serving Store&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Elasticsearch / Cassandra&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#bbdefb;strokeColor=#42a5f5;fontSize=11;" vertex="1" parent="100">
+<mxGeometry x="260" y="400" width="240" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="104" value="&lt;b&gt;Reprocessing&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:8px&quot;&gt;新しいConsumerを&lt;br&gt;offset 0 から起動して&lt;br&gt;全データを再処理&lt;/font&gt;" style="shape=note;whiteSpace=wrap;html=1;size=14;fillColor=#fffde7;strokeColor=#f9a825;fontSize=9;align=center;" vertex="1" parent="100">
+<mxGeometry x="30" y="210" width="155" height="70" as="geometry"/>
+</mxCell>
+<mxCell id="105" value="単一パスで全データ処理 → コード統一 / 運用シンプル / 二重管理不要" style="shape=note;whiteSpace=wrap;html=1;size=14;fillColor=#fffde7;strokeColor=#f9a825;fontSize=8;align=left;" vertex="1" parent="100">
+<mxGeometry x="575" y="400" width="165" height="55" as="geometry"/>
+</mxCell>
+<mxCell id="125" value="Data&lt;br&gt;Engineer" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=8;" vertex="1" parent="100">
+<mxGeometry x="130" y="510" width="25" height="38" as="geometry"/>
+</mxCell>
+<mxCell id="126" value="Data&lt;br&gt;Analyst" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;outlineConnect=0;fillColor=#f5f5f5;strokeColor=#333333;fontSize=8;" vertex="1" parent="100">
+<mxGeometry x="365" y="510" width="25" height="38" as="geometry"/>
+</mxCell>
+<mxCell id="127" value="App / API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8eaf6;strokeColor=#5c6bc0;fontSize=9;" vertex="1" parent="100">
+<mxGeometry x="500" y="517" width="90" height="28" as="geometry"/>
+</mxCell>
+
+<mxCell id="140" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="111" target="101" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="141" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="112" target="101" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="142" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="113" target="101" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="143" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="114" target="101" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="144" style="endArrow=block;endFill=1;html=1;strokeColor=#66bb6a;strokeWidth=2;" edge="1" source="101" target="102" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="145" style="endArrow=block;endFill=1;html=1;strokeColor=#42a5f5;strokeWidth=2;" edge="1" source="102" target="103" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="146" style="endArrow=open;dashed=1;html=1;strokeColor=#f9a825;exitX=1;exitY=0.3;entryX=0;entryY=0.7;" edge="1" source="104" target="101" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="147" style="endArrow=open;dashed=1;html=1;strokeColor=#f9a825;exitX=1;exitY=0.8;entryX=0;entryY=0.5;" edge="1" source="104" target="102" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="148" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="103" target="125" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="149" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="103" target="126" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="150" style="endArrow=block;endFill=1;html=1;strokeColor=#555555;" edge="1" source="103" target="127" parent="100">
+<mxGeometry relative="1" as="geometry"/>
+</mxCell>
+
+<mxCell id="200" value="&lt;b style=&quot;font-size:13px&quot;&gt;比較サマリー&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;table cellpadding=&quot;5&quot; cellspacing=&quot;0&quot; style=&quot;border-collapse:collapse;font-size:10px;width:100%&quot;&gt;&lt;tr&gt;&lt;th style=&quot;border:1px solid #ccc;background:#e3f2fd;text-align:left;width:14%&quot;&gt;観点&lt;/th&gt;&lt;th style=&quot;border:1px solid #ccc;background:#dae8fc;text-align:left;width:43%&quot;&gt;Lambda Architecture&lt;/th&gt;&lt;th style=&quot;border:1px solid #ccc;background:#d5e8d4;text-align:left;width:43%&quot;&gt;Kappa Architecture&lt;/th&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;複雑性&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;高い（Batch + Speed の二重管理が必要）&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;低い（単一処理パスのみ）&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;レイテンシ&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;Batch: 高 / Speed: 低（混在）&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;常に低レイテンシ&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;再処理方式&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;Batch Layer で全履歴を再計算&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;Kafka Log Replay（offset 0 から再消費）&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;コード管理&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;2つのコードベース（同一ロジックを二重実装）&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;1つのコードベース（統一管理）&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;適用場面&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;大量履歴データ + リアルタイム混在（DWH + ダッシュボード）&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;イベント駆動中心（IoT / ログ分析 / リアルタイム推薦）&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td style=&quot;border:1px solid #ccc;font-weight:bold&quot;&gt;代表ツール&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;Hadoop / Spark / Flink / Druid / HBase / Presto&lt;/td&gt;&lt;td style=&quot;border:1px solid #ccc&quot;&gt;Kafka / Flink / Kafka Streams / Elasticsearch / Cassandra&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fafafa;strokeColor=#bdbdbd;verticalAlign=top;spacingLeft=10;spacingTop=8;spacingRight=10;overflow=fill;" vertex="1" parent="1">
+<mxGeometry x="15" y="800" width="1545" height="200" as="geometry"/>
+</mxCell>
+</root>
+</mxGraphModel>

--- a/docs/drawio/data-arch-kappa-vs-lambda.html
+++ b/docs/drawio/data-arch-kappa-vs-lambda.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lambda vs Kappa アーキテクチャ比較 - draw.io ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --red:#ef4444; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1100px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) { .tag-project { background:#78350f; color:#fde68a; } }
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; color:var(--text); }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.note { background:#fffbe6; border:1px solid #fde68a; border-radius:8px; padding:12px 16px;
+        font-size:.85rem; margin:16px 0; }
+@media (prefers-color-scheme: dark) { .note { background:#422006; border-color:#78350f; } }
+.learning-points { list-style:none; padding:0; }
+.learning-points li { padding:10px 0; border-bottom:1px solid #e2e8f0; line-height:1.7; }
+.learning-points li:last-child { border-bottom:none; }
+.learning-points li strong { color:#1e40af; }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+</style>
+</head>
+<body>
+<a href="./" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>Lambda vs Kappa アーキテクチャ比較</h1>
+<div class="meta">
+  <span class="tag tag-project">データ基盤</span>
+  <span class="tag tag-type" style="background:#8b5cf6;">UML Architecture</span>
+</div>
+<p class="date">作成日: 2026-04-03 / 作成者: SAS-Sasao</p>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+flowchart TB
+    SRC["Data Sources: IoT / Web App / Database CDC"]
+
+    subgraph L["Lambda Architecture"]
+        direction TB
+        LK["Apache Kafka (Message Broker)"]
+        subgraph LB["Batch Layer"]
+            direction TB
+            HDFS["Hadoop HDFS (Raw Store)"] --> SPARK["Apache Spark (Batch)"]
+            SPARK --> BV["Batch Views (Druid/HBase)"]
+        end
+        subgraph LS["Speed Layer"]
+            direction TB
+            FLINK["Flink/Storm (Stream)"] --> RTV["RT Views (Redis/Cassandra)"]
+        end
+        LK --> HDFS
+        LK --> FLINK
+        BV --> SERVE["Serving Layer - Presto/Trino (Merge Views)"]
+        RTV --> SERVE
+    end
+
+    subgraph K["Kappa Architecture"]
+        direction TB
+        KK["Apache Kafka (Immutable Log / Long Retention)"]
+        SP["Stream Processor (Flink / Kafka Streams)"]
+        SS["Serving Store (Elasticsearch / Cassandra)"]
+        KK --> SP
+        SP --> SS
+        SP -.->|"Reprocessing (Log Replay from offset 0)"| KK
+    end
+
+    SRC --> LK
+    SRC --> KK
+    SERVE --> C["Data Consumers: Engineer / Analyst / App"]
+    SS --> C
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./data-arch-kappa-vs-lambda.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+  </div>
+</div>
+
+<h2>概要</h2>
+<p>
+  大規模データ処理における2つの代表的アーキテクチャパターン「Lambda Architecture」と「Kappa Architecture」を
+  同一キャンバス上で並列比較するUMLスタイルの構成図。データ生成者（UMLアクター）、メッセージブローカー（Kafka）、
+  処理エンジン（Spark/Flink）、ストレージ（シリンダー形状のDB）、利用者（アクター/アプリケーション）を
+  適切なUMLシェイプで表現し、全データフローを可視化している。
+</p>
+
+<div class="note">
+  <strong>Nathan Marzの提唱:</strong> Lambda ArchitectureはNathan Marzが2011年に提唱。
+  Batch LayerとSpeed Layerの二重構造で正確性とリアルタイム性を両立する。
+  Kappa ArchitectureはJay Krepsが2014年に提唱し、ストリーム処理のみで同等の結果を得るシンプル化を実現した。
+</div>
+
+<h2>構成要素</h2>
+<table>
+  <thead>
+    <tr><th>アーキテクチャ</th><th>コンポーネント</th><th>説明</th></tr>
+  </thead>
+  <tbody>
+    <tr><td rowspan="7">Lambda</td><td>Apache Kafka</td><td>メッセージブローカー。全データソースからのイベントを受信</td></tr>
+    <tr><td>Hadoop HDFS</td><td>バッチ層の生データストア。全履歴を永続保存</td></tr>
+    <tr><td>Apache Spark (Batch)</td><td>バッチ処理エンジン。大量データの一括変換・集計</td></tr>
+    <tr><td>Batch Views (Druid/HBase)</td><td>バッチ処理結果の事前集計ビュー</td></tr>
+    <tr><td>Apache Flink / Storm</td><td>スピード層のストリーム処理エンジン。低レイテンシ処理</td></tr>
+    <tr><td>Real-time Views (Redis)</td><td>ストリーム処理結果のリアルタイムビュー</td></tr>
+    <tr><td>Serving Layer (Presto)</td><td>Batch ViewsとRT Viewsをマージしてクエリに応答</td></tr>
+    <tr><td rowspan="3">Kappa</td><td>Apache Kafka (Immutable Log)</td><td>イミュータブルログ。長期保持設定で全履歴を保存</td></tr>
+    <tr><td>Stream Processor (Flink)</td><td>唯一の処理パス。全データをストリームとして処理</td></tr>
+    <tr><td>Serving Store (ES/Cassandra)</td><td>処理結果の配信ストア。クエリに直接応答</td></tr>
+  </tbody>
+</table>
+
+<h2>設計のポイント</h2>
+<ul>
+  <li><strong>Lambda: 二重パスの正確性保証</strong> — Batch Layerが全履歴から正確な結果を算出し、Speed Layerの近似結果を補正する。最終的整合性（eventual consistency）モデル。</li>
+  <li><strong>Kappa: 単一パスのシンプルさ</strong> — ストリーム処理のみで完結するため、コードベースが統一され運用負荷が低い。再処理はKafka Log Replay（offset 0から再消費）で実現。</li>
+  <li><strong>Kafkaの役割の違い</strong> — Lambdaではメッセージブローカーとして短期バッファ、Kappaではイミュータブルログとして長期保持。Kappaの成立にはKafkaの保持期間設定が鍵。</li>
+  <li><strong>適用判断の基準</strong> — 大量履歴の再計算が頻繁に必要→Lambda、イベント駆動でリアルタイム性重視→Kappa。多くのモダンシステムはKappa寄りに進化している。</li>
+</ul>
+
+<h2>学習ポイント</h2>
+<ul class="learning-points">
+  <li><strong>Batch/Speed二重管理のコスト</strong> — Lambda Architectureの最大の課題は、同一のビジネスロジックをBatch（Spark）とSpeed（Flink）の2つのフレームワークで実装・保守する必要がある点。これが技術的負債と運用負荷の主因となる。</li>
+  <li><strong>イミュータブルログの威力</strong> — Kappa ArchitectureはKafkaのイミュータブルログ（append-only、offset管理）を活用し、「再処理=新しいConsumerを過去のoffsetから再起動する」というシンプルなモデルで再計算を実現する。</li>
+  <li><strong>ストコン移行への示唆</strong> — コンビニストコンのPOSトランザクションデータは典型的なイベントストリーム。AWS移行時にKinesis Data Streams + Flink（Managed Service）でKappaパターンを適用すれば、リアルタイム売上集計と履歴分析を単一パイプラインで実現できる。</li>
+  <li><strong>Serving Layerの設計判断</strong> — LambdaのServing Layer（Presto/Trino）はBatch ViewsとRT Viewsのマージクエリを実行する。このマージロジックの複雑さがKappaへの移行動機の一つ。Kappaでは単一のServing Store（ES/Cassandra）に書き込むだけで済む。</li>
+  <li><strong>現代のハイブリッドアプローチ</strong> — 実務ではLambda/Kappaの純粋型ではなく、Delta Lake / Apache Iceberg等のLakehouseアーキテクチャが台頭。バッチとストリームの統合処理を単一フレームワーク（Spark Structured Streaming等）で実現する。</li>
+</ul>
+
+<p class="updated">Generated by /company-drawio &mdash; draw.io MCP Server</p>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: true, theme: 'default', securityLevel: 'loose' });
+</script>
+</body>
+</html>

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 12 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 13 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -81,6 +81,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <!-- ▲ 検索・フィルタ ここまで -->
 
 <div class="grid">
+<a href="./data-arch-kappa-vs-lambda.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🏗️</div>
+    <div class="card-title">Lambda vs Kappa アーキテクチャ比較</div>
+    <div class="card-meta">
+      <span class="tag tag-project">データ基盤</span>
+      <span class="tag tag-type" style="background:#8b5cf6;">UML Architecture</span>
+    </div>
+    <div class="card-desc">Lambda（Batch+Speed二重パス）とKappa（単一ストリームパス）の全データフローをUMLで比較</div>
+    <div class="card-date">2026-04-03</div>
+  </div>
+</a>
 <a href="./storcon-instore-system.html" class="card">
   <div class="card-body">
     <div class="card-icon">🏗️</div>


### PR DESCRIPTION
## Summary
- Lambda Architecture（Batch+Speed二重パス）とKappa Architecture（単一ストリームパス）の全データフローをUML形式で並列比較
- UMLアクター（Data Producer/Engineer/Analyst）、シリンダー（HDFS/Batch Views/RT Views/Serving Store）、コンポーネント（Kafka/Spark/Flink/Presto）を適切なシェイプで表現
- 比較サマリーテーブル（6観点: 複雑性/レイテンシ/再処理/コード管理/適用場面/代表ツール）を下部に配置
- 学習ポイント5項目（ストコン移行への示唆含む）

## draw.io エディタ
https://app.diagrams.net/?grid=0&pv=0&border=10&edit=_blank

## Judge評価
| 評価軸 | スコア |
|--------|--------|
| completeness | 9/10 |
| accuracy | 9/10 |
| clarity | 8/10 |
| **total** | **0.87** |

## Test plan
- [ ] draw.ioファイルがエディタで正しく開けることを確認
- [ ] HTMLページのMermaidプレビューが正しく表示されることを確認
- [ ] ギャラリーindex.htmlにカードが追加されていることを確認
- [ ] エッジ貫通レビュー 0件を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)