### PR TITLE
docs: 日次活動レポート 2026-04-03 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260403-100000-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260403-100000-daily-digest.md
@@ -55,3 +55,14 @@ judge_summary: "completeness 8/10, accuracy 9/10, clarity 9/10"
 | accuracy | 9/10 | 全記事にソースURLを付与。要約は各記事内容を正確に反映。クロスドメイン分析のSIer示唆も的確。 |
 | clarity | 9/10 | 品質ゲートのフォーマットテンプレートに完全準拠。テーブル形式・テーマ別分類・パラグラフ形式クロスドメイン分析と統一構成。 |
 | **total** | **0.87** | (8+9+9)/30 = 0.87 |
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-04-03T09:10:36"
+```

--- a/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
+++ b/.companies/domain-tech-collection/.task-log/20260403-110000-drawio-data-arch-comparison.md
@@ -52,3 +52,14 @@ judge_summary: "completeness 9/10, accuracy 9/10, clarity 8/10"
 | accuracy | 9/10 | 各ツールの役割・配置が正確。提唱者情報も正しい。 |
 | clarity | 8/10 | swimlane並列比較で構造明快。エッジ貫通0件。Batch/Speed視覚的グルーピングがやや弱い。 |
 | **total** | **0.87** | (9+9+8)/30 = 0.87 |
+
+## reward
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-04-03T09:49:24"
+```

--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-04-03-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-04-03-today.md
@@ -1,0 +1,116 @@
+# domain-tech-collection 活動レポート — 2026-04-03（日次）
+
+> 生成日時: 2026-04-03 | 生成者: SAS-Sasao | 期間: 2026-04-03
+
+## エグゼクティブサマリー
+
+本日はデータアーキテクチャの体系化に集中した1日となった。日次ダイジェストで技術・小売52記事を収集したのち、Lambda ArchitectureとKappa Architectureの比較を3段階で深掘り — (1) draw.ioでUML形式の汎用比較図、(2) AWSサービスにマッピングしたクラウド構成図 — を作成した。AWS構成図では初回レビューでElastiCache→Athena非互換を検出し、DynamoDBに修正して再レビューPassという品質改善サイクルも回せた。全タスクjudge評価0.87と安定した品質を維持。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 11 回 |
+| 完了タスク数 | 3 件 |
+| 作成・編集ファイル数 | 16 件 |
+| オープンIssue数（本日新規） | 3 件 |
+| クローズIssue数（本日） | 0 件 |
+| PR作成数 | 3 件（#204, #206, #208） |
+| 平均judge評価 | 0.87 |
+
+## 完了タスク
+
+### 1. 日次ダイジェスト 2026-04-03
+- **実行モード**: direct（秘書WebFetch並列実行）
+- **依頼**: 日次ダイジェスト対応を行ってほしい
+- **成果物**: [.companies/domain-tech-collection/docs/daily-digest/2026-04-03.md](../../daily-digest/2026-04-03.md)
+- **概要**: 優先度「高」8ソース中7ソースを並列WebFetchで巡回。技術31件+小売21件=計52件をテーマ別テーブル形式で整理。axiosサプライチェーン攻撃、Claude Code関連記事席巻が主要トピック。
+- **judge**: 0.87（completeness 8/10, accuracy 9/10, clarity 9/10）
+- **PR**: [#204](https://github.com/SAS-Sasao/cc-sier-organization/pull/204) / **Issue**: [#205](https://github.com/SAS-Sasao/cc-sier-organization/issues/205)
+
+### 2. draw.io Lambda vs Kappa アーキテクチャ比較図
+- **実行モード**: direct（/company-drawio Skill）
+- **依頼**: カッパアーキテクチャとラムダアーキテクチャの詳細比較図をUML形式で作成
+- **成果物**:
+  - [docs/drawio/data-arch-kappa-vs-lambda.drawio](../../../docs/drawio/data-arch-kappa-vs-lambda.drawio)
+  - [docs/drawio/data-arch-kappa-vs-lambda.html](../../../docs/drawio/data-arch-kappa-vs-lambda.html)
+- **概要**: 2つのswimlane（Lambda/Kappa）にUMLアクター・シリンダー・コンポーネントで全データフローを配置。エッジ貫通レビュー初回13件→修正→0件。比較サマリーテーブル（6観点）と学習ポイント5項目を含む。
+- **judge**: 0.87（completeness 9/10, accuracy 9/10, clarity 8/10）
+- **PR**: [#206](https://github.com/SAS-Sasao/cc-sier-organization/pull/206) / **Issue**: [#207](https://github.com/SAS-Sasao/cc-sier-organization/issues/207)
+
+### 3. AWS Lambda vs Kappa 構成図
+- **実行モード**: direct（/company-diagram Skill）
+- **依頼**: カッパアーキテクチャとラムダアーキテクチャの比較をAWS構成図にしてみて欲しい
+- **成果物**:
+  - [docs/diagrams/data-arch-lambda-vs-kappa-aws.png](../../../docs/diagrams/data-arch-lambda-vs-kappa-aws.png)
+  - [docs/diagrams/data-arch-lambda-vs-kappa-aws.html](../../../docs/diagrams/data-arch-lambda-vs-kappa-aws.html)
+  - [docs/diagrams/data-arch-lambda-vs-kappa-aws.yaml](../../../docs/diagrams/data-arch-lambda-vs-kappa-aws.yaml)（CloudFormation）
+  - [docs/diagrams/data-arch-lambda-vs-kappa-aws-iac.html](../../../docs/diagrams/data-arch-lambda-vs-kappa-aws-iac.html)
+- **概要**: draw.io比較図をAWSサービスにマッピング。Lambda Architecture（MSK+Glue+Redshift+Flink+DynamoDB+Athena）、Kappa Architecture（MSK+Flink+OpenSearch+DynamoDB）。AWSレビュー1回目Fail（ElastiCache→Athena非互換）→修正→2回目Pass(6/6)。コスト概算: Dev $221-492/mo, Prod $681-2,785/mo。CloudFormation YAML生成済み。
+- **judge**: 0.87（completeness 9/10, accuracy 9/10, clarity 8/10）
+- **PR**: [#208](https://github.com/SAS-Sasao/cc-sier-organization/pull/208) / **Issue**: [#209](https://github.com/SAS-Sasao/cc-sier-organization/issues/209)
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 組織ディレクトリ（.companies/domain-tech-collection/）
+| パス | 種別 |
+|------|------|
+| docs/daily-digest/2026-04-03.md | 日次ダイジェスト |
+| docs/drawio/data-arch-kappa-vs-lambda.md | draw.ioメタデータ |
+| .task-log/20260403-100000-daily-digest.md | タスクログ |
+| .task-log/20260403-110000-drawio-data-arch-comparison.md | タスクログ |
+| .task-log/20260403-120000-diagram-data-arch-comparison.md | タスクログ |
+
+### GitHub Pages（docs/）
+| パス | 種別 |
+|------|------|
+| docs/daily-digest/index.html | ダイジェストHTMLページ更新 |
+| docs/drawio/data-arch-kappa-vs-lambda.drawio | draw.io XMLソース |
+| docs/drawio/data-arch-kappa-vs-lambda.html | draw.io詳細ページ |
+| docs/drawio/index.html | draw.ioギャラリー更新 |
+| docs/diagrams/data-arch-lambda-vs-kappa-aws.png | AWS構成図PNG |
+| docs/diagrams/data-arch-lambda-vs-kappa-aws.html | AWS構成図詳細ページ |
+| docs/diagrams/data-arch-lambda-vs-kappa-aws.yaml | CloudFormation YAML |
+| docs/diagrams/data-arch-lambda-vs-kappa-aws-iac.html | IaCビューア |
+| docs/diagrams/index.html | AWS構成図ギャラリー更新 |
+| docs/index.html | トップページ更新 |
+
+## Issue 動向
+
+### 新規オープンのIssue（本日）
+- [#205](https://github.com/SAS-Sasao/cc-sier-organization/issues/205) [domain-tech-collection] 日次ダイジェスト 2026-04-03
+- [#207](https://github.com/SAS-Sasao/cc-sier-organization/issues/207) [domain-tech-collection] Lambda vs Kappa アーキテクチャ比較図
+- [#209](https://github.com/SAS-Sasao/cc-sier-organization/issues/209) [domain-tech-collection] Lambda vs Kappa AWS構成図
+
+### クローズされたIssue（本日）
+なし
+
+## 会話トピック
+
+### セッション ddaa18f4（本セッション）
+本日の全作業は単一セッション内で完結。以下の依頼が順次処理された:
+1. `/company` — 秘書起動、組織ダッシュボード表示
+2. 「日次ダイジェスト対応を行ってほしい」 — wf-daily-digest ワークフロー実行
+3. `/company-digest-html` — ダイジェストHTMLページ生成・GitHub Pages更新
+4. `/company-drawio` — Lambda vs Kappa 比較図をdraw.io XMLで作成
+5. `/company-diagram` — Lambda vs Kappa のAWS構成図を生成
+6. `/company-report` — 本レポートの生成
+
+### ファイル生成を伴わなかったやり取り
+- ブランチ削除依頼（3回） — PRマージ後のローカルブランチクリーンアップ
+
+## 次のアクション候補
+
+1. **ストコン移行案件へのKappaパターン適用検討**（根拠: 学習ポイントでKinesis→MSK→Flink→DynamoDB/OpenSearchのKappaパターンがコンビニPOSデータに最適と分析。2026年6月のPM参画前に具体設計を進めるべき）
+2. **axiosサプライチェーン攻撃への対応確認**（根拠: ダイジェストでaxios 3/31攻撃を検出。自組織のnpm依存関係にaxiosが含まれていないか確認が必要）
+3. **日次ダイジェストのAWS What's New対策**（根拠: 動的ページでWebFetch失敗が継続。RSSフィード経由やAWS Blog APIの活用を検討すべき）
+4. **draw.ioギャラリーの学習体系化**（根拠: 13件+1件=14件のdraw.io図が蓄積。データアーキテクチャ→アプリケーション→インフラの学習パスとして体系化すると効果的）
+5. **オープンIssueの棚卸し**（根拠: 本日3件を追加。累積Issueの優先度整理とクローズ判定が必要）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary
- 2026-04-03の日次活動レポートを自動生成
- 完了タスク3件（日次ダイジェスト、draw.io比較図、AWS構成図）
- 成果物16ファイル、PR 3件、Issue 3件を記録
- 平均judge評価 0.87

## 関連Issue
- #210 活動レポート

🤖 Generated with [Claude Code](https://claude.com/claude-code)