### PR TITLE
日次レポート 2026-04-09

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-04-09-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-04-09-today.md
@@ -1,0 +1,117 @@
+# domain-tech-collection 活動レポート — 2026-04-09（日次）
+
+> 生成日時: 2026-04-09 21:00 | 生成者: SAS-Sasao | 期間: 2026-04-09
+
+## エグゼクティブサマリー
+
+NEC入社前準備を大きく前進させた1日。朝の日次ダイジェスト（技術65件+小売47件=112件）に続き、NEC×ローソンの深堀り調査4テーマを2エージェント並列で実行し、ローソンのIT開発パートナーマップや店舗システムアーキテクチャの全体像を把握した。午後はFigma MCPの導入・認証・マスタ登録を完了し、ダッシュボードのBIツール風デザイン刷新にも着手した。全タスクが完了し、未完了の懸念はない。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 26 回（3セッション） |
+| ツール実行数（合計） | 3,599 回 |
+| 完了タスク数 | 3 件 |
+| 新規オープンIssue数 | 2 件（+interaction-log 1件） |
+| マージ済みPR数 | 3 件（#234, #236, #238） |
+| 作成ファイル数 | 10 件 |
+
+## 完了タスク
+
+### 1. 日次ダイジェスト 2026-04-09
+- **実行モード**: agent-teams（wf-daily-digest）
+- **Subagent**: tech-researcher + retail-domain-researcher
+- **成果物**: `docs/daily-digest/2026-04-09.md`（技術65件+小売47件=112件）
+- **注目トレンド**: S3 Files GA、Claude Code関連（技術）/ 流通ISAC設立、エージェンティックコマース（小売）
+- **PR**: #234 → マージ済み
+- **Issue**: #235
+
+### 2. NEC×ローソン深堀り調査4テーマ
+- **実行モード**: agent-teams
+- **Subagent**: tech-researcher + retail-domain-researcher（共にgeneral-purpose型）
+- **reward**: 0.90
+- **成果物**:
+  - `docs/research/nec-lawson-video-ai-followup-2026-04-09.md` — 映像AI実証の後続展開
+  - `docs/research/kddi-wakonx-platform-2026-04-09.md` — WAKONXの3層アーキテクチャ・ローソン活用事例
+  - `docs/retail-domain/industry-reports/lawson-ldi-analysis-2026-04-09.md` — LDIの実態（技術スタック・パートナーマップ）
+  - `docs/retail-domain/industry-reports/lawson-store-system-architecture-2026-04-09.md` — 店舗システム現行構成・セブン比較
+- **主要発見**:
+  - ローソン基幹系SIの中心はフューチャーアーキテクト（2007年〜）、NECはPOS/AI特化
+  - KDDIは50%株主として構造的優位を持ち、Real×Tech LAWSON 1号店にNEC技術の明示的採用なし
+  - LDI（約123名）はアプリ・Web内製。ストコン移行はLDI担当外でNECとの競合なし
+- **PR**: #236 → マージ済み
+- **Issue**: #237
+
+### 3. MCPサービスにFigma MCP Server追加
+- **実行モード**: direct（/company-admin）
+- **成果物**: `masters/mcp-services.md`（figmaエントリ追加）
+- **認証**: OAuth完了（Starterプラン・Viewシート）
+- **ツール数**: 16ツール利用可能
+- **PR**: #238 → マージ済み
+
+## 進行中タスク
+
+なし（全タスク完了）
+
+## 作成・更新された成果物
+
+### 技術リサーチ室（docs/research/）
+- `nec-midterm-plan-and-products-2026-04-09.md` — NEC中期経営計画・製品・社内体制
+- `nec-retail-reading-list-2026-04-09.md` — NEC入社前必読リンクリスト
+- `nec-lawson-video-ai-followup-2026-04-09.md` — 映像AI実証の「その後」
+- `kddi-wakonx-platform-2026-04-09.md` — KDDI WAKONXプラットフォーム
+
+### 小売ドメイン室（docs/retail-domain/industry-reports/）
+- `lawson-dx-strategy-2026-04-09.md` — ローソンDX戦略・NEC×ローソン案件
+- `lawson-ldi-analysis-2026-04-09.md` — LDI実態分析
+- `lawson-store-system-architecture-2026-04-09.md` — 店舗システム現行アーキテクチャ
+
+### 日次ダイジェスト（docs/daily-digest/）
+- `2026-04-09.md` — 技術+小売ニュース112件
+
+### マスタ（masters/）
+- `mcp-services.md` — Figma MCPエントリ追加
+
+## Issue 動向
+
+### 新規オープンのIssue（当日）
+- #235 日次ダイジェスト 2026-04-09（技術65件+小売47件=112件）
+- #237 NEC×ローソン深堀り調査4テーマ
+
+### interaction-log（除外対象）
+- #233 インタラクションログ 2026-04-09
+
+## 会話トピック
+
+### セッション1: db1e25c4（59発言 / 75応答）
+- `/company` で組織起動
+- 日次ダイジェスト生成（wf-daily-digest、Agent Teams並列巡回）
+- 品質ゲート確認・PR作成・マージ
+
+### セッション2: 72c129ee（25発言 / 29応答）
+- ai-war-roomリポジトリの内容活用の相談（壁打ち）
+- NEC・ローソン基礎調査ファイルの配置確認
+
+### セッション3: 9a0faf78（121発言 / 156応答）— 本セッション
+- NEC×ローソン深堀り調査（4テーマ並列実行）
+- Figma MCP導入の検討・認証・マスタ登録（/company-admin）
+- ダッシュボードBIツール風デザイン刷新の着手
+- 本レポートの生成
+
+### ファイル生成を伴わなかったやり取り
+- ai-war-roomリポジトリのcc-sier活用に関する壁打ち（セッション2）
+- Figma MCPの機能確認・Viewシート制約の説明（セッション3）
+- ダッシュボードHTML生成元スクリプトの構造調査（セッション3）
+
+## 次のアクション候補
+
+1. **ダッシュボードBIデザインのマージ・確認** — PR #239 が未マージ。GitHub Pagesで目視確認後マージ（根拠: 本日着手済み）
+2. **NEC入社前リーディングリストの読了開始** — 優先度Aの9件を5/15までに完了目標（根拠: nec-retail-reading-list に定義済み）
+3. **ストコンAWS移行のアーキテクチャ検討** — 店舗システムアーキテクチャ調査をベースに、移行方式（リフト&シフト vs マイクロサービス化）の比較検討（根拠: lawson-store-system-architecture の未解明論点）
+4. **セブン-イレブン案件のNEC社内ナレッジ調査** — 入社後に確認すべき社内情報のチェックリスト作成（根拠: 深堀り調査でセブン知見の転用可能性を特定）
+5. **日次ダイジェストの継続** — 明日の定時巡回（根拠: Cron設定済み）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## Summary

- 2026-04-09 の日次活動レポートを生成
- 5ソース（session-summaries / task-log / docs / GitHub Issues / conversation-log）から収集
- GitHub Issue #240 にも投稿済み

## 本日の実績

- 完了タスク: 3件（日次ダイジェスト / NEC×ローソン深堀り調査 / Figma MCP追加）
- マージ済みPR: 3件（#234, #236, #238）
- 作成ファイル: 10件
- ツール実行: 3,599回

🤖 Generated with [Claude Code](https://claude.com/claude-code)