### PR TITLE
日次ダイジェスト 2026-04-10（技術75件+小売60件=135件）

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260410-100000-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260410-100000-daily-digest.md
@@ -1,0 +1,27 @@
+---
+task_id: "20260410-100000-daily-digest"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "agent-teams"
+started: "2026-04-10T10:00:00"
+completed: "2026-04-10T10:30:00"
+request: "日次ダイジェスト対応から初めて"
+issue_number: null
+pr_number: null
+subagents: [tech-researcher, retail-domain-researcher]
+---
+
+## 実行計画
+- **実行モード**: agent-teams（wf-daily-digest）
+- **アサインされたロール**: secretary（チームリード）, tech-researcher, retail-domain-researcher
+- **参照したマスタ**: workflows.md(wf-daily-digest), info-source-master.md, quality-gates/by-type/daily-digest.md
+- **判断理由**: ワークフロー wf-daily-digest に一致。agent-teams で技術系・小売系を並列巡回
+
+## エージェント作業ログ
+
+### [2026-04-10 10:00] secretary
+受付: 日次ダイジェスト 2026-04-10 の生成依頼
+
+### [2026-04-10 10:00] secretary
+判断: agent-teams、wf-daily-digest に従い tech-researcher + retail-domain-researcher を並列起動

--- a/.companies/domain-tech-collection/.task-log/20260410-100000-daily-digest.md
+++ b/.companies/domain-tech-collection/.task-log/20260410-100000-daily-digest.md
@@ -7,8 +7,8 @@ mode: "agent-teams"
 started: "2026-04-10T10:00:00"
 completed: "2026-04-10T10:30:00"
 request: "日次ダイジェスト対応から初めて"
-issue_number: null
-pr_number: null
+issue_number: 244
+pr_number: 243
 subagents: [tech-researcher, retail-domain-researcher]
 ---
 

--- a/.companies/domain-tech-collection/docs/daily-digest/2026-04-10.md
+++ b/.companies/domain-tech-collection/docs/daily-digest/2026-04-10.md
@@ -1,0 +1,207 @@
+# 日次ダイジェスト 2026-04-10
+
+> **組織**: ドメイン知識や技術スタック収集PJT (`domain-tech-collection`)
+> **生成方式**: Agent Teams（wf-daily-digest）
+> **巡回ソース数**: 8件（技術5件+小売3件、全件成功）
+> **オペレーター**: SAS-Sasao
+
+---
+
+## 本日のハイライト
+
+1. **AIエージェント全面開花** — Claude Code Skills/MCP活用事例がZennで大量出現、AWS Agent Registry・AgentCore Browser OS操作もプレビュー公開。「エージェントがGUIを殺す」議論も
+2. **小売2月期決算ラッシュ** — イオン5期連続過去最高、ファストリ上期営利31.7%増、スギHD売上1兆円達成、ツルハHD次期2.55兆円予想。主要企業が揃って好決算
+3. **ドラッグストア大再編** — ツルハHD×ウエルシアHD統合で2兆円グループ誕生、スギHDがセキ薬品を子会社化
+4. **エージェンティックコマース加速** — Amazon「Help Me Decide」、Visa/Mastercard「エージェント型決済」、Yahoo!ショッピングAIエージェント活用
+5. **国産LLM「LLM-jp-4」がGPT-4o超え** — 日本語MT-BenchでGPT-4oを上回る性能を達成
+
+---
+
+## A. 技術スタック
+
+### A1. AI駆動開発・エージェント
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [全PRの83%をAIレビューだけでマージできるようにした](https://zenn.dev/kauche/articles/e051583461c181) | Zenn | AIコードレビューの自動化によりPRの83%を人手なしでマージ可能にした実践事例。 |
+| 2 | [デザインシステムを丸ごと Skills にする](https://zenn.dev/cybozu_frontend/articles/design-system-skills) | Zenn | デザインシステムをClaude Code Skillsとして定義し、AIにデザイン規約を遵守させる手法。 |
+| 3 | [社内業務をAIに開放 -- 自社MCPサーバー群一挙公開！](https://zenn.dev/aircloset/articles/d9fc317c1336c2) | Zenn | 社内業務APIをMCPサーバーとして公開し、AIエージェントから利用可能にした事例。 |
+| 4 | [Claude CodeにCLIツールを渡して精度と効率を上げる](https://zenn.dev/chot/articles/d0cd0425edd869) | Zenn | Claude Codeに専用CLIツールを組み合わせることでコード生成の精度と効率を向上させるテクニック。 |
+| 5 | [エージェント開発の参考に！GitHub Copilotのシステムプロンプトを見てみよう](https://zenn.dev/microsoft/articles/github-copilot-prompts) | Zenn | GitHub Copilotの内部システムプロンプトを分析し、エージェント設計の参考にする解説。 |
+| 6 | [PMが本来やるべき仕事の時間を取り戻す -- Claude Codeで変わった3つのPM業務](https://zenn.dev/medirom_tech/articles/4a61491a6b5059) | Zenn | PM業務をClaude Codeで効率化し、本質的なPM作業に集中できるようになった体験談。 |
+| 7 | [仕様書は"使い捨て"にした方がうまくいった -- 仕様駆動開発3ヶ月の転換](https://zenn.dev/dely_jp/articles/ef573ae39b9162) | Zenn | AI駆動の仕様駆動開発で仕様書を使い捨てにする運用が有効だった3ヶ月の知見。 |
+| 8 | [Claude Codeのメモリを3階層にしたら「覚えてる」が「学んでる」に変わった](https://zenn.dev/tokium_dev/articles/claude-code-evolutionary-memory) | はてブ | Claude Codeの記憶を3階層に構造化し、進化的な学習能力を実現した手法。 |
+| 9 | [大規模にエージェントを構築する Claude Managed Agents を試してみた](https://azukiazusa.dev/blog/claude-managed-agents/) | はてブ | Claude Managed Agentsを使った大規模エージェント構築の実践レポート。 |
+| 10 | [Cognition: How Devin Is Modernizing COBOL at Fortune 500 Companies](https://cognition.ai/blog/how-devin-is-modernizing-cobol-at-fortune-500-companies) | はてブ | AIエージェントDevinがFortune 500企業のCOBOLモダナイゼーションを実施している事例。 |
+| 11 | [AIエージェントはGUIの世界を殺すのか](https://www.itmedia.co.jp/news/articles/2604/09/news114.html) | はてブ | AIエージェント普及によるGUI操作パラダイムの変化を考察する論考。 |
+| 12 | [GitHub Copilot CLIのBYOK機能でOllamaのローカルモデルを使ってみた](https://dev.classmethod.jp/articles/copilot-cli-byok-ollama-local-model/) | DevelopersIO | GitHub Copilot CLIのBring Your Own Key機能でOllamaローカルモデルを接続する手順。 |
+| 13 | [【アップデート】Claude Code v2.1.98でGoogle Cloud Vertex AIのセットアップウィザードが追加されました](https://dev.classmethod.jp/articles/claude-code-v2-1-98-vertex-ai-setup-wizard/) | DevelopersIO | Claude Code最新版でVertex AIセットアップウィザードが追加されたアップデート紹介。 |
+| 14 | [Strands Agents x AgentCore Code Interpreter でコードを書かずにデータ分析しレポートを作成する](https://dev.classmethod.jp/articles/agentcore-codeinterpreter-strands/) | DevelopersIO | AWS Strands AgentsとAgentCore Code Interpreterを組み合わせたノーコードデータ分析。 |
+| 15 | [AWS Agent Registry for centralized agent discovery and governance is now available in Preview](https://aws.amazon.com/about-aws/whats-new/2026/04/aws-agent-registry-in-agentcore-preview/) | AWS | エージェントの一元管理・発見・ガバナンスを提供するAgent Registryがプレビュー公開。 |
+| 16 | [Amazon Bedrock AgentCore Browser adds OS-level interaction capabilities](https://aws.amazon.com/about-aws/whats-new/2026/04/agentcore-browser-os-actions/) | AWS | AgentCore BrowserにOS操作機能が追加され、エージェントのGUI操作が可能に。 |
+| 17 | [GA版のDevOps AgentでPagerDutyを連携してみた](https://dev.classmethod.jp/articles/devops-agent-ga-pagerduty/) | DevelopersIO | DevOps AgentのGA版でPagerDutyと連携してインシデント対応を自動化する手順。 |
+
+### A2. AI・ML・LLM
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [RAGとAgentic Searchの戦争を終わらせに来た!!!](https://zenn.dev/microsoft/articles/d1aa5068b432f9) | Zenn | RAGとAgentic Searchの対立構図を整理し、統合的なアプローチを提案する記事。 |
+| 2 | [国産LLM「LLM-jp-4」が日本語MT-BenchでGPT-4oを上回った](https://qiita.com/nogataka/items/6821e5d530938d269e58) | Qiita | 国産LLM「LLM-jp-4」が日本語ベンチマークでGPT-4oを超える性能を達成。 |
+| 3 | [日本発、LLMの推論を「桁違い」に効率化する新アーキテクチャ「PHOTON」](https://qiita.com/yuji-arakawa/items/2ad0240c56eb7507b261) | はてブ | LLM推論を大幅に効率化する日本発の新アーキテクチャ「PHOTON」の論文解説。 |
+| 4 | [グーグルが最新AIモデル「Gemma 4」を公開 -- Apache 2.0で完全オープンソースに](https://japan.zdnet.com/article/35246120/) | はてブ | GoogleがGemma 4をApache 2.0ライセンスの完全オープンソースとして公開。 |
+| 5 | [Google、GeminiアプリにNotebookLMをソースとして追加可能に](https://www.macotakara.jp/Google/entry-50882.html) | はてブ | GeminiアプリにNotebookLMの知識ベースを統合し、パーソナル知識DBを構築可能に。 |
+| 6 | [11億件の応募を却下したAI -- Workday訴訟が突きつける「意図のない差別」の正体](https://takoratta.hatenablog.com/entry/2026/04/09/085051) | はてブ | AIによる採用選考で11億件の応募を却下したWorkday訴訟から見えるAIバイアスの問題。 |
+| 7 | [Amazon Bedrock now offers Claude Mythos Preview (Gated Research Preview)](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-bedrock-claude-mythos/) | AWS | BedrockにClaude Mythosのゲート付きリサーチプレビューが追加。 |
+| 8 | [Amazon Bedrock now supports cost allocation by IAM user and role](https://aws.amazon.com/about-aws/whats-new/2026/04/bedrock-iam-cost-allocation/) | AWS | Bedrockの利用コストをIAMユーザー・ロール単位で配分可能になるアップデート。 |
+| 9 | [SageMaker HyperPod now supports gang scheduling for distributed training workloads](https://aws.amazon.com/about-aws/whats-new/2026/04/sagemaker-hyperpod-gang-scheduling/) | AWS | SageMaker HyperPodに分散学習のギャングスケジューリングサポートが追加。 |
+
+### A3. クラウド・インフラ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [S3 Filesで消えるアーキテクチャ層、生まれるアーキテクチャ](https://zenn.dev/genda_jp/articles/b6ff5ea33c7a71) | Zenn | S3 Filesの登場でファイルストレージ層のアーキテクチャが根本的に変わる考察。 |
+| 2 | [Terraformを使わずにGitHubをコードで管理する](https://zenn.dev/babarot/articles/github-as-code-with-gh-infra) | Zenn | gh-infraツールでTerraformを使わずGitHub設定をコード管理する方法。 |
+| 3 | ["キュピーン猫画像メーカー"初日50万アクセスもサーバ代「0円」](https://www.itmedia.co.jp/news/articles/2604/09/news108.html) | はてブ | 初日50万アクセスをサーバーレスアーキテクチャでコスト0円に抑えた構成の解説。 |
+| 4 | [Amazon RDS Blue/Green Deployments now supports Amazon RDS Proxy](https://aws.amazon.com/about-aws/whats-new/2026/04/rds-proxy-blue-green/) | AWS | RDS Blue/GreenデプロイメントがRDS Proxyをサポート開始。 |
+| 5 | [Amazon EKS managed node groups now support EC2 Auto Scaling warm pools](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-eks-managed-node-groups-ec2-warm-pools/) | AWS | EKSマネージドノードグループがEC2 Auto Scalingウォームプールをサポート。 |
+| 6 | [AWS Lambda expands response streaming support to all commercial AWS Regions](https://aws.amazon.com/about-aws/whats-new/2026/04/aws-lambda-response-streaming/) | AWS | Lambdaレスポンスストリーミングが全商用リージョンに拡大。 |
+| 7 | [Oracle Database@AWS is now available in twelve AWS Regions](https://aws.amazon.com/about-aws/whats-new/2026/04/oracle-database-aws-available-twelve-regions/) | AWS | Oracle Database@AWSが12リージョンに拡大。 |
+| 8 | [ヒートアイランド現象の主な原因は、データセンター。半径10kmを2度上昇させている](https://www.gizmodo.jp/2026/04/data-centers-create-heat-islands-stretching-6-miles-study-finds.html) | はてブ | データセンターが半径10kmの気温を2度上昇させているという研究結果。 |
+| 9 | [CodeBuildのDocker Hub 429エラーをECR Public Galleryで回避してみた](https://dev.classmethod.jp/articles/codebuild-docker-hub-429-ecr-public-gallery-workaround/) | DevelopersIO | CodeBuildでのDocker Hubレート制限エラーをECR Public Galleryで回避する方法。 |
+| 10 | [Aurora PostgreSQL 17.9 がリリースされたので、Babelfish 5.5 のアップデート内容を確認してみた](https://dev.classmethod.jp/articles/aurora-postgresql-17-9-babelfish-5-5/) | DevelopersIO | Aurora PostgreSQL 17.9のBabelfish 5.5アップデートの変更点を確認。 |
+
+### A4. データ基盤・DWH
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [AgentCore Code Interpreter を boto3 で直接操作して Excel レポートを生成してみた](https://dev.classmethod.jp/articles/agentcore-codeinterpreter/) | DevelopersIO | AgentCore Code Interpreterをboto3で直接操作しExcelレポートを自動生成する手順。 |
+| 2 | [【新機能】DatabricksのGenie CodeにAgent Skillsが追加されたので試してみた](https://dev.classmethod.jp/articles/databricks-genie-code-agent-skills/) | DevelopersIO | Databricks Genie CodeのAgent Skills機能でデータ分析ワークフローを強化。 |
+| 3 | [AWS Cost Explorer launches Natural Language Query capabilities powered by Amazon Q](https://aws.amazon.com/about-aws/whats-new/2026/04/aws-cost-explorer-natural-language-query/) | AWS | Cost ExplorerにAmazon Q搭載の自然言語クエリ機能が追加。 |
+
+### A5. 開発プラクティス・設計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [新しくプロジェクトに入った人がリポジトリの現状を素早く把握するためのGitコマンド5選](https://gigazine.net/news/20260410-git-command-before-reading-code/) | はてブ | プロジェクト参画時にリポジトリ全体像を素早く把握するためのGitコマンドTips。 |
+| 2 | [【Git】実務でよくあるGitエラーと対処法まとめ](https://qiita.com/yuto-vj/items/402d4a9c414354220ba3) | Qiita | 実務で頻出するGitエラーとその対処法をまとめたリファレンス。 |
+| 3 | [初心者こそ知っておきたい「単一責任の原則」](https://qiita.com/hiroki_notes/items/76eb3df7fbc26059c03c) | Qiita | SOLID原則の単一責任の原則を初心者向けにわかりやすく解説。 |
+| 4 | [Open source security at Astral](https://astral.sh/blog/open-source-security-at-astral) | はてブ | Python高速ツールチェーンAstral（uv/ruff）のオープンソースセキュリティ方針。 |
+
+### A6. セキュリティ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [VSCode拡張機能から考える、サプライチェーン攻撃の身近さ](https://zenn.dev/acntechjp/articles/e0f9ce661e794e) | Zenn | VSCode拡張機能を入口としたサプライチェーン攻撃のリスクと対策。 |
+| 2 | [ロシアGRU、家庭用ルーター1万8000台を乗っ取りOutlook認証情報を窃取](https://joho-todai.com/russia-gru-hijacks-routers-steal-outlook-credentials/) | はてブ | ロシアGRUが家庭用ルーター18,000台をボットネット化しOutlook認証情報を窃取した攻撃。 |
+| 3 | [Android「らしさ」失われる？ 2026年9月から「開発者認証」完全義務化](https://gihyo.jp/article/2026/04/android-weekly-topics-260409) | はてブ | Android開発者の認証完全義務化が2026年9月から開始、セキュリティ強化の動き。 |
+| 4 | [脱・セキュリティ初心者。現場の信頼を勝ち取るための「3つの原則」と「1つの習慣」](https://qiita.com/masa20057/items/be5d46e82f7301747e86) | Qiita | セキュリティ初心者が現場で信頼されるために身につけるべき原則と習慣。 |
+
+---
+
+## B. 小売ドメイン
+
+### B1. 業態変革・新店
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [開業日は約700人が行列！年商40億をめざす近畿ライフの大型店「緑地公園店」の全貌](https://diamond-rm.net/store/newstorereport/541728/) | DCS | 近畿ライフが大型新店を開業、初日700人行列で年商40億円目標。 |
+| 2 | [フジグラン川之江 跡地／愛媛県「ゆめタウン四国中央」27年春オープン](https://www.ryutsuu.biz/store/s040978.html) | 流通ニュース | イズミがフジグラン跡地に専門店40店のゆめタウンを2027年春開業。 |
+| 3 | [イオン九州／鹿児島市「イオンモールKAGOSHIMA BAY」32店舗リニューアル](https://www.ryutsuu.biz/store/s040972.html) | 流通ニュース | イオン九州が鹿児島のモールを32店舗規模でリニューアルオープン。 |
+| 4 | [ダイエーが「KOHYOロサヴィア茨木店」をオープン 時短・即食ニーズに徹底対応](https://diamond-rm.net/store/newstorereport/541985/) | DCS | ダイエーがKOHYOブランドで茨木に新店、時短・即食ニーズに特化。 |
+| 5 | [【一店入魂】ベルクベスタ狭山店 埼玉有数の激戦区に見たベルクの凄み](https://diamond-rm.net/store/storevisit/540539/) | DCS | ベルクが埼玉激戦区の狭山で競争力の高い店舗を展開。 |
+| 6 | [PPIH／愛知にカネ美食品の総菜新工場、ドンキやロビン・フッドに28年3月供給開始](https://www.ryutsuu.biz/strategy/s040984.html) | 流通ニュース | PPIHが愛知に総菜新工場を建設、ドンキ・ロビンフッドへ2028年供給開始。 |
+| 7 | [WEGO、アジア進出を加速。年内に台湾・上海で旗艦店を開設](https://netshop.impress.co.jp/n/2026/04/10/15895) | ネッ担 | WEGOが台湾・上海に旗艦店を年内開設しアジア展開を加速。 |
+
+### B2. 経営・人事戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [ツルハHD／中計発表、29年2月期売上高2.7兆円・営業利益1350億円目指す](https://www.ryutsuu.biz/strategy/s040913.html) | 流通ニュース | ツルハHDが中期経営計画を発表、29年2月期に売上2.7兆円目標。 |
+| 2 | [【ドラッグストア業界相関図2026】ツルハHDとウエルシアHD統合で2兆円グループ誕生！](https://diamond-rm.net/retaildata/distribution-correlations-2022/541841/) | DCS | ツルハHDとウエルシアHD統合で売上2兆円のDGSグループが誕生する構図を解説。 |
+| 3 | [【食品スーパー相関図2026】イオン、トライアル、ヤオコー……再編・M&A頻発で混沌！](https://diamond-rm.net/retaildata/distribution-correlations-2022/541551/) | DCS | 食品スーパー業界の2026年版相関図、再編が加速。 |
+| 4 | [スギHD／セキ薬品を連結子会社化](https://www.ryutsuu.biz/strategy/s040982.html) | 流通ニュース | スギHDがセキ薬品を連結子会社化しドラッグストア事業を拡大。 |
+| 5 | [ワークマン土屋専務が語る「ローリスク経営」からの脱却と攻めの成長戦略とは](https://diamond-rm.net/management/topinterview/541614/) | DCS | ワークマン土屋専務がローリスク経営からの転換と攻めの成長戦略を語る。 |
+| 6 | [イオンモール×三井不動産／都内2SCで「学生が働きたくなるSC」実証実験開始](https://www.ryutsuu.biz/strategy/s040974.html) | 流通ニュース | イオンモールと三井不動産がSC人材確保に向けた実証実験を開始。 |
+
+### B3. PB・商品戦略
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [コープデリの冷凍ミールキットの売上が、具材を減らしても落ちなかった理由](https://diamond-rm.net/sales-promotion/541178/) | DCS | コープデリが冷凍ミールキットの具材を減らしても売上維持に成功した背景を分析。 |
+| 2 | [好調継続のしまむらと全米最高利益率のバックル、両社に見られる共通点](https://diamond-rm.net/market/accounting/541649/) | DCS | しまむらと米バックルの好業績に共通するMD戦略の分析。 |
+| 3 | [生鮮だけじゃない！バローでついカゴに入れたくなる、コスパ最強のオリジナル商品5選](https://diamond-rm.net/sales-promotion/541289/) | DCS | バローのオリジナル商品5選を紹介、コスパの高さが消費者に支持。 |
+
+### B4. EC・デジタル
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [Amazonの新しいAI搭載ショッピング機能「Help Me Decide」とは](https://netshop.impress.co.jp/n/2026/04/10/15900) | ネッ担 | AmazonがAI搭載の購買意思決定支援機能「Help Me Decide」を新たに提供。 |
+| 2 | [加速する「エージェント型決済」の今。Visa、Mastercardが取り組むAI決済](https://netshop.impress.co.jp/e/2026/04/09/15888) | ネッ担 | Visa・MastercardがAIエージェント型決済に本格参入。 |
+| 3 | [「AIが買い物を選ぶ時代」がEC事業者の勝敗を分ける](https://netshop.impress.co.jp/n/2026/04/08/15883) | ネッ担 | AIが購買行動を代替する時代のEC事業者への影響を分析。 |
+| 4 | [AIエージェントで「Yahoo!ショッピング」の流通総額押し上げへ](https://netshop.impress.co.jp/e/2026/04/06/15792) | ネッ担 | Yahoo!ショッピングがAIエージェント活用で流通総額の拡大を目指す。 |
+| 5 | [世界で一気に注目度アップ!「エージェンティックコマース」と「UCP」とは](https://diamond-rm.net/technology/digitalmarketing/541080/) | DCS | エージェンティックコマースとUCPの概念を解説。 |
+| 6 | [AI活用はどう可視化して推進する？ZOZOのAI活用指標「AZARS」](https://netshop.impress.co.jp/n/2026/04/09/15890) | ネッ担 | ZOZOが独自のAI活用指標「AZARS」を策定し、AI推進を可視化。 |
+| 7 | [トライアルがグループのEC事業を担う子会社「TRYU」を新設](https://netshop.impress.co.jp/n/2026/04/08/15882) | ネッ担 | トライアルがEC事業子会社「TRYU」を設立しデジタル事業を本格化。 |
+| 8 | [トライアル・スギ薬局の協業本格化 「TRIAL GO」にスギの棚割りを初導入](https://diamond-rm.net/store/541446/) | DCS | トライアルとスギ薬局がTRIAL GOアプリで棚割り連携を開始。 |
+| 9 | [モスグループのECが好調なワケ。ライスバーガー「のり弁」ヒットで売り上げ1.5倍](https://netshop.impress.co.jp/e/2026/04/08/15810) | ネッ担 | モスグループのEC売上がのり弁ライスバーガーのヒットで1.5倍に伸長。 |
+| 10 | [最もよく利用する購買チャネルは「ECモール」63%](https://netshop.impress.co.jp/n/2026/04/08/15880) | ネッ担 | 消費者調査で最も利用する購買チャネルはECモールが63%でトップ。 |
+
+### B5. 決算・統計
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [イオン 決算／2月期増収増益、営業収益は5期連続で過去最高に](https://www.ryutsuu.biz/accounts/s040912.html) | 流通ニュース | イオンの2月期決算は増収増益、営業収益が5期連続で過去最高を更新。 |
+| 2 | [ファーストリテイリング 決算／上期過去最高の業績を達成、営業利益31.7％増](https://www.ryutsuu.biz/accounts/s040979.html) | 流通ニュース | ファーストリテイリング上期は過去最高業績、営業利益31.7%増。 |
+| 3 | [セブン＆アイ 決算／2月期は減収増益、国内コンビニ事業は1.2％増収](https://www.ryutsuu.biz/accounts/s040945.html) | 流通ニュース | セブン&アイの2月期は減収増益、国内CVS事業は1.2%増収で底堅い。 |
+| 4 | [ライフ 決算／2月期は増収増益、営業収益と純利益ともに過去最高を更新](https://www.ryutsuu.biz/accounts/s040944.html) | 流通ニュース | ライフの2月期は増収増益、営業収益・純利益ともに過去最高。 |
+| 5 | [スギHD 決算／2月期売上高1兆円を達成・営業利益14.1％増](https://www.ryutsuu.biz/accounts/s040981.html) | 流通ニュース | スギHDが2月期売上高1兆円を達成、営業利益は14.1%増。 |
+| 6 | [ツルハHD 決算／2月期売上高1兆4505億円、次期売上高2兆5550億円予想](https://www.ryutsuu.biz/accounts/s040911.html) | 流通ニュース | ツルハHDの2月期売上高は約1.45兆円、次期は統合効果で2.55兆円を予想。 |
+| 7 | [ファミリーマート2025年度決算発表 話題のキャンペーンや新商品がけん引し増収増益](https://diamond-rm.net/management/businessplan/542113/) | DCS | ファミリーマートの25年度決算はキャンペーン・新商品で増収増益。 |
+| 8 | [吉野家HD 決算／2月期営業利益10.7％増](https://www.ryutsuu.biz/accounts/s040983.html) | 流通ニュース | 吉野家HDの2月期は営業利益10.7%増と好調。 |
+| 9 | [パルグループHDの2026年2月期EC売上は590億円で11%増](https://netshop.impress.co.jp/n/2026/04/09/15892) | ネッ担 | パルグループHDのEC売上が590億円で前期比11%増と好調。 |
+
+### B6. セキュリティ
+
+| # | 記事 | ソース | 要約 |
+|---|------|--------|------|
+| 1 | [製造・卸・小売横断でサイバーセキュリティを強化「流通ISAC」を設立](https://netshop.impress.co.jp/n/2026/04/09/15891) | ネッ担 | 製造・卸・小売を横断するサイバーセキュリティ共助組織「流通ISAC」が設立。 |
+
+---
+
+## C. クロスドメイン分析
+
+### 1. AIエージェントがコマースの購買プロセスを根本から変える
+
+技術側ではAWS Agent Registry・AgentCore BrowserのOS操作機能がプレビュー公開され、エージェント基盤の整備が急速に進んでいる。小売側ではAmazon「Help Me Decide」、Visa/Mastercardの「エージェント型決済」、Yahoo!ショッピングのAIエージェント活用と、EC×AIの実装が相次ぐ。SIerとしてはNEC入社後、ローソンの顧客接点（アプリ・POS）にエージェント機能を統合する提案が差別化ポイントになる可能性がある。
+
+### 2. 決算ラッシュが示す小売業の二極化とDX投資余力
+
+イオン・ファストリ・ライフ・スギHDが過去最高決算を記録する一方、マックスバリュ東海はコスト増で営利減。好業績企業はDX投資余力があり、ツルハHD×ウエルシアHD統合後の2兆円グループはシステム統合案件が大型化する見込み。NECリテール部門にとって、決算好調なチェーンへのAI/クラウド提案のタイミングとして最適。
+
+### 3. Claude Code/AIコーディングの爆発的普及とPM業務の変容
+
+Zennを中心にClaude Code活用事例が大量に出現。特に「PRの83%をAIレビューのみでマージ」「PM業務の3つが変わった」は、NEC入社後のPM業務にも直結する知見。仕様駆動開発の「使い捨て仕様書」やMCP活用の事例は、ローソン案件でのAI活用検討にも参考になる。
+
+### 4. 流通ISACの設立とサプライチェーンセキュリティ
+
+製造・卸・小売横断の「流通ISAC」設立は、技術側のサプライチェーン攻撃リスク（VSCode拡張経由等）と呼応する動き。ローソンのストコンAWS移行においても、NEC-KDDIのUCF合弁によるセキュリティ体制との連携が重要テーマ。
+
+---
+
+## D. 巡回メタデータ
+
+| # | ソース | ステータス | 取得記事数 | 備考 |
+|---|--------|-----------|-----------|------|
+| 1 | Zenn | ✅ 成功 | 15件 | AI駆動開発・エージェント系が多数 |
+| 2 | Qiita | ✅ 成功 | 10件 | LLM・セキュリティ・初心者向け |
+| 3 | はてなブックマーク テクノロジー | ✅ 成功 | 20件 | Claude Code・LLM・セキュリティが注目 |
+| 4 | DevelopersIO | ✅ 成功 | 20件 | AWS Agent系・Claude Code系が中心 |
+| 5 | AWS What's New | ✅ 成功 | 20件 | Agent Registry・AgentCore等エージェント関連多数 |
+| 6 | 流通ニュース | ✅ 成功 | 20件 | 2月期決算ラッシュ（イオン・セブン・ツルハ等） |
+| 7 | ダイヤモンド・チェーンストア | ✅ 成功 | 20件 | 業界相関図2026特集・新店レポート |
+| 8 | ネットショップ担当者フォーラム | ✅ 成功 | 20件 | AIエージェント×EC関連が多数 |
+
+**総記事数**: 技術75件 + 小売60件 = 135件
+
+---
+_このダイジェストは wf-daily-digest ワークフロー（Agent Teams）により自動生成されました_


### PR DESCRIPTION
## Summary

- 技術5ソース + 小売3ソース = 全8ソースを Agent Teams で並列巡回
- **技術75件 + 小売60件 = 135件**を収集・テーマ別分類
- 品質ゲート全項目PASS

## 注目トピック

- **AIエージェント全面開花**: Claude Code Skills/MCP事例がZennで大量出現、AWS Agent Registry/AgentCore Browserプレビュー
- **小売2月期決算ラッシュ**: イオン5期連続過去最高、ファストリ営利31.7%増、スギHD売上1兆円
- **DGS大再編**: ツルハHD×ウエルシアHD統合で2兆円グループ、スギHDセキ薬品子会社化
- **エージェンティックコマース**: Amazon Help Me Decide、Visa/Mastercard AI決済、Yahoo!ショッピングAIエージェント

🤖 Generated with [Claude Code](https://claude.com/claude-code)