### PR TITLE
feat: ストコン移行 As-Is / To-Be 対比図を追加

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260404-193150-drawio-storcon-asis-tobe.md
+++ b/.companies/domain-tech-collection/.task-log/20260404-193150-drawio-storcon-asis-tobe.md
@@ -7,8 +7,8 @@ mode: "direct"
 started: "2026-04-04T19:31:50"
 completed: "2026-04-04T19:40:00"
 request: "ストコン移行 As-Is / To-Be 対比図を draw.io で作成"
-issue_number: null
-pr_number: null
+issue_number: 216
+pr_number: 215
 reward: 0.86
 subagent: "secretary"
 ---

--- a/.companies/domain-tech-collection/.task-log/20260404-193150-drawio-storcon-asis-tobe.md
+++ b/.companies/domain-tech-collection/.task-log/20260404-193150-drawio-storcon-asis-tobe.md
@@ -1,0 +1,53 @@
+---
+task_id: "20260404-193150-drawio-storcon-asis-tobe"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "direct"
+started: "2026-04-04T19:31:50"
+completed: "2026-04-04T19:40:00"
+request: "ストコン移行 As-Is / To-Be 対比図を draw.io で作成"
+issue_number: null
+pr_number: null
+reward: 0.86
+subagent: "secretary"
+---
+
+## 実行計画
+- **実行モード**: direct（/company-drawio Skill直接実行）
+- **アサインされたロール**: secretary
+- **参照したマスタ**: departments.md, workflows.md（wf-drawio-architecture）
+- **判断理由**: C4スタイルの対比図は draw.io XML による精密レイアウトが必要。壁打ちで合意済みの構成案をそのまま作図する
+
+## エージェント作業ログ
+
+### [2026-04-04 19:31] secretary
+受付: ストコン移行 As-Is / To-Be 対比図の作成依頼（壁打ちで構成合意済み）
+
+### [2026-04-04 19:31] secretary
+判断: direct実行、/company-drawio Skill で draw.io XML を生成
+
+### [2026-04-04 19:35] secretary
+成果物: docs/drawio/storcon-asis-tobe.drawio（draw.io XMLソース）
+成果物: docs/drawio/storcon-asis-tobe.html（詳細ページ）
+成果物: .companies/domain-tech-collection/docs/drawio/storcon-asis-tobe.md（メタデータ）
+
+### [2026-04-04 19:40] secretary
+完了: As-Is / To-Be 対比図の作成完了。エッジ貫通レビュー実施済み（親コンテナ内の構造的偽陽性のみ）
+
+## 成果物
+| ファイル | 作成者 | パス |
+|---------|--------|------|
+| draw.io XMLソース | secretary | docs/drawio/storcon-asis-tobe.drawio |
+| HTML詳細ページ | secretary | docs/drawio/storcon-asis-tobe.html |
+| メタデータ | secretary | .companies/domain-tech-collection/docs/drawio/storcon-asis-tobe.md |
+| 一覧ページ更新 | secretary | docs/drawio/index.html |
+
+## judge
+
+| 軸 | スコア | 評価 |
+|---|---|---|
+| completeness | 4/5 | As-Is 3層 + To-Be 全レイヤー網羅。セキュリティ詳細は省略 |
+| accuracy | 5/5 | 既存ドメイン知識ドキュメントと整合。移行フェーズもWBSと一致 |
+| clarity | 4/5 | 左右対比レイアウト + 番号マッピング + 凡例・課題/メリット注釈 |
+| **total** | **4.3/5** | 案件参画時の説明資料として十分な品質 |

--- a/.companies/domain-tech-collection/docs/drawio/storcon-asis-tobe.md
+++ b/.companies/domain-tech-collection/docs/drawio/storcon-asis-tobe.md
@@ -1,0 +1,45 @@
+---
+title: ストコン移行 As-Is / To-Be 対比図
+type: C4 Model
+project: ストコン移行
+tool: open_drawio_xml
+created: 2026-04-04
+---
+
+# ストコン移行 As-Is / To-Be 対比図
+
+コンビニエンスストアのストアコンピューターをオンプレミスからAWSクラウドへ移行する際の、現行構成（As-Is）と移行後構成（To-Be）を左右対比で可視化。中央に3フェーズの移行ステップ（Rehost → Replatform → Refactor）と主要コンポーネントの対応マッピングを示す。
+
+## 主要構成要素
+
+| カテゴリ | As-Is（オンプレ） | To-Be（AWS） |
+|---------|------------------|-------------|
+| アプリケーション | EOS/EOB発注管理（モノリス） | ECS/Fargate マイクロサービス（発注/在庫/売上/従業員） |
+| データベース | Oracle / SQL Server | Aurora + DynamoDB + ElastiCache + Redshift |
+| バッチ処理 | バッチサーバー（日次精算/棚卸） | Step Functions + AWS Batch |
+| DWH | オンプレDWH | Redshift |
+| ネットワーク | 専用回線 / VPN | Direct Connect + VPC (Multi-AZ) |
+| エッジ/セキュリティ | なし（閉域網で保護） | CloudFront + WAF + Cognito + Route 53 |
+| 監視 | なし（個別ツール） | CloudWatch + X-Ray |
+| 店舗端末 | 専用HW ストコン + ローカルDB | クラウド接続型ストコン + ローカルDB（オフライン耐性） + IoT Core |
+
+## 移行マッピング
+
+| # | As-Is | To-Be | 手法 |
+|---|-------|-------|------|
+| 1 | Oracle/SQL Server | Aurora | DMS + SCT |
+| 2 | EOS/EOB発注管理 | 発注サービス (ECS) | ストラングラーフィグ + コンテナ化 |
+| 3 | DWH | Redshift | S3バルクロード + CDC |
+
+## 設計の特徴
+
+- 3フェーズ段階移行（Rehost → Replatform → Refactor）でリスク最小化
+- オフライン耐性のローカルDB維持（差分同期で整合）
+- データ層の用途別最適化（ACID / NoSQL / Cache / DWH）
+- 温度監視のIoT Core移行（HACCP対応クラウド化）
+
+## 関連
+
+- 店舗内システム構成: [storcon-instore-system](storcon-instore-system.md)
+- UMLコンポーネント図: [storcon-uml-component](storcon-uml-component.md)
+- AWS構成図: [storcon-app-architecture](../diagrams/storcon-app-architecture.md)

--- a/docs/drawio/index.html
+++ b/docs/drawio/index.html
@@ -70,7 +70,7 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <a href="../" class="back-btn">&larr; トップに戻る</a>
 <h1>draw.io ダイアグラム一覧</h1>
 <p class="subtitle">draw.io MCP Server で生成したER図・フローチャート・シーケンス図等</p>
-<p class="count"><span id="match-count">0</span> / 13 件のダイアグラム</p>
+<p class="count"><span id="match-count">0</span> / 14 件のダイアグラム</p>
 
 <!-- ▼ 検索・フィルタ（カード追加時に編集不要） -->
 <div class="search-bar">
@@ -81,6 +81,18 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <!-- ▲ 検索・フィルタ ここまで -->
 
 <div class="grid">
+<a href="./storcon-asis-tobe.html" class="card">
+  <div class="card-body">
+    <div class="card-icon">🏗️</div>
+    <div class="card-title">ストコン移行 As-Is / To-Be 対比図</div>
+    <div class="card-meta">
+      <span class="tag tag-project">ストコン移行</span>
+      <span class="tag tag-type" style="background:#ef4444">C4 Model</span>
+    </div>
+    <div class="card-desc">オンプレミス現状とAWSクラウド移行後のシステム構成を左右対比。3フェーズ移行ステップ付き</div>
+    <div class="card-date">2026-04-04</div>
+  </div>
+</a>
 <a href="./data-arch-kappa-vs-lambda.html" class="card">
   <div class="card-body">
     <div class="card-icon">🏗️</div>

--- a/docs/drawio/storcon-asis-tobe.drawio
+++ b/docs/drawio/storcon-asis-tobe.drawio
@@ -1,0 +1,393 @@
+<mxGraphModel dx="2000" dy="1400" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="2400" pageHeight="1600" math="0" shadow="0">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+
+    <!-- ========== TITLE ========== -->
+    <mxCell id="title" value="ストアコンピューター クラウド移行 ― As-Is / To-Be 対比図" style="text;html=1;fontSize=20;fontStyle=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#1e293b;" vertex="1" parent="1">
+      <mxGeometry x="600" y="20" width="800" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="subtitle" value="コンビニエンスストア ストコン ― オンプレミス → AWS 移行アーキテクチャ" style="text;html=1;fontSize=12;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#64748b;" vertex="1" parent="1">
+      <mxGeometry x="600" y="55" width="800" height="25" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== AS-IS CONTAINER (LEFT) ========== -->
+    <mxCell id="asis" value="As-Is: オンプレミス構成" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;verticalAlign=top;fontStyle=1;fontSize=14;spacingTop=5;dashed=1;arcSize=6;" vertex="1" parent="1">
+      <mxGeometry x="40" y="100" width="520" height="860" as="geometry"/>
+    </mxCell>
+
+    <!-- HQ DC -->
+    <mxCell id="asis_hq" value="本部データセンター" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;verticalAlign=top;fontStyle=1;fontSize=11;startSize=28;" vertex="1" parent="1">
+      <mxGeometry x="70" y="140" width="460" height="280" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_master" value="商品マスタ管理" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="90" y="180" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_eos" value="EOS/EOB&#xa;発注管理" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="230" y="180" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_logistics" value="在庫管理&#xa;物流システム" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="370" y="180" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_accounting" value="会計&#xa;経営管理" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="90" y="240" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_dwh" value="DWH&#xa;売上分析/需要予測" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="230" y="240" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_batch" value="バッチサーバー&#xa;日次精算/棚卸" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="370" y="240" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_onpre_db" value="オンプレDB&#xa;(Oracle/SQL Server)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="120" y="310" width="140" height="50" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_file" value="ファイルサーバー&#xa;(NAS/SAN)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="310" y="310" width="140" height="50" as="geometry"/>
+    </mxCell>
+
+    <!-- Network -->
+    <mxCell id="asis_net" value="専用回線 / VPN" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="140" y="440" width="320" height="35" as="geometry"/>
+    </mxCell>
+
+    <!-- Store Layer -->
+    <mxCell id="asis_store" value="店舗 (数千〜数万店舗)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;verticalAlign=top;fontStyle=1;fontSize=11;startSize=28;" vertex="1" parent="1">
+      <mxGeometry x="70" y="500" width="460" height="200" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_storcon" value="ストアコンピューター&#xa;(専用HW)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="190" y="540" width="140" height="45" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_pos" value="POSレジ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="90" y="610" width="90" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_payment" value="決済端末" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="200" y="610" width="90" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_handy" value="ハンディ端末" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="310" y="610" width="90" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_temp" value="温度監視" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="420" y="610" width="90" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_localdb" value="ローカルDB" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="355" y="540" width="80" height="40" as="geometry"/>
+    </mxCell>
+
+    <!-- External Services -->
+    <mxCell id="asis_ext" value="物流・サービス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="70" y="730" width="460" height="80" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_delivery" value="配送センター" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="90" y="762" width="120" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_payment_ext" value="収納代行" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="230" y="762" width="120" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="asis_ticket" value="チケット発券" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="370" y="762" width="120" height="35" as="geometry"/>
+    </mxCell>
+
+    <!-- As-Is Issues callout -->
+    <mxCell id="asis_issues" value="&lt;b&gt;課題&lt;/b&gt;&#xa;- HW老朽化・保守コスト増大&#xa;- スケール困難（ピーク時性能限界）&#xa;- DR構成が高コスト&#xa;- デプロイに長期リードタイム&#xa;- 店舗HW障害時の復旧遅延" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;size=15;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;align=left;spacingLeft=8;spacingTop=2;" vertex="1" parent="1">
+      <mxGeometry x="80" y="840" width="210" height="100" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== MIGRATION ARROW (CENTER) ========== -->
+    <mxCell id="migration_arrow" value="" style="shape=mxgraph.arrows2.arrow;dy=0.6;dx=40;notch=0;fillColor=#FF6D00;strokeColor=#C63F17;rotation=0;" vertex="1" parent="1">
+      <mxGeometry x="570" y="280" width="60" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="migration_label" value="&lt;b&gt;移行&lt;/b&gt;" style="text;html=1;fontSize=13;fontStyle=0;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#C63F17;" vertex="1" parent="1">
+      <mxGeometry x="565" y="250" width="70" height="25" as="geometry"/>
+    </mxCell>
+
+    <!-- Migration Phases -->
+    <mxCell id="phase_box" value="移行ステップ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;verticalAlign=top;fontStyle=1;fontSize=11;startSize=22;dashed=1;" vertex="1" parent="1">
+      <mxGeometry x="565" y="340" width="80" height="210" as="geometry"/>
+    </mxCell>
+    <mxCell id="phase1" value="Phase 1&#xa;Rehost" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="572" y="370" width="66" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="phase2" value="Phase 2&#xa;Replatform" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="572" y="420" width="66" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="phase3" value="Phase 3&#xa;Refactor" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="572" y="470" width="66" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="phase_arrow1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;strokeColor=#666666;fontSize=9;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="phase1" target="phase2" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="phase_arrow2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;strokeColor=#666666;fontSize=9;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="phase2" target="phase3" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="strangler" value="ストラングラー&#xa;フィグパターン" style="text;html=1;fontSize=8;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#666666;fontStyle=2;" vertex="1" parent="1">
+      <mxGeometry x="560" y="520" width="90" height="30" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== TO-BE CONTAINER (RIGHT) ========== -->
+    <mxCell id="tobe" value="To-Be: AWS クラウド構成" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e6f3ff;strokeColor=#3b82f6;verticalAlign=top;fontStyle=1;fontSize=14;spacingTop=5;dashed=1;arcSize=6;" vertex="1" parent="1">
+      <mxGeometry x="660" y="100" width="560" height="860" as="geometry"/>
+    </mxCell>
+
+    <!-- Edge & Security -->
+    <mxCell id="tobe_edge" value="エッジ・セキュリティ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="140" width="500" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_cf" value="CloudFront&#xa;(CDN)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="710" y="170" width="100" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_waf" value="WAF&#xa;(Firewall)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="830" y="170" width="100" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_cognito" value="Cognito&#xa;(認証)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="950" y="170" width="100" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_r53" value="Route 53&#xa;(DNS)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1070" y="170" width="100" height="30" as="geometry"/>
+    </mxCell>
+
+    <!-- API Layer -->
+    <mxCell id="tobe_api" value="API レイヤー" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="220" width="500" height="55" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_apigw" value="API Gateway (REST/WebSocket)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="810" y="248" width="220" height="22" as="geometry"/>
+    </mxCell>
+
+    <!-- Compute - Microservices -->
+    <mxCell id="tobe_compute" value="コンピュート (ECS/Fargate マイクロサービス)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="290" width="500" height="80" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_order" value="発注&#xa;サービス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="710" y="320" width="100" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_inv" value="在庫&#xa;サービス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="830" y="320" width="100" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_sales" value="売上&#xa;サービス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="950" y="320" width="100" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_staff" value="従業員&#xa;サービス" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1070" y="320" width="100" height="40" as="geometry"/>
+    </mxCell>
+
+    <!-- Async Processing -->
+    <mxCell id="tobe_async" value="非同期処理" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="385" width="240" height="75" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_sqs" value="SQS&#xa;(FIFO/Standard)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="710" y="415" width="100" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_lambda" value="Lambda&#xa;(イベント処理)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="830" y="415" width="80" height="35" as="geometry"/>
+    </mxCell>
+
+    <!-- Batch -->
+    <mxCell id="tobe_batch_grp" value="バッチ処理" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="950" y="385" width="240" height="75" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_stepfn" value="Step Functions&#xa;(オーケストレーション)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="960" y="415" width="100" height="35" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_awsbatch" value="AWS Batch&#xa;(日次集計)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1080" y="415" width="90" height="35" as="geometry"/>
+    </mxCell>
+
+    <!-- Data Layer -->
+    <mxCell id="tobe_data" value="データレイヤー (Multi-AZ)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="480" width="500" height="90" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_aurora" value="Aurora&#xa;(トランザクション)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="710" y="510" width="100" height="45" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_dynamo" value="DynamoDB&#xa;(商品マスタ)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="830" y="510" width="100" height="45" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_redis" value="ElastiCache&#xa;(Redis)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="950" y="510" width="100" height="45" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_redshift" value="Redshift&#xa;(DWH/分析)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1070" y="510" width="100" height="45" as="geometry"/>
+    </mxCell>
+
+    <!-- Storage -->
+    <mxCell id="tobe_storage" value="ストレージ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="690" y="585" width="240" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_s3" value="S3 (レポート/ログ)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="710" y="614" width="100" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_glacier" value="Glacier (アーカイブ)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="830" y="614" width="80" height="30" as="geometry"/>
+    </mxCell>
+
+    <!-- Monitoring -->
+    <mxCell id="tobe_monitor" value="監視・運用" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f0f0f0;strokeColor=#666666;verticalAlign=top;fontStyle=1;fontSize=11;startSize=25;" vertex="1" parent="1">
+      <mxGeometry x="950" y="585" width="240" height="65" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_cw" value="CloudWatch" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#666666;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="965" y="615" width="90" height="28" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_xray" value="X-Ray" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#666666;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1075" y="615" width="90" height="28" as="geometry"/>
+    </mxCell>
+
+    <!-- Network -->
+    <mxCell id="tobe_net" value="Direct Connect / VPN + VPC (Multi-AZ)" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="690" y="670" width="500" height="35" as="geometry"/>
+    </mxCell>
+
+    <!-- Store (To-Be) -->
+    <mxCell id="tobe_store" value="店舗 (クラウド接続 + オフライン耐性)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;verticalAlign=top;fontStyle=1;fontSize=11;startSize=28;" vertex="1" parent="1">
+      <mxGeometry x="690" y="725" width="500" height="130" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_storcon2" value="ストコン端末&#xa;(クラウド接続型)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="710" y="762" width="120" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_localdb2" value="ローカルDB&#xa;(オフライン)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="850" y="762" width="80" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_pos2" value="POS" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="950" y="762" width="60" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_payment2" value="決済" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1020" y="762" width="60" height="30" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_iot" value="IoT Core&#xa;(温度/センサー)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+      <mxGeometry x="1090" y="762" width="80" height="40" as="geometry"/>
+    </mxCell>
+    <mxCell id="tobe_sync" value="差分同期" style="text;html=1;fontSize=8;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#6c8ebf;fontStyle=2;" vertex="1" parent="1">
+      <mxGeometry x="840" y="808" width="60" height="15" as="geometry"/>
+    </mxCell>
+
+    <!-- To-Be Benefits callout -->
+    <mxCell id="tobe_benefits" value="&lt;b&gt;メリット&lt;/b&gt;&#xa;- Auto Scaling でピーク対応&#xa;- Multi-AZ / DR が標準&#xa;- マイクロサービスで独立デプロイ&#xa;- IaC による再現性&#xa;- 従量課金でコスト最適化" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;size=15;fillColor=#e6f3ff;strokeColor=#3b82f6;fontSize=9;align=left;spacingLeft=8;spacingTop=2;" vertex="1" parent="1">
+      <mxGeometry x="690" y="870" width="210" height="100" as="geometry"/>
+    </mxCell>
+
+    <!-- CI/CD callout -->
+    <mxCell id="tobe_cicd" value="&lt;b&gt;CI/CD&lt;/b&gt;&#xa;CodePipeline → CodeBuild&#xa;→ ECR → ECS Blue/Green" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;size=15;fillColor=#e6f3ff;strokeColor=#3b82f6;fontSize=9;align=left;spacingLeft=8;spacingTop=2;" vertex="1" parent="1">
+      <mxGeometry x="920" y="870" width="180" height="60" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== EDGES: As-Is ========== -->
+    <mxCell id="e_hq_net" style="strokeColor=#b85450;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_hq" target="asis_net" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_net_store" style="strokeColor=#6c8ebf;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_net" target="asis_store" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_sc_pos" style="strokeColor=#6c8ebf;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_storcon" target="asis_pos" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_sc_pay" style="strokeColor=#6c8ebf;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_storcon" target="asis_payment" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_sc_handy" style="strokeColor=#6c8ebf;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_storcon" target="asis_handy" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_store_ext" style="strokeColor=#82b366;strokeWidth=1;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="asis_store" target="asis_ext" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== EDGES: To-Be ========== -->
+    <mxCell id="e_edge_api" style="strokeColor=#9673a6;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_edge" target="tobe_api" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_api_compute" style="strokeColor=#6c8ebf;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_api" target="tobe_compute" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_compute_async" style="strokeColor=#82b366;strokeWidth=1;dashed=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_compute" target="tobe_async" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_compute_batch" style="strokeColor=#82b366;strokeWidth=1;dashed=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_compute" target="tobe_batch_grp" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_compute_data" style="strokeColor=#d6b656;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_async" target="tobe_data" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_batch_data" style="strokeColor=#d6b656;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_batch_grp" target="tobe_data" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_data_storage" style="strokeColor=#d6b656;strokeWidth=1;dashed=1;exitX=0.15;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_data" target="tobe_storage" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_data_monitor" style="strokeColor=#666666;strokeWidth=1;dashed=1;exitX=0.85;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_data" target="tobe_monitor" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_storage_net" style="strokeColor=#9673a6;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_storage" target="tobe_net" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_monitor_net" style="strokeColor=#9673a6;strokeWidth=1;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_monitor" target="tobe_net" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="e_net_store2" style="strokeColor=#6c8ebf;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="tobe_net" target="tobe_store" parent="1">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+
+    <!-- ========== AS-IS ↔ TO-BE MAPPING ANNOTATIONS ========== -->
+    <mxCell id="map1" value="&lt;b style='color:#C63F17'&gt;1&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="245" y="318" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="map1b" value="&lt;b style='color:#C63F17'&gt;1&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="695" y="518" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="map2" value="&lt;b style='color:#C63F17'&gt;2&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="335" y="185" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="map2b" value="&lt;b style='color:#C63F17'&gt;2&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="695" y="328" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="map3" value="&lt;b style='color:#C63F17'&gt;3&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="335" y="245" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <mxCell id="map3b" value="&lt;b style='color:#C63F17'&gt;3&lt;/b&gt;" style="text;html=1;fontSize=11;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="1155" y="518" width="20" height="20" as="geometry"/>
+    </mxCell>
+    <!-- Mapping Legend -->
+    <mxCell id="map_legend" value="&lt;b&gt;移行マッピング&lt;/b&gt;&#xa;1 Oracle/SQL Server → Aurora (DMS/SCT)&#xa;2 EOS/EOB発注管理 → 発注サービス (コンテナ化)&#xa;3 DWH → Redshift (データ移行)" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;size=15;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;align=left;spacingLeft=8;spacingTop=2;fontColor=#C63F17;" vertex="1" parent="1">
+      <mxGeometry x="330" y="840" width="230" height="80" as="geometry"/>
+    </mxCell>
+
+    <!-- Legend -->
+    <mxCell id="legend" value="凡例" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;verticalAlign=top;fontStyle=1;fontSize=11;startSize=20;" vertex="1" parent="1">
+      <mxGeometry x="1240" y="100" width="150" height="180" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg1" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="130" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg1t" value="本部/セキュリティ" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="128" width="100" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg2" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="152" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg2t" value="ネットワーク/API" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="150" width="100" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="174" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg3t" value="コンピュート/店舗" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="172" width="100" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg4" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="196" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg4t" value="非同期/外部" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="194" width="100" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg5" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="218" width="20" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg5t" value="データ/ストレージ" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="216" width="100" height="18" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg6" value="&lt;b&gt;1&lt;/b&gt;" style="text;html=1;fontSize=9;align=center;verticalAlign=middle;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontColor=#C63F17;" vertex="1" parent="1">
+      <mxGeometry x="1258" y="241" width="14" height="14" as="geometry"/>
+    </mxCell>
+    <mxCell id="leg6t" value="移行マッピング" style="text;html=1;fontSize=9;align=left;fillColor=none;strokeColor=none;fontColor=#C63F17;" vertex="1" parent="1">
+      <mxGeometry x="1280" y="240" width="100" height="18" as="geometry"/>
+    </mxCell>
+
+  </root>
+</mxGraphModel>

--- a/docs/drawio/storcon-asis-tobe.html
+++ b/docs/drawio/storcon-asis-tobe.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ストコン移行 As-Is / To-Be 対比図 - draw.io ダイアグラム</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:960px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.5rem; margin-bottom:8px; }
+.meta { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-type { background:#ef4444; color:#fff; }
+.tag-project { background:#fef3c7; color:#92400e; }
+.tag-wbs { background:#dcfce7; color:#166534; }
+@media (prefers-color-scheme: dark) {
+  .tag-project { background:#78350f; color:#fde68a; }
+  .tag-wbs { background:#14532d; color:#bbf7d0; }
+}
+.date { font-size:.82rem; color:var(--muted); margin-bottom:24px; }
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; text-align:center; }
+.diagram-render { overflow-x:auto; }
+.diagram-render svg { max-width:100%; height:auto; }
+.diagram-actions { display:flex; gap:12px; justify-content:center; margin-top:16px; }
+.dl-btn { display:inline-block; padding:8px 20px; border-radius:8px; background:var(--blue);
+          color:#fff; text-decoration:none; font-size:.88rem; font-weight:600; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+h2 { font-size:1.15rem; margin:32px 0 12px; border-bottom:1px solid var(--border); padding-bottom:6px; }
+p, li { font-size:.9rem; line-height:1.7; }
+ul { padding-left:24px; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; margin:12px 0 24px; font-size:.85rem; }
+th { background:var(--bg); text-align:left; padding:8px 12px; border:1px solid var(--border); font-weight:600; }
+td { padding:8px 12px; border:1px solid var(--border); }
+tr:nth-child(even) td { background:var(--bg); }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+.section { margin-bottom:24px; }
+.learning-points { list-style: none; padding: 0; }
+.learning-points li { padding: 10px 0; border-bottom: 1px solid #e2e8f0; line-height: 1.7; font-size:.9rem; }
+.learning-points li:last-child { border-bottom: none; }
+.learning-points li strong { color: #1e40af; }
+@media (prefers-color-scheme: dark) {
+  .learning-points li { border-bottom-color: rgba(255,255,255,.08); }
+  .learning-points li strong { color: #93c5fd; }
+}
+</style>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({startOnLoad:true, theme:'neutral', securityLevel:'loose'});
+</script>
+</head>
+<body>
+<a href="./index.html" class="back-btn">&larr; 一覧に戻る</a>
+
+<h1>ストコン移行 As-Is / To-Be 対比図</h1>
+<div class="meta">
+  <span class="tag tag-project">ストコン移行</span>
+  <span class="tag tag-type">C4 Model</span>
+</div>
+<div class="date">生成日: 2026-04-04 | オンプレミス現状とAWSクラウド移行後のシステム構成対比</div>
+
+<div class="diagram-container">
+  <div class="diagram-render">
+    <pre class="mermaid">
+graph LR
+  subgraph ASIS["As-Is: オンプレミス"]
+    direction TB
+    subgraph HQ["本部DC"]
+      MASTER_A["商品マスタ管理"]
+      EOS_A["EOS/EOB 発注管理"]
+      DWH_A["DWH 売上分析"]
+      BATCH_A["バッチサーバー"]
+      DB_A[("Oracle / SQL Server")]
+    end
+    NET_A["専用回線 / VPN"]
+    subgraph STORE_A["店舗"]
+      SC_A["ストコン 専用HW"]
+      POS_A["POS"]
+      PAY_A["決済端末"]
+    end
+    HQ --> NET_A --> STORE_A
+  end
+
+  subgraph MIGRATION["移行"]
+    direction TB
+    P1["Phase1 Rehost"]
+    P2["Phase2 Replatform"]
+    P3["Phase3 Refactor"]
+    P1 --> P2 --> P3
+  end
+
+  subgraph TOBE["To-Be: AWS クラウド"]
+    direction TB
+    subgraph EDGE["エッジ/セキュリティ"]
+      CF["CloudFront"] --- WAF["WAF"] --- COGNITO["Cognito"]
+    end
+    APIGW["API Gateway"]
+    subgraph COMPUTE["ECS/Fargate"]
+      SVC_ORD["発注"] --- SVC_INV["在庫"] --- SVC_SALES["売上"] --- SVC_STAFF["従業員"]
+    end
+    subgraph DATA["データ層 Multi-AZ"]
+      AURORA[("Aurora")] --- DYNAMO[("DynamoDB")] --- REDIS[("ElastiCache")] --- RS[("Redshift")]
+    end
+    NET_B["Direct Connect / VPC"]
+    subgraph STORE_B["店舗"]
+      SC_B["ストコン クラウド接続型"]
+      LOCAL_B[("ローカルDB")]
+      IOT_B["IoT Core"]
+    end
+    EDGE --> APIGW --> COMPUTE --> DATA
+    NET_B --> STORE_B
+  end
+
+  ASIS --> MIGRATION --> TOBE
+    </pre>
+  </div>
+  <div class="diagram-actions">
+    <a href="./storcon-asis-tobe.drawio" download class="dl-btn">draw.io XML をダウンロード</a>
+  </div>
+</div>
+
+<div class="section">
+  <h2>概要</h2>
+  <p>コンビニエンスストアのストアコンピューター（ストコン）をオンプレミスからAWSクラウドへ移行する際の、現行構成（As-Is）と移行後構成（To-Be）を左右対比で可視化した図。中央に3フェーズの移行ステップ（Rehost → Replatform → Refactor）と主要コンポーネントの対応関係を示す。</p>
+</div>
+
+<div class="section">
+  <h2>構成要素</h2>
+
+  <h3 style="font-size:.95rem; margin:16px 0 8px;">As-Is（オンプレミス）</h3>
+  <table>
+    <tr><th>要素</th><th>種類</th><th>説明</th></tr>
+    <tr><td>本部データセンター</td><td>コンテナ</td><td>商品マスタ管理、EOS/EOB発注管理、DWH、バッチサーバー、会計システムを集約</td></tr>
+    <tr><td>オンプレDB (Oracle/SQL Server)</td><td>データベース</td><td>トランザクション・マスタデータを一元管理するRDBMS</td></tr>
+    <tr><td>専用回線 / VPN</td><td>ネットワーク</td><td>本部DCと店舗を接続する閉域網</td></tr>
+    <tr><td>ストアコンピューター（専用HW）</td><td>店舗端末</td><td>店舗の全業務を統合制御するハブ。POS・決済端末・ハンディ端末・温度監視と接続</td></tr>
+    <tr><td>物流・サービス</td><td>外部連携</td><td>配送センター、収納代行、チケット発券との接続</td></tr>
+  </table>
+
+  <h3 style="font-size:.95rem; margin:16px 0 8px;">To-Be（AWSクラウド）</h3>
+  <table>
+    <tr><th>要素</th><th>種類</th><th>説明</th></tr>
+    <tr><td>CloudFront + WAF + Cognito + Route 53</td><td>エッジ・セキュリティ</td><td>CDN配信、ファイアウォール、認証、DNS管理</td></tr>
+    <tr><td>API Gateway</td><td>APIレイヤー</td><td>REST/WebSocket APIの統合ゲートウェイ</td></tr>
+    <tr><td>ECS/Fargate マイクロサービス</td><td>コンピュート</td><td>発注・在庫・売上・従業員の4サービスに分割</td></tr>
+    <tr><td>SQS + Lambda</td><td>非同期処理</td><td>FIFO/Standardキューとイベント駆動処理</td></tr>
+    <tr><td>Step Functions + AWS Batch</td><td>バッチ処理</td><td>日次集計・棚卸のオーケストレーション</td></tr>
+    <tr><td>Aurora / DynamoDB / ElastiCache / Redshift</td><td>データレイヤー</td><td>Multi-AZ構成。用途別にDB最適化（ACID / NoSQL / Cache / DWH）</td></tr>
+    <tr><td>S3 + Glacier</td><td>ストレージ</td><td>レポート・ログの永続化とアーカイブ</td></tr>
+    <tr><td>CloudWatch + X-Ray</td><td>監視</td><td>メトリクス・ログ・分散トレーシング</td></tr>
+    <tr><td>Direct Connect + VPC (Multi-AZ)</td><td>ネットワーク</td><td>専用線接続とVPC内ネットワーク分離</td></tr>
+    <tr><td>ストコン端末（クラウド接続型）+ ローカルDB</td><td>店舗端末</td><td>クラウド接続 + オフライン耐性（差分同期）</td></tr>
+    <tr><td>IoT Core</td><td>店舗IoT</td><td>温度センサー・機器監視のクラウド連携</td></tr>
+  </table>
+</div>
+
+<div class="section">
+  <h2>移行マッピング</h2>
+  <table>
+    <tr><th>#</th><th>As-Is</th><th>To-Be</th><th>移行手法</th></tr>
+    <tr><td>1</td><td>Oracle / SQL Server</td><td>Aurora (MySQL/PostgreSQL)</td><td>DMS (Database Migration Service) + SCT (Schema Conversion Tool)</td></tr>
+    <tr><td>2</td><td>EOS/EOB 発注管理（モノリス）</td><td>発注サービス (ECS/Fargate)</td><td>ストラングラーフィグパターンでコンテナ化</td></tr>
+    <tr><td>3</td><td>DWH（オンプレ）</td><td>Redshift</td><td>S3経由バルクロード + CDC連携</td></tr>
+  </table>
+</div>
+
+<div class="section">
+  <h2>設計のポイント</h2>
+  <ul>
+    <li><strong>段階的移行（3フェーズ）</strong> ― Phase 1: Rehost（EC2へのLift&Shift）でリスク最小化 → Phase 2: Replatform（コンテナ化・マネージドDB化）→ Phase 3: Refactor（マイクロサービス＋イベント駆動化）</li>
+    <li><strong>オフライン耐性の維持</strong> ― 移行後もローカルDBを維持し、店舗ネットワーク障害時の業務継続を保証。差分同期で復旧時にクラウドと整合</li>
+    <li><strong>データ層の用途別最適化</strong> ― 単一RDBMSからAurora（ACID）、DynamoDB（高頻度アクセス）、ElastiCache（キャッシュ）、Redshift（分析）に分割し、各ワークロードに最適化</li>
+    <li><strong>温度監視のIoT化</strong> ― 既存の店舗内温度監視をIoT Coreに移行し、センサーデータのクラウド収集・異常検知を実現</li>
+  </ul>
+</div>
+
+<div class="section">
+  <h2>学習ポイント</h2>
+  <ul class="learning-points">
+    <li><strong>7R移行戦略の段階的適用</strong> ― 24/365稼働のシステムでは一括移行は高リスク。Rehost→Replatform→Refactorの段階適用が王道パターン。各フェーズでロールバック可能な状態を維持する</li>
+    <li><strong>モノリスからマイクロサービスへの分解基準</strong> ― ストコンの業務機能（発注・在庫・売上・従業員）はそれぞれ独立したビジネスドメインを持つ。ドメイン境界に沿った分割がマイクロサービス設計の基本</li>
+    <li><strong>ハイブリッド期間の設計</strong> ― 移行期間中はオンプレとAWSが共存する。Direct Connectによる専用線接続と、ストラングラーフィグパターンによるAPIルーティング層が共存を可能にする</li>
+    <li><strong>非機能要件の移行先マッピング</strong> ― 24/365可用性 → Multi-AZ + Auto Scaling、PCI DSS → WAF + KMS + GuardDuty、スケーラビリティ → SQS背圧制御 + DynamoDB On-Demand。As-Isの課題がTo-Beのどの要素で解消されるかを対応付けることが重要</li>
+    <li><strong>エッジコンピューティングの継続</strong> ― クラウド移行後もローカルDBを残す設計は、コンビニ特有のオフライン耐性要件に起因する。すべてをクラウドに寄せるのではなく、業務継続要件に応じたエッジ処理の残し方が実案件では問われる</li>
+  </ul>
+</div>
+
+<p class="updated">最終更新: 2026-04-04 | 作成者: secretary</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ストコン移行の As-Is（オンプレ）/ To-Be（AWS）対比図を draw.io XML で新規作成
- 3フェーズ移行ステップ（Rehost → Replatform → Refactor）と番号マッピングで対応関係を明示
- HTML詳細ページ（学習ポイント5項目付き）と一覧ページへのカード追加

## 成果物
| ファイル | 内容 |
|---------|------|
| `docs/drawio/storcon-asis-tobe.drawio` | draw.io XMLソース |
| `docs/drawio/storcon-asis-tobe.html` | 詳細ページ（Mermaidプレビュー + ダウンロードボタン） |
| `docs/drawio/index.html` | 一覧ページ（カード追加、14件に更新） |
| `.companies/domain-tech-collection/docs/drawio/storcon-asis-tobe.md` | メタデータ |

## draw.io エディタ
https://app.diagrams.net/ でXMLファイルをインポートして編集可能

## Judge 評価
| 軸 | スコア |
|---|---|
| completeness | 4/5 |
| accuracy | 5/5 |
| clarity | 4/5 |
| **total** | **4.3/5** |

## Test plan
- [ ] `docs/drawio/storcon-asis-tobe.html` をブラウザで開き、Mermaidプレビューが表示されることを確認
- [ ] `.drawio` ファイルをダウンロードし���draw.ioアプリで開けることを確認
- [ ] 一覧ページ（`docs/drawio/index.html`）でカードが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)