### PR TITLE
MCPサービスにFigma MCP Serverを追加

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260409-193500-admin-add-mcp-figma.md
+++ b/.companies/domain-tech-collection/.task-log/20260409-193500-admin-add-mcp-figma.md
@@ -1,0 +1,29 @@
+---
+task_id: 20260409-193500-admin-add-mcp-figma
+title: MCPサービスにFigma MCP Serverを追加
+status: completed
+mode: direct
+org: domain-tech-collection
+dept: secretary
+operator: SAS-Sasao
+created: 2026-04-09T19:35:00+09:00
+issue_number: null
+pr_number: null
+subagents: []
+reward: null
+---
+
+## 概要
+
+Figma MCP Server（公式リモートサーバー）をMCPサービスマスタに登録。
+OAuth認証済み（アカウント: t.s.0514.0952@gmail.com、Starterプラン・Viewシート）。
+
+## 実行計画
+
+- 対象マスタ: `masters/mcp-services.md`
+- 操作種別: 追加
+- 連鎖更新: なし
+
+## 成果物
+
+- `.companies/domain-tech-collection/masters/mcp-services.md`（figmaエントリ追加）

--- a/.companies/domain-tech-collection/masters/mcp-services.md
+++ b/.companies/domain-tech-collection/masters/mcp-services.md
@@ -83,3 +83,35 @@
   - [GitHub](https://github.com/jgraph/drawio-mcp)
   - [サーバーワークスBlog解説](https://blog.serverworks.co.jp/drawio-mcp-claude-code)
   - [Zenn解説記事](https://zenn.dev/aya1357/articles/12f4ede03bc32c)
+
+## figma
+
+- **サービス名**: Figma MCP Server
+- **提供元**: Figma公式
+- **ステータス**: active
+- **連携部署**: [dept-secretary, dept-research]
+- **想定操作**: Figmaデザイン取得・スクリーンショット・メタデータ取得、FigJamダイアグラム生成、Code Connect管理
+- **設定先**: Claude Code組み込み（claude.ai MCP connector）
+- **認証**: OAuth（ブラウザ認証、`/mcp` → Figma → Authenticate）
+- **プラン**: Starter（Viewシート）— 読み取り系は制限なし、キャンバス書き込みは制限あり
+- **提供ツール**:
+  - `get_design_context` — デザインのコード・スクリーンショット・コンテキストヒントを取得
+  - `get_screenshot` — デザインのスクリーンショット取得
+  - `get_metadata` — ファイルメタデータ取得
+  - `get_figjam` — FigJamファイルのリソース取得
+  - `generate_diagram` — FigJamにダイアグラム生成
+  - `get_variable_defs` — デザイン変数（トークン）定義の取得
+  - `search_design_system` — デザインシステム検索
+  - `use_figma` — キャンバスへの書き込み（Viewシートでは制限あり）
+  - `create_new_file` — 新規Figmaファイル作成
+  - `whoami` — 認証ユーザー情報の確認
+  - `get_code_connect_map` — Code Connectマッピング取得
+  - `get_code_connect_suggestions` — Code Connect候補の提案
+  - `get_context_for_code_connect` — Code Connectコンテキスト取得
+  - `add_code_connect_map` — Code Connectマッピング追加
+  - `send_code_connect_mappings` — Code Connectマッピング送信
+  - `create_design_system_rules` — デザインシステムルール作成
+- **参考ドキュメント**:
+  - [公式ドキュメント](https://developers.figma.com/docs/figma-mcp-server/)
+  - [リモートサーバーインストール](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/)
+  - [GitHub ガイド](https://github.com/figma/mcp-server-guide)


### PR DESCRIPTION
## Summary

- Figma MCP Server（公式リモートサーバー）を `masters/mcp-services.md` に登録
- OAuth認証済み（Starterプラン・Viewシート）
- 16ツール（デザイン取得、スクリーンショット、FigJamダイアグラム生成、Code Connect等）が利用可能

## 変更ファイル

- `masters/mcp-services.md` — figmaエントリ追加
- `.task-log/20260409-193500-admin-add-mcp-figma.md` — タスクログ

🤖 Generated with [Claude Code](https://claude.com/claude-code)