### PR TITLE
feat: 日次ダイジェスト 2026-04-05（102記事）

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260405-114749-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260405-114749-daily-digest.md
@@ -7,8 +7,8 @@ mode: "agent-teams"
 started: "2026-04-05T11:47:49"
 completed: "2026-04-05T12:07:00"
 request: "日次ダイジェスト対応"
-issue_number: null
-pr_number: null
+issue_number: 221
+pr_number: 220
 subagents: ["tech-researcher (general-purpose)", "retail-domain-researcher (general-purpose)"]
 ---
 

--- a/.companies/domain-tech-collection/.task-log/20260405-114749-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260405-114749-daily-digest.md
@@ -1,0 +1,71 @@
+---
+task_id: "20260405-114749-daily-digest"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "agent-teams"
+started: "2026-04-05T11:47:49"
+completed: "2026-04-05T12:07:00"
+request: "日次ダイジェスト対応"
+issue_number: null
+pr_number: null
+subagents: ["tech-researcher (general-purpose)", "retail-domain-researcher (general-purpose)"]
+---
+
+## 実行計画
+- **実行モード**: agent-teams（wf-daily-digest）
+- **アサインされたロール**: secretary（チームリード）, tech-researcher, retail-domain-researcher
+- **参照したマスタ**: workflows.md (wf-daily-digest), info-source-master.md, quality-gates/by-type/daily-digest.md
+- **判断理由**: wf-daily-digestワークフローに一致。定義通りAgent Teams方式で実行
+
+## エージェント作業ログ
+
+### [2026-04-05 11:47] secretary
+受付: 日次ダイジェスト生成依頼（2026-04-05分）
+
+### [2026-04-05 11:47] secretary
+判断: agent-teams方式。tech-researcher + retail-domain-researcher を並列巡回、secretaryが統合
+
+### [2026-04-05 11:48] secretary → tech-researcher
+委譲: 技術系ソース（優先度「高」中心）のWebFetch巡回・記事収集
+
+### [2026-04-05 11:48] secretary → retail-domain-researcher
+委譲: 小売ドメイン系ソース（優先度「高」中心）のWebFetch巡回・記事収集
+
+### [2026-04-05 12:00] tech-researcher
+完了: 技術系ソース14件巡回、71記事収集（成功7、補完5、失敗2）。A1〜A6テーマ別に分類
+
+### [2026-04-05 12:00] retail-domain-researcher
+完了: 小売ドメイン系ソース11件巡回、57記事収集（成功7、一部成功2、失敗2）。B1〜B6テーマ別に分類
+
+### [2026-04-05 12:05] secretary
+完了: 両チーム結果を統合しダイジェスト生成。品質ゲート全項目PASS。最終102記事（技術59+小売43）
+
+## 成果物
+| ファイル | 作成者 | パス |
+|---------|--------|------|
+| 日次ダイジェスト 2026-04-05 | secretary（統合） | .companies/domain-tech-collection/docs/daily-digest/2026-04-05.md |
+
+## judge
+
+### completeness: 4/5
+優先度「高」ソースは全て巡回済み。優先度「中」も大半をカバー。ITmedia・セブン＆アイ・Retail Tech Japanの3ソースが取得不可だったが理由明記で許容範囲。ロジスティクス・トゥデイの記事5件をB章に含めなかった点は若干の網羅性低下。
+
+### accuracy: 4/5
+記事タイトル・URLは各ソースのWebFetch/WebSearch結果に基づく。一部WebSearch補完ソースは記事日付が直近数日〜数週間のものを含む可能性があるが、ダイジェスト品質としては許容範囲。フィッシング対策記事がB6に重複掲載（ネットショップ担当者F + ECのミカタ）だが異ソースのため許容。
+
+### clarity: 5/5
+品質ゲートのフォーマットテンプレートに完全準拠。テーブル形式統一、章構成順序固定、C章パラグラフ形式で4トピックのSIer示唆を記述。ハイライト5件で本日の注目ポイントを簡潔に要約。
+
+### 総合: 4.3/5
+
+## reward
+```yaml
+score: 0.86
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-04-05T12:07:00"
+```

--- a/.companies/domain-tech-collection/docs/daily-digest/2026-04-05.md
+++ b/.companies/domain-tech-collection/docs/daily-digest/2026-04-05.md
@@ -1,0 +1,247 @@
+# 日次ダイジェスト 2026-04-05
+
+> **組織**: ドメイン知識や技術スタック収集PJT (`domain-tech-collection`)
+> **生成方式**: Agent Teams（wf-daily-digest）
+> **巡回ソース数**: 25件（成功14件、補完5件、一部成功2件、失敗4件）
+> **オペレーター**: SAS-Sasao
+
+---
+
+## 本日のハイライト
+
+1. **AI駆動開発ツール競争が激化** — CodexがClaude Codeからシェア首位を奪取、OpenAIが従量課金を導入。Claude Code・Copilot・Cursorの機能強化も相次ぎ、AIコーディングツール市場が急速に再編中
+2. **サプライチェーン攻撃が連鎖的に発生** — Axios npmパッケージへの「遅延型」攻撃とOSSセキュリティツールTrivyへの攻撃が同時期に報道。ソフトウェアサプライチェーンの脆弱性が深刻化
+3. **トライアル×西友のEC連携が加速** — 新会社「TRYU」設立、札幌でネットスーパー本格展開。新業態「トライアル西友」2号店も出店し、リアル×EC融合が本格化
+4. **流通業界の賃上げが過去最高** — UAゼンセン傘下で正社員1.7万円・パート80.4円のアップ。イオン・ライフ・ヤオコー等の首都圏スーパーも時給引き上げ
+5. **Anthropicがパートナーネットワークに1億ドル投資** — 企業のClaude導入支援エコシステム構築を加速。AI安全性研究機関「The Anthropic Institute」も設立
+
+---
+
+## A章 技術スタック
+
+### A1. AI駆動開発・エージェント
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Claude Codeの首位陥落。CodexがシェアNo.1へ](https://qiita.com/kotauchisunsun/items/ab78bb338500b4c71103) | Qiita | 2026年3月のAIコーディングツール市場でCodex CLIがシェア首位を獲得。 |
+| 2 | [Codex now offers pay-as-you-go pricing for teams](https://openai.com/index/codex-flexible-pricing-for-teams/) | OpenAI | OpenAI CodexがBusiness/Enterprise向けに従量課金制を導入、シート価格も引き下げ。 |
+| 3 | [Anthropic's Three-Agent Harness](https://www.infoq.com/news/2026/04/anthropic-three-agent-harness-ai/) | InfoQ | Anthropicが長時間フルスタックAI開発を支援する3エージェントシステムを設計。 |
+| 4 | [ハーネスエンジニアリングを極めたら、IssueからAIエージェントが動き、人間の役割は要件定義だけになった](https://zenn.dev/aicon_kato/articles/harness-engineering-startup) | Zenn | AIエージェント駆動開発パイプラインを構築し、開発者の役割が要件定義のみに変わった実践報告。 |
+| 5 | [Claude Codeに仕様書を丸ごと渡すな──「要件を伝える」との決定的な違い](https://zenn.dev/bookamasedo/articles/c264a26dafe55b) | Zenn | Claude Code活用の要諦は「仕様書提供」ではなく「要件伝達」であることを解説。 |
+| 6 | [Claude CodeでAI RSSリーダーを作ったら、その日にInoreaderを解約した](https://zenn.dev/caphtech/articles/feed-curator-ai-rss-with-claude-code) | Zenn | Claude CodeでAI搭載RSSリーダーを構築し、有料サービスを代替した事例。 |
+| 7 | [Claude Code 完全リファレンス — 全機能網羅+意外と知らない便利機能トップ10](https://qiita.com/nogataka/items/5e64037cc452c5d497fa) | Qiita | Claude Codeの全機能を網羅し、実務で役立つ隠れ機能を紹介。 |
+| 8 | [Claude Code向けの著名なSkillsを合成して「Super Skills」を作ってみた](https://qiita.com/takurot/items/98472032a3f4535c66b2) | Qiita | 複数のClaude Code拡張Skillを統合したカスタムスキル構築の実例。 |
+| 9 | [Claude Code の出力スタイル（output-style）を同じタスクで比べてみた](https://dev.classmethod.jp/articles/claude-code-output-style/) | DevelopersIO | Claude Codeの異なる出力形式を同一タスクで比較検証した結果。 |
+| 10 | [Claude CodeのカレントディレクトリにObsidian Vaultを使っている人は除外設定を確認しよう](https://dev.classmethod.jp/articles/claude-code-obsidian-exclusion-settings/) | DevelopersIO | Claude Code+Obsidian併用時の除外設定の重要性を指摘。 |
+| 11 | [Vibe Coding、最初は速い。でも後半で急にしんどくなる](https://qiita.com/engchina/items/2b28f629ea2daab701cd) | Qiita | バイブコーディングの初期メリットと後期の課題・失速パターンを分析。 |
+| 12 | [Stitch x Figma Make x Claude Code で個人サイトがすんなり完成した話](https://zenn.dev/sunagaku/articles/stitch-figmamake-design-flow) | Zenn | デザインツール連携によるAI駆動Webサイト開発ワークフローの実践記。 |
+| 13 | [GitHub Copilot のカスタマイズに疲弊した人に: Copilot Chat のビルトイン スキルがすごい](https://zenn.dev/microsoft/articles/88253e369ae8ea) | Zenn | Copilot Chatの組み込みスキル機能により複雑なカスタマイズが不要になる利点を紹介。 |
+| 14 | [GitHub Copilotの『SKILL.md育成RPG』— Lv.0の村人がLv.7の伝説の勇者になるまで](https://qiita.com/yukurash/items/d8971bdf08f8416ad7dd) | Qiita | GitHub Copilotのスキル強化メカニズムと反復改善プロセスの体験記。 |
+| 15 | [Cursor 3.0の主要新機能5つを試してみた](https://dev.classmethod.jp/articles/cursor-3-0-multi-agent-features-guide/) | DevelopersIO | Cursor 3.0のマルチエージェント機能など新機能5つを検証。 |
+| 16 | [【非エンジニアのためのClaude/ClaudeCodeシリーズ】Coworkで業務時間外の情報整理を自動化した話](https://dev.classmethod.jp/articles/cowork-morning-sales-automation/) | DevelopersIO | 営業担当者がClaudeで自然言語のみのCRM自動化をコードなしで実現。 |
+| 17 | [5 Key Trends Shaping Agentic Development in 2026](https://thenewstack.io/5-key-trends-shaping-agentic-development-in-2026/) | The New Stack | 2026年のエージェント開発を形作る5つの主要トレンドを解説。 |
+| 18 | [GenU に AgentCore Gateway を統合して Lambda 関数を MCP ツール化](https://dev.classmethod.jp/articles/genu-agentcore-gateway/) | DevelopersIO | Lambda関数をMCPツールとして活用するAgentCore Gateway統合方法。 |
+
+### A2. AI・ML・LLM
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Anthropic invests $100 million into the Claude Partner Network](https://www.anthropic.com/news/claude-partner-network) | Anthropic | Anthropicが企業のClaude導入支援パートナーネットワークに1億ドルを投資。 |
+| 2 | [Introducing The Anthropic Institute](https://www.anthropic.com/news/the-anthropic-institute) | Anthropic | 強力なAIがもたらす社会的課題に対処する研究機関をAnthropicが設立。 |
+| 3 | [Australian government and Anthropic sign MOU for AI safety and research](https://www.anthropic.com/news/australia-MOU) | Anthropic | オーストラリア政府とAnthropicがAI安全性・研究に関する覚書に署名。 |
+| 4 | [Introducing ChatGPT Go, now available worldwide](https://openai.com/index/introducing-chatgpt-go/) | OpenAI | OpenAIがChatGPT Goを全世界で提供開始。 |
+| 5 | [Testing ads in ChatGPT](https://openai.com/index/testing-ads-in-chatgpt/) | OpenAI | OpenAIがChatGPT内での広告表示テストを開始。 |
+| 6 | [パラメータ4個で710M超えのFoundation Modelに勝った時系列予測手法FLAIRの全貌](https://zenn.dev/t_honda/articles/flair-time-series-forecasting) | Zenn | わずか4パラメータで7.1億パラメータ基盤モデルを超える時系列予測手法の詳細解説。 |
+| 7 | [RAGの最適化手法が多すぎて迷子になったので、整理したら全体像が見えた](https://zenn.dev/nagi98/articles/260405-rag-optimization-overview) | Zenn | RAG（検索拡張生成）の複数最適化手法を体系的に整理・分類。 |
+| 8 | [Gemma 4 徹底解説：Googleのオープンモデル最新版で何ができるのか](https://qiita.com/TaichiEndoh/items/0b06c96326e0f41912b1) | Qiita | Google Gemma 4モデルの機能・活用方法を包括的に解説。 |
+| 9 | [「メモリは8ギガで十分ですよ」時代の到来。1ビットLLM「Bonsai 8B」を8GBのMacBook Neoで動かしてみたら爆速だった](https://www.techno-edge.net/article/2026/04/04/4971.html) | はてブ | 1.1GBに8Bパラメータを圧縮する1ビットLLMが低スペックMacで高速動作。 |
+| 10 | [AIクローラーにだけ課金する。Hono + x402で実現するCloudflare Workers上のAIペイウォール](https://zenn.dev/jphfa/articles/x402-ai-crawler-monetization) | Zenn | AIクローラー限定課金モデルをCloudflare Workersで実装する技術手法。 |
+| 11 | [AIデータセンター建設計画の半数は変圧器やバッテリー不足で延期または取り消しになる見込み](https://gigazine.net/news/20260404-ai-data-center-delayed-canceled/) | はてブ | インフラ部品不足でAIデータセンター建設の約50%が延期・キャンセルの可能性。 |
+
+### A3. クラウド・インフラ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Amazon CloudWatch now supports OpenTelemetry metrics in public preview](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-cloudwatch-opentelemetry-metrics/) | AWS What's New | CloudWatchがOTLPプロトコルによるOpenTelemetryメトリクス直接送信をパブリックプレビュー開始。 |
+| 2 | [Amazon ECS announces Managed Daemons for ECS Managed Instances](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-ecs-managed-daemons/) | AWS What's New | ECS Managed Instancesにセキュリティ・監視エージェント等のManaged Daemons機能を追加。 |
+| 3 | [AWS Managed Microsoft AD adds Multi-Region replication for Opt-In regions](https://aws.amazon.com/about-aws/whats-new/2026/04/multi-region-opt-in-aws-microsoft-ad/) | AWS What's New | AWS Managed Microsoft ADがオプトインリージョンでのマルチリージョンレプリケーションに対応。 |
+| 4 | [Amazon Bedrock Guardrails でクロスアカウントのセーフガードが GA に](https://dev.classmethod.jp/articles/bedrock-guardrails-cross-account-safeguards/) | DevelopersIO | Bedrock Guardrailsの組織横断セーフガード機能が一般提供開始。 |
+| 5 | [新しい AWS Sustainability コンソールが登場](https://dev.classmethod.jp/articles/ccft-deprecation/) | DevelopersIO | AWS Sustainabilityコンソールの新バージョンリリースと旧ツールの整理。 |
+| 6 | [AWS Marketplace 経由の Claude Enterprise でシート数を追加してみた](https://dev.classmethod.jp/articles/aws-marketplace-claude-enterprise-add-seats/) | DevelopersIO | AWS Marketplace経由でのClaude Enterprise契約のシート追加手順を解説。 |
+| 7 | [S3エミュレーションでrustfsを使ってみたメモとPresigned URLの仕組み](https://future-architect.github.io/articles/20260403a/) | フューチャー技術ブログ | Apache2ライセンスのrustfsでS3エミュレーション環境を構築しPresigned URLの仕組みを検証。 |
+| 8 | [API GatewayとLambdaで実装するプライベートなMCPサーバー](https://future-architect.github.io/articles/20260324a/) | フューチャー技術ブログ | AWS LambdaとAPI Gatewayを組み合わせたプライベートMCPサーバーの構築手順。 |
+| 9 | [Linux 7.0でPostgreSQL性能半減、修正困難か](https://joho-todai.com/linux-7-postgresql-performance-halved/) | はてブ | Linuxカーネル7.0の設計変更でPostgreSQLスループットが約半減する問題が報告。 |
+| 10 | [Ubuntu 26.04 LTSの最低メモリ要件が6GBに引き上げ](https://gazlog.com/entry/ubuntu-26-04-lts-memory-up/) | はてブ | GNOME/ブラウザ等の実態に合わせUbuntu LTSの最低メモリ要件を4GB→6GBに変更。 |
+| 11 | [TigerFS PostgreSQL Filesystem](https://www.infoq.com/news/2026/04/tigerfs-postgresql-filesystem/) | InfoQ | PostgreSQLデータベースをファイルシステムとしてマウント可能にする新ツール。 |
+
+### A4. データ基盤・DWH
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [NTTドコモと描く、Snowflakeを活用した分散・自律型データ活用の未来](https://www.nttdata.com/jp/ja/trends/data-insight/2026/032401/) | NTTデータ | NTTデータのTirofog(R)とSnowflakeを活用した分散・自律型データ分析ソリューション。 |
+| 2 | [Snowflake: AI_FUNCTIONS_USER database role GA](https://docs.snowflake.com/en/release-notes/new-features) | Snowflake | SnowflakeのAI関数ユーザーロールが4月2日に一般提供開始。 |
+| 3 | [Data ins and outs for 2026: what data teams are keeping, cutting, and reconsidering](https://www.getdbt.com/blog/data-ins-and-outs-for-2026) | dbt Blog | 2026年にデータチームが採用・廃止・再検討する技術トレンドをポッドキャストで議論。 |
+| 4 | [主キーはもう「UUIDv7」一択なのか？ 〜 ID技術の歴史的変遷と現時点の最適解 〜](https://zenn.dev/loglass/articles/c2db7e85702571) | Zenn | ID技術の歴史を辿りながらUUIDv7が本当に最適解かを検証するデータベース設計論。 |
+
+### A5. 開発プラクティス・設計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Module Federation 2.0 Release](https://www.infoq.com/news/2026/04/module-federation-2-stable/) | InfoQ | Module Federation 2.0安定版リリース、Webpack以外の広範なサポートが可能に。 |
+| 2 | [YAMLの変更点を見落とさない！diffより強力なYAML差分確認ツール『dyff』のすすめ](https://tech-lab.sios.jp/archives/52303) | はてブ | データ構造ベースでYAML/JSONを比較する差分ツールdyffの活用方法。 |
+| 3 | [無料・高速・多機能でクロスプラットフォーム対応のターミナルエミュレータ「Ghostty」が魅力的な理由](https://gigazine.net/news/20260404-ghostty-ui/) | はてブ | HashiCorp創設者が開発したZig言語製ターミナルGhosttyが高い支持を獲得。 |
+| 4 | [npm をセキュアな挙動にするために .npmrc に記述する最小設定](https://zenn.dev/cycloud_blog/articles/5ce66daf4bd0cb) | Zenn | npmのセキュリティ設定を最小限の.npmrc記述で実装する方法。 |
+| 5 | [WordPress後継CMS「EmDash」を触ってみる](https://zenn.dev/z4ck_key/articles/try-emdash-cms) | Zenn | 新CMSプラットフォームEmDashの機能と利点をハンズオン形式でレビュー。 |
+| 6 | [Flutter Flavorsの設定をXcode GUI操作なしで自動化するプラグイン作ってみた](https://dev.classmethod.jp/articles/flutter-flavors-auto-setup/) | DevelopersIO | Flutter開発のFlavors設定を自動化するプラグインの実装。 |
+| 7 | [実験して入門するKubernetes：Pod起動の裏側を追っていたら、どうしてもSchedulerを止めてみたくなった件](https://future-architect.github.io/articles/20260325a/) | フューチャー技術ブログ | Kubernetes Pod起動プロセスを実験的に追跡しSchedulerの動作を検証した入門記事。 |
+| 8 | [Swift 6.3 Android Support](https://www.infoq.com/news/2026/04/swift-6-3-android-c-interop/) | InfoQ | Swift 6.3がAndroid SDKを安定化しC相互運用性を拡張。 |
+
+### A6. セキュリティ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Axiosサプライチェーン攻撃の手口をPostmortemで読んだら、まるでルパン三世だった](https://qiita.com/WdknWdkn/items/c787ccd02775613f6f13) | Qiita | npmパッケージAxiosへのサプライチェーン攻撃事例をポストモーテムから詳細分析。 |
+| 2 | [なぜ検知できなかったのか？ Axiosを襲った「遅延型」サプライチェーン攻撃の技術的解析](https://codezine.jp/article/detail/23847) | はてブ | Axiosへの約3時間の遅延型サプライチェーン攻撃の技術的背景と検知困難性を解説。 |
+| 3 | [Trivy Security Tool Supply Chain Attack](https://www.infoq.com/news/2026/04/trivy-supply-chain-attack/) | InfoQ | OSSセキュリティツールTrivyがサプライチェーン攻撃を受け業界全体に緊急対応が波及。 |
+| 4 | [Claude Code ソースコード漏洩: npmパッケージに512,000行のソースマップが混入](https://fortune.com/2026/03/31/anthropic-source-code-claude-code-data-leak-second-security-lapse-days-after-accidentally-revealing-mythos/) | はてブ | Anthropicがnpmパッケージに512,000行のClaude Codeソースコードを誤って公開。 |
+| 5 | [NEC「Aterm」シリーズに複数の脆弱性 アップデートまたは買い換えを推奨](https://ascii.jp/elem/000/004/387/4387155/) | はてブ | NECルーターに権限チェック欠如やOSコマンドインジェクション等6つの脆弱性。 |
+| 6 | [AI時代のサイバー攻撃は次のステージへ。2026年の転換点とは？](https://www.nttdata.com/jp/ja/trends/data-insight/2026/031901/) | NTTデータ | AI普及に伴いランサムウェア・ディープフェイク等のサイバー攻撃が社会課題レベルに高度化。 |
+| 7 | [Claude Enterpriseのデータ保持期間の仕様と削除時の注意点](https://dev.classmethod.jp/articles/claude-enterprise-data-retention-setting/) | DevelopersIO | Claude Enterpriseにおけるデータガバナンス・保持期間設定の注意点を整理。 |
+
+---
+
+## B章 小売ドメイン
+
+### B1. 業態変革・新店
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [「旬」を強く打ち出す売場づくりに注力 小平市初出店の「オーケー小平小川東店」を解説](https://diamond-rm.net/store/newstorereport/540992/) | DCS オンライン | オーケーが小平市初出店、旬を打ち出す売場戦略を展開。 |
+| 2 | [新フォーマット「トライアル西友」の2号店「武蔵新城店」を徹底レポート!](https://diamond-rm.net/store/newstorereport/540886/) | DCS オンライン | トライアルと西友の提携新業態2号店の店舗特性を報告。 |
+| 3 | [静岡の「食」にフォーカス!「イオンスタイル静岡」の売場づくりをレポート](https://diamond-rm.net/store/newstorereport/540962/) | DCS オンライン | イオンスタイル静岡が地域食材を活かした売場構成を展開。 |
+| 4 | [バロー関東1号店から1.5km! ヤオコー東戸塚店の売場づくりをレポート](https://diamond-rm.net/store/541343/) | DCS オンライン | ヤオコーがバロー関東1号店近隣で差別化売場を展開。 |
+| 5 | [イオンタウン／大阪市住吉区「あびこ駅前」飲食・食物販など18店舗4/25オープン](https://www.ryutsuu.biz/store/s040379.html) | 流通ニュース | イオンタウンが大阪メトロあびこ駅前に18店舗の新SC「あびこ駅前」を4/25グランドオープン。 |
+| 6 | [ダイエー／大阪市住吉区に「フードスタイルあびこ駅前店」4/25オープン](https://www.ryutsuu.biz/store/s040380.html) | 流通ニュース | ダイエーの新フォーマット「フードスタイル」が大阪住吉区に出店。 |
+| 7 | [平和堂／26年秋〜冬、富山県にスーパーマーケット2店舗オープン](https://www.ryutsuu.biz/store/s040314.html) | 流通ニュース | 平和堂が富山県への新規出店2店舗を計画。 |
+| 8 | [バロー／「大和田店」4/10オープン、福井県に10年ぶり出店](https://www.ryutsuu.biz/store/s040315.html) | 流通ニュース | バローが福井県に10年ぶりの新規出店を実施。 |
+| 9 | [双日／埼玉県「モラージュ菖蒲」今春5店舗オープン、ユニクロ移転・増床リニューアル](https://www.ryutsuu.biz/store/s040375.html) | 流通ニュース | 埼玉の商業施設でユニクロ含む5店舗が春オープン予定。 |
+| 10 | [マルエツ／「マルエツプチ西横浜駅前店」4/9オープン、年商目標4.7億円](https://www.ryutsuu.biz/store/s040313.html) | 流通ニュース | マルエツの小型店舗「プチ」フォーマットが横浜に新規オープン。 |
+| 11 | [ケンタッキー／神奈川県相模原市に次世代モデル店4/3オープン、バーガー生産力6倍](https://www.ryutsuu.biz/report/s040242.html) | 流通ニュース | KFCが次世代型店舗を相模原に出店、バーガー生産力を6倍に向上。 |
+| 12 | [第138回 日本家屋に学ぶ"ショッピングセンターの居心地"](https://diamond-rm.net/management/541462/) | DCS オンライン | SC経営における「居心地」の価値を日本家屋から考察。 |
+
+### B2. 経営・人事戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [賃上げ2026 UAゼンセン／正社員1万7024円・パート80.4円アップ、過去最高に](https://www.ryutsuu.biz/strategy/s040341.html) | 流通ニュース | UAゼンセン傘下の流通業界が過去最高の賃上げを実現。 |
+| 2 | [賃上げ2026／イオン、ライフ、ヤオコーなど首都圏スーパー、パート時給をアップ](https://www.ryutsuu.biz/strategy/s040317.html) | 流通ニュース | 大手スーパーチェーンが相次いでパート時給を引き上げ。 |
+| 3 | [パート賃上げ、6.63%](https://news.nissyoku.co.jp/flash/1275742) | 日本食糧新聞 | UAゼンセン発表でパート時給80.4円上昇を記録。 |
+| 4 | [ドライバー年収、大型500万円超に](https://news.nissyoku.co.jp/news/yokotah20260330055623606) | 日本食糧新聞 | 物流ドライバーの待遇改善が進み大型年収500万円超え。 |
+| 5 | [ローソン、取締役人事案を決議 竹澤氏が副社長就任へ](https://diamond-rm.net/flash_news/541430/) | DCS オンライン | ローソンが経営陣の人事異動を発表、竹澤氏が副社長に。 |
+| 6 | [グローバル外食企業への進化に向け、サンマルクHD藤川社長が問う「外食の本質」](https://diamond-rm.net/management/topinterview/540703/) | DCS オンライン | サンマルクHD社長がグローバル展開と外食の本質を語る。 |
+| 7 | [紀ノ國屋富田社長インタビュー 「路面店のリモデル」を検討へ](https://diamond-rm.net/management/topinterview/540619/) | DCS オンライン | 高級スーパー紀ノ國屋が既存路面店の大規模改装を示唆。 |
+
+### B3. PB・商品戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [イトーヨーカ堂「セブン・ザ・プライス」が好調! 新商品では「ユニット単価」の割安感を訴求](https://diamond-rm.net/sales-promotion/541303/) | DCS オンライン | IY「セブン・ザ・プライス」がユニット単価訴求で好調。 |
+| 2 | [25年菓子市場、小売4兆円到達](https://news.nissyoku.co.jp/news/aoyagi20260401092306312) | 日本食糧新聞 | 菓子市場が小売ベースで4兆円に到達、チョコ7000億円・スナック6000億円台で過去最高。 |
+| 3 | [銀座木村家と木村屋總本店、ブランド統合](https://news.nissyoku.co.jp/flash/1275535) | 日本食糧新聞 | 老舗パンメーカー2社が「伝統と新価値融合」を掲げブランド統合。 |
+| 4 | [コメ価格、7週連続下落](https://news.nissyoku.co.jp/flash/1275751) | 日本食糧新聞 | 農水省発表で5キロあたり3935円、7週連続の価格下落。 |
+
+### B4. EC・デジタル
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [トライアルHD／札幌市内でネットスーパー本格展開、品数約1.3万・西友PBも扱う](https://www.ryutsuu.biz/ec/s040376.html) | 流通ニュース | トライアルが北海道でネットスーパー事業を拡大、西友PBも取扱い。 |
+| 2 | [トライアルが新会社「TRYU」を設立、西友とのEC事業連携を加速](https://diamond-rm.net/flash_news/541490/) | DCS オンライン | トライアルと西友がEC事業強化のため新会社TRYUを設立。 |
+| 3 | [STRACT、AIショッピングアプリ「PLUG」に新機能「買い時表示機能」を実装](https://netshop.impress.co.jp/n/2026/04/03/15833) | ネットショップ担当者F | AI活用アプリに最適購入タイミング提示機能が追加。 |
+| 4 | [楽天、リニア型動画配信サービス「Rチャンネル」でAIを活用した地域創生支援サービスを開始](https://netshop.impress.co.jp/n/2026/04/03/15859) | ネットショップ担当者F | 楽天がAI動画配信によるローカルビジネス支援を開始。 |
+| 5 | [BEENOSグループ、越境EC支援事業を組織再編。FASBEEは「BEENOS Solutions」に商号変更](https://netshop.impress.co.jp/n/2026/04/03/15855) | ネットショップ担当者F | BEENOS社が越境EC支援事業を再編しFASBEEを新商号に統合。 |
+| 6 | [ベルーナ、酒蔵直送のECサイト「みんなの酒屋」を開設](https://netshop.impress.co.jp/n/2026/04/03/15856) | ネットショップ担当者F | ベルーナが全国の銘酒を送料無料・現地価格で提供するEC開設。 |
+| 7 | [よく使うECサイト・アプリは1位がAmazon、2位が楽天。AIショッピング利用経験は2割強](https://netshop.impress.co.jp/n/2026/03/30/15828) | ネットショップ担当者F | EC利用調査でAmazon・楽天が上位、AI検索経由購入は約20%。 |
+| 8 | [STORESネットショップ、決済手段に後払い「atone」を追加](https://ecnomikata.com/ecnews/50060/) | ECのミカタ | STORES決済に後払いオプション「atone」を拡充。 |
+| 9 | [シルバーエッグ、セルフィから生成する「SaaS型AI試着サービス」](https://ecnomikata.com/ecnews/50077/) | ECのミカタ | 生成AIでセルフィ1枚からバーチャル試着を実現するSaaS提供開始。 |
+| 10 | [「AIによる問い合わせ対応の導入」検討中が半数以上](https://ecnomikata.com/ecnews/50075/) | ECのミカタ | 約9割がCS有人対応に限界と回答、AI導入検討企業が増加。 |
+| 11 | [Z世代「イメージが良くなったと感じるブランド」1位ZOZOTOWN](https://ecnomikata.com/ecnews/50082/) | ECのミカタ | Z世代の支持ブランド調査でZOZOTOWN(35%)とQoo10(25%)が上位。 |
+
+### B5. 決算・統計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [NRF forecasts 4.4% retail sales growth this year despite rising uncertainty](https://www.retaildive.com/news/nrf-forecasts-retail-sales-growth-2026-consumer-uncertainty/815102/) | Retail Dive | NRFが2026年の米国小売売上を前年比4.4%増の5.6兆ドルと予測。 |
+| 2 | [NRF is forecasting U.S. retail sales to grow 4.4% in 2026](https://nrf.com/blog/nrf-is-forecasting-u-s-retail-sales-to-grow-4-4-in-2026) | NRF Blog | NRFがOxford Economicsと共同開発した新手法で2026年小売売上4.4%成長を予測。 |
+| 3 | [ランサムウェア被害のアスクル、サービス復旧と販促で顧客数の回復が進む。今期205億円最終赤字から2027年5月期はV字回復を計画](https://netshop.impress.co.jp/n/2026/04/02/15853) | ネットショップ担当者F | アスクルがサイバー攻撃被害からの復旧進展、来期V字回復を計画。 |
+| 4 | [物価高で生活「困窮してきた」8割超](https://ecnomikata.com/ecnews/50059/) | ECのミカタ | KSI調査で消費者の83%が物価高による生活困窮を実感。 |
+
+### B6. セキュリティ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [クラウドEC構築プラットフォーム「メルカート」、国際セキュリティ基準「PCI DSS v4.0.1」に準拠](https://netshop.impress.co.jp/n/2026/04/03/15860) | ネットショップ担当者F | EC構築PF「メルカート」が最新PCI DSS v4.0.1基準への準拠を完了。 |
+| 2 | [フィッシングサイト閉鎖を! 国内クレジットカード会社13社が共同の取り組みを拡大](https://netshop.impress.co.jp/n/2026/04/03/15861) | ネットショップ担当者F | 国内主要カード会社13社がフィッシング詐欺対策の共同取り組みを拡大。 |
+| 3 | [日本クレジットカード協会、13社と共同で「フィッシング対策」強化](https://ecnomikata.com/ecnews/50083/) | ECのミカタ | JCCA主導でカード会社13社がフィッシングサイト閉鎖活動を強化。 |
+| 4 | [日本郵便、YTGATEと「EC取引の不正対策強化」業務提携](https://ecnomikata.com/ecnews/50074/) | ECのミカタ | 日本郵便がEC不正対策専業企業YTGATEと業務提携を発表。 |
+| 5 | [Explore the insights shaping retail security in 2026](https://nrf.com/blog/explore-the-insights-shaping-retail-security-in-2026) | NRF Blog | NRF PROTECT 2026(6月開催)で返品不正・デジタル詐欺等のセキュリティ課題を議論。 |
+
+---
+
+## C章 クロスドメイン分析
+
+### 1. サプライチェーン攻撃と小売EC決済セキュリティの連動リスク
+
+技術側ではAxios npmパッケージとTrivyへの連鎖的なサプライチェーン攻撃が報道され、OSSエコシステムの脆弱性が改めて露呈した。一方、小売側ではPCI DSS v4.0.1準拠やクレジットカード会社13社のフィッシング対策強化が進む。SIerとしては、小売EC基盤の開発においてOSS依存関係のセキュリティ監査（SCA）とPCI DSS準拠を一体で設計提案する必要がある。特にnpmエコシステムを利用するフロントエンド開発では、Trivyのようなセキュリティツール自体が攻撃対象となるリスクも考慮したディフェンスインデプスの設計が求められる。
+
+### 2. AIエージェントの小売EC業務への適用拡大
+
+技術側ではAI駆動開発ツール（Claude Code、Codex、Copilot）の競争が激化し、非エンジニアによるAI業務自動化の事例も登場している。小売側では「AIによる問い合わせ対応の導入」を検討する企業が半数を超え、AIショッピングアプリやAI試着サービスが実装段階に入った。SIerとしては、小売業向けのAIエージェント導入支援（カスタマーサポート自動化、商品レコメンド、購買タイミング最適化等）が有望な提案領域であり、Anthropicの1億ドルパートナーネットワーク投資はこの方向性を後押しする。
+
+### 3. トライアル×西友モデルに見るリアル×EC融合のシステム要件
+
+トライアルが新会社「TRYU」を設立し西友PBも扱うネットスーパーを展開するなど、異なる小売企業間のEC連携が加速している。技術側ではCloudWatchのOpenTelemetry対応やBedrock Guardrailsのクロスアカウント機能がGAとなり、マルチテナント・マルチアカウント環境での監視・ガバナンスが容易になった。SIerがリテール企業間連携のEC基盤を構築する際、AWS上でのマルチアカウント設計とオブザーバビリティの一元化が差別化ポイントになる。
+
+### 4. 賃上げ圧力と店舗DX・自動化投資の加速
+
+流通業界で過去最高の賃上げ（パート80.4円増）が実現し、物流ドライバーの年収も500万円を超えた。人件費上昇は店舗運営・物流の自動化投資を加速させる。技術側ではKFCの次世代モデル店（バーガー生産力6倍）やセルフレジ・AI棚割の進化が見られ、4月施行の物流制度改正（白トラ規制・管理簿義務）も物流DXの追い風となる。SIerとしては、小売業の店舗オペレーション自動化・物流管理システムの提案が一層求められる局面である。
+
+---
+
+## D章 巡回メタデータ
+
+### 技術系ソース
+
+| # | ソース | ステータス | 取得記事数 | 備考 |
+|---|--------|-----------|-----------|------|
+| 1 | Zenn | ✅ 成功 | 11件 | トレンド・新着記事を抽出 |
+| 2 | Qiita | ✅ 成功 | 11件 | トレンド記事を抽出 |
+| 3 | はてなブックマーク テクノロジー | ✅ 成功 | 12件 | ホットエントリを抽出 |
+| 4 | DevelopersIO | ✅ 成功 | 10件 | 最新記事を抽出 |
+| 5 | AWS What's New | ⚠️ 一部成功 | 5件 | JSレンダリングのためWebFetch失敗、WebSearchで補完 |
+| 6 | InfoQ | ✅ 成功 | 5件 | WebFetchで直接取得 |
+| 7 | dbt Blog | ⚠️ 補完 | 1件 | ドメインブロックでWebFetch不可、WebSearchで補完 |
+| 8 | Snowflake Blog | ⚠️ 補完 | 2件 | CSSのみ返却、WebSearchでリリースノート等を補完 |
+| 9 | The New Stack | ⚠️ 補完 | 2件 | CSS/JSのみ返却、WebSearchで補完 |
+| 10 | フューチャー技術ブログ | ✅ 成功 | 3件 | WebFetchで直接取得 |
+| 11 | NTTデータ テックブログ | ⚠️ 補完 | 3件 | DNSエラー、WebSearchでDATA INSIGHTから補完 |
+| 12 | リクルートテックブログ | ❌ 失敗 | 0件 | WebFetch権限拒否、4月記事未確認 |
+| 13 | Anthropic News | ✅ 成功 | 3件 | 3月分を収録（4月記事なし） |
+| 14 | OpenAI Blog | ⚠️ 補完 | 3件 | 403エラー、WebSearchで補完 |
+
+### 小売ドメイン系ソース
+
+| # | ソース | ステータス | 取得記事数 | 備考 |
+|---|--------|-----------|-----------|------|
+| 1 | 流通ニュース | ✅ 成功 | 10件 | 4/2-4/3付の記事を取得 |
+| 2 | ダイヤモンド・チェーンストア オンライン | ✅ 成功 | 10件 | 4/2-4/4付の記事を取得 |
+| 3 | ネットショップ担当者フォーラム | ✅ 成功 | 10件 | 4/2-4/3付の記事を取得 |
+| 4 | ITmedia ビジネスオンライン（流通・小売） | ⚠️ 一部成功 | 5件 | タイトル・URLに不整合の可能性、テーマ別集計からは除外 |
+| 5 | Retail Dive | ⚠️ 一部成功 | 2件 | JSレンダリングのためWebSearch経由で補完 |
+| 6 | NRF Blog | ✅ 成功 | 3件 | WebFetch+WebSearch併用 |
+| 7 | 日本食糧新聞 | ✅ 成功 | 5件 | リダイレクト経由で取得 |
+| 8 | ロジスティクス・トゥデイ | ✅ 成功 | 5件 | 物流制度改正・燃料危機関連が中心 |
+| 9 | ECのミカタ | ✅ 成功 | 7件 | EC不正対策・AI導入・消費動向を取得 |
+| 10 | セブン＆アイ ニュースリリース | ❌ 失敗 | 0件 | JSのみ返却、WebSearchでも一覧取得不可 |
+| 11 | Retail Tech Japan | ❌ 失敗 | 0件 | DNS解決不可（ドメイン変更の可能性） |
+
+**総記事数**: 技術59件 + 小売43件 = 102件


### PR DESCRIPTION
## Summary
- 日次ダイジェスト 2026-04-05 を Agent Teams（wf-daily-digest）で生成
- 技術系14ソース + 小売系11ソース = 計25ソースを巡回
- 技術59件 + 小売43件 = **計102記事**を収集・テーマ別に分類

## 本日のハイライト
1. AI駆動開発ツール競争激化（Codex首位奪取、OpenAI従量課金導入）
2. サプライチェーン攻撃の連鎖（Axios + Trivy）
3. トライアル×西友のEC連携加速（新会社TRYU設立）
4. 流通業界の賃上げが過去最高（パート80.4円増）
5. Anthropicパートナーネットワークに1億ドル投資

## 品質ゲート
- 全必須項目 PASS
- Judge評価: 4.3/5（completeness:4, accuracy:4, clarity:5）

## 成果物
- `docs/daily-digest/2026-04-05.md`
- `.task-log/20260405-114749-daily-digest.md`

## Labels
`org:domain-tech-collection`, `type:daily-digest`, `mode:agent-teams`

🤖 Generated with [Claude Code](https://claude.com/claude-code)