### PR TITLE
docs: CLAUDE.md を starter-kit 8セクション構成にリライト + .claude/rules/ 新設

### DIFF
--- a/.claude/rules/artifact-placement.md
+++ b/.claude/rules/artifact-placement.md
@@ -1,0 +1,59 @@
+# 成果物配置ルール
+
+生成したファイルをどこに置くかの原則。配置を間違えると GitHub Pages 配信対象外になったり、組織独立性が破綻する。
+
+## 配置先マトリクス
+
+| 成果物種別 | 配置先 | 理由 |
+|---|---|---|
+| 業務ドキュメント（MD） | `.companies/{org}/docs/{dept}/` | 組織スコープ、Git管理、PR運用 |
+| タスクログ | `.companies/{org}/.task-log/` | 組織スコープ、docs/と分離 |
+| マスタデータ | `.companies/{org}/masters/` | 組織設定 |
+| 日次ダイジェスト MD | `.companies/{org}/docs/daily-digest/` | 組織固有 |
+| 日次ダイジェスト HTML | `docs/daily-digest/` | GitHub Pages 配信 |
+| AWS 構成図 PNG/HTML/YAML | `docs/diagrams/` | GitHub Pages 配信 |
+| draw.io 汎用図 | `docs/drawio/` | GitHub Pages 配信 |
+| ダッシュボード HTML | `docs/secretary/dashboard.html` および `.companies/{org}/docs/secretary/` | Pages 配信 + 組織スコープ |
+| ナレッジポータル HTML | `docs/handover/` | Pages 配信 |
+| トップ `index.html` | `docs/index.html` | Pages ルート |
+| Subagent 定義 | `.claude/agents/` | グローバルリソース（組織外） |
+| Skill 定義 | `plugins/cc-sier/skills/` + `.claude/skills/`（同期） | プラグインソース + ランタイム |
+
+## 原則
+
+### ✅ 必ず守る
+
+- **業務成果物は `.companies/{org-slug}/docs/` 配下に作成**
+- GitHub Pages 配信対象（構成図・ダイジェスト HTML・ダッシュボード）は `docs/` 配下
+- Subagent への委譲時も組織パス（`.companies/{org}/docs/`）を明示して指示
+
+### ❌ 禁止
+
+- リポジトリルート直下に業務成果物を作成する
+- `.claude/` 配下に業務成果物を作成する（`skills/` `agents/` `hooks/` `rules/` はグローバルリソースで例外）
+- 組織 A の作業で組織 B のディレクトリに書き込む
+
+## GitHub Pages 配信対象の判断
+
+**`docs/` 配下に置く判断基準**: 成果物が HTML でブラウザから閲覧される・公開可視化される場合。
+
+| 配信あり | 配信なし |
+|---|---|
+| `docs/diagrams/*.html` | `.companies/{org}/docs/research/*.md` |
+| `docs/drawio/*.html` | `.companies/{org}/.task-log/*.md` |
+| `docs/daily-digest/index.html` | `.companies/{org}/masters/*.md` |
+| `docs/secretary/dashboard.html` | `.companies/{org}/docs/decisions/*.md` |
+| `docs/handover/*.html` | （組織固有の業務ドキュメント全般） |
+
+## 同一成果物を複数箇所に置くケース
+
+日次ダイジェストは例外的に **2 箇所** に配置:
+- **MD ソース**: `.companies/{org}/docs/daily-digest/YYYY-MM-DD.md`（PR運用・組織スコープ）
+- **HTML 配信**: `docs/daily-digest/index.html`（main 直コミット・Pages 配信）
+
+両者は `/company-daily-digest` Phase 7 の HTML 再生成工程で自動同期される。
+
+## 関連
+
+- @.claude/rules/multi-org.md — 組織独立性の原則
+- @.claude/rules/git-workflow.md — main 直コミット許可対象

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,82 @@
+# Git ワークフロー
+
+ブランチ運用・コミット・PR・auto-merge の詳細ルール。CLAUDE.md 本体から @参照。
+
+## ブランチ命名規則
+
+```
+{org-slug}/{type}/{YYYY-MM-DD}-{summary}
+```
+
+プラグイン開発など組織スコープ外の変更は `{type}/{YYYY-MM-DD}-{summary}` 形式可。
+
+- `{type}`: `feat` / `fix` / `docs` / `refactor` / `chore` / `admin`
+- `{summary}`: kebab-case で概要
+
+例:
+- `domain-tech-collection/feat/2026-04-11-daily-digest`
+- `a-sha-dwh-project/admin/2026-03-19-update-roles`
+- `fix/2026-04-11-diagram-cost-section`
+
+## コミットメッセージ
+
+Conventional Commits 準拠:
+
+```
+{type}: {概要} [{org-slug}] by {operator}
+```
+
+- `{operator}` は `git config user.name`
+- 組織スコープ内作業は `[{org-slug}]` 必須、スコープ外（プラグイン開発等）は省略可
+
+例:
+- `feat: セキュリティ部門を追加 [a-sha-dwh-project] by SAS-Sasao`
+- `fix: /company-diagram に コスト概算必須化 [domain-tech-collection]`
+- `chore: .claude/skills/ を同期（ランタイム反映）`
+
+## PR 運用
+
+### ファイル生成を伴う作業（原則）
+
+1. `main` から作業ブランチを作成
+2. 成果物を `.companies/{org-slug}/docs/` または `docs/` 配下に生成
+3. コミット
+4. `git push` → `gh pr create`
+5. PR 本文に変更サマリー・L0/L1/L2 スコア・関連 Issue を記載
+6. `gh pr merge --auto --squash --delete-branch`
+7. `main` に戻り pull
+
+### main 直コミット許可
+
+以下のみ main 直コミットを許可（PR 運用対象外）:
+
+- ダッシュボード HTML 再生成（`/company-dashboard`）
+- ダイジェスト HTML 再生成（`/company-digest-html`）
+- Case Bank 自動報酬スコア追記（hook 経由）
+- プラグインランタイム同期（`.claude/skills/` ↔ `plugins/cc-sier/skills/`）
+- マージ後のタスクログ `completed` 更新（Issue/PR番号追記）
+
+## auto-merge パターン
+
+3層レビュー（L0/L1/L2）通過後、PR は自動マージ:
+
+```bash
+gh pr merge {N} --auto --squash --delete-branch
+```
+
+- required status checks が無い場合 `--auto` は即時発火
+- マージ後、ローカル `main` は fast-forward で自動同期
+- リモート削除済みブランチは `git fetch --prune` で追従
+
+## 禁止事項
+
+- `main` への force push（緊急時もユーザー明示承認が必要）
+- `--no-verify` フック skip
+- `git reset --hard` / `rm -rf` の無承認実行
+- `.companies/.active` のコミット（`.gitignore` で除外済み）
+- マージ前の source branch 削除
+
+## 関連
+
+- @.claude/rules/task-log.md — タスクログと Issue 自動作成
+- @.claude/rules/review-pattern.md — L0/L1/L2 3層レビュー設計

--- a/.claude/rules/multi-org.md
+++ b/.claude/rules/multi-org.md
@@ -1,0 +1,80 @@
+# マルチ組織運用
+
+`.companies/` 配下で複数の仮想組織を並列管理する。各組織は独立のマスタ・成果物・task-log を持つ。
+
+## ディレクトリ構造
+
+```
+.companies/
+├── .active                  ← アクティブ組織のslug（1行、.gitignoreで除外）
+├── domain-tech-collection/  ← 組織ディレクトリの例
+│   ├── masters/             ← マスタデータ（organization/departments/roles/workflows/projects/mcp-services/quality-gates）
+│   ├── docs/                ← 全業務成果物
+│   │   ├── secretary/       ← 秘書室（常設）
+│   │   ├── research/        ← 技術リサーチ室
+│   │   ├── retail-domain/   ← 小売ドメイン室
+│   │   ├── daily-digest/    ← 日次ダイジェスト MD
+│   │   └── {dept}/          ← 部署ごとの成果物
+│   ├── .task-log/           ← タスクログ（Git管理）
+│   └── CLAUDE.md            ← 組織の文脈情報
+├── jutaku-dev-team/
+└── standardization-initiative/
+```
+
+## org-slug 命名ルール
+
+- **kebab-case**（小文字英数字とハイフンのみ）
+- 日本語はローマ字または英訳に変換
+- `.companies/` 直下でディレクトリ名として一意
+- 既存と重複する場合はサフィックス（`-2`, `-3` 等）を付与
+
+例:
+- 「A社DWH構築プロジェクト」→ `a-sha-dwh-project`
+- 「社内標準化推進」→ `standardization-initiative`
+- 「技術ドメイン収集PJT」→ `domain-tech-collection`
+
+## .active ファイル
+
+`.companies/.active` は**ローカル設定ファイル**（`.gitignore` で除外）。各ユーザーが独立して組織を切り替え可能。
+
+```
+# .companies/.active の例
+domain-tech-collection
+```
+
+Skill はこのファイルを起動時に読み取り、操作対象組織を特定する。`/company` 等のコマンドが組織切替 UI を提供する。
+
+## 組織マスタの標準構成
+
+各組織の `masters/` 配下に以下を配置:
+
+| ファイル | 用途 |
+|---|---|
+| `organization.md` | 組織名・オーナー・事業・コスト設定 |
+| `departments.md` | 部署一覧とトリガーワード |
+| `roles.md` | 部署対応 Subagent ロール |
+| `workflows.md` | 定義済みワークフロー（wf-daily-digest 等） |
+| `projects.md` | 進行中プロジェクト |
+| `mcp-services.md` | MCP サーバー一覧・利用可否 |
+| `quality-gates/by-type/*.md` | 成果物種別ごとの品質ゲート |
+
+## 組織追加フロー
+
+1. `/company` 起動 → 新規組織オンボーディング
+2. Q0〜Q3 ヒアリング（組織名・オーナー・事業・初期部署）
+3. `.companies/{new-slug}/` とマスタ生成
+4. `.companies/.active` を新 slug で更新
+
+詳細は `.claude/skills/company/SKILL.md` のオンボーディングフローを参照。
+
+## 組織独立性の原則
+
+- 組織 A の作業から組織 B のファイルを参照しない
+- 共通ルール（CLAUDE.md, rules/）はリポジトリルートに配置
+- 組織固有の文脈は `.companies/{slug}/CLAUDE.md` に配置
+- 組織をまたぐ作業（ナレッジ横串）は `/company-handover` 専用 Skill 経由
+
+## 関連
+
+- @.claude/rules/artifact-placement.md — 成果物配置ルール
+- @.claude/rules/git-workflow.md — 組織スコープのブランチ命名

--- a/.claude/rules/review-pattern.md
+++ b/.claude/rules/review-pattern.md
@@ -1,0 +1,107 @@
+# 3層レビュー + auto-merge パターン
+
+`/company-daily-digest`, `/company-diagram`, `/company-drawio` で採用する共通レビュー設計。PR 自動マージまでを統合実行する Skill は全てこのパターンに従う。
+
+## 3層レビューの全体像
+
+| 層 | 評価者 | 目的 | 実装 |
+|---|---|---|---|
+| **L0 機械レビュー** | シェル/Node スクリプト | 決定論的・定量チェック | grep / ls / 外部スクリプト（例: `review-drawio.js`） |
+| **L1 セルフ構造ゲート** | 秘書（author） | 構造・フォーマット・必須項目存在 | `masters/quality-gates/` の必須項目を自己チェック |
+| **L2 独立 LLM レビュー** | **fresh `general-purpose` agent** | 内容品質・整合性 | `references/review-prompt.md` で 6軸採点、JSON 出力 |
+
+## なぜ fresh general-purpose agent か
+
+- `lead-developer` 等の専門エージェントはコード/技術方針向きで文面評価の fit が弱い
+- 執筆者（秘書）自身に評価させると authoring bias が発生
+- fresh な general-purpose は WebFetch/Read 等全ツールを持ち、画像 Read も可能
+- 独立コンテキストで採点の一貫性と客観性を担保
+
+## L2 採点 6軸構成
+
+Skill ごとに軸の中身は変わるが、**共通で必ず 6軸 + composite + 致命軸**で設計する:
+
+```json
+{
+  "s1_structure": 0.00,        // 構造準拠（致命軸★が多い）
+  "s2_*": 0.00,                // Skill 固有（致命軸）
+  "s3_*": 0.00,                // Skill 固有
+  "s4_*": 0.00,
+  "s5_*": 0.00,
+  "s6_*": 0.00,                // 禁則違反系（致命軸）
+  "composite": 0.00,
+  "verdict": "pass|fail",
+  "critical_triggered": false,
+  "findings": [],
+  "fix_suggestions": []
+}
+```
+
+## 判定ルール（統一）
+
+- **致命軸** のいずれかが `< 0.5` → composite 強制 0.00, verdict = fail, critical_triggered = true
+- **必須セクション欠落** → composite 強制 0.00, verdict = fail, critical_triggered = true（数値均し込みで通過させない）
+- それ以外: composite = 等重み平均、`≥ 0.85` で pass
+
+## リトライポリシー
+
+- 各層 **1 回まで** 自動修正リトライ
+- L1 fail → 秘書が自動修正 → 再チェック → それでも fail なら中断
+- L2 fail → reviewer の findings/fix_suggestions を秘書にフィードバック → 1 回修正 → 再採点 → fail なら **auto-merge 中止**
+
+## Skill 別の致命軸設計
+
+| Skill | 致命軸 | 備考 |
+|---|---|---|
+| `/company-daily-digest` | s2 リンク完全性 / s6 禁則違反 | L2 2層（L0 なし） |
+| `/company-diagram` | s1 構造準拠 / s2 IaC生成 / s6 英語ラベル | L0: IaC存在+英語ラベル、L1: HTML 7セクション |
+| `/company-drawio` | s2 エッジ貫通 / s6 HTML埋め込み禁則 | L0: `review-drawio.js` 実行 |
+
+## 9フェーズ統合実行フロー（diagram/drawio 型）
+
+```
+Phase 0  ヒアリング（--yes でスキップ可）
+Phase 1  前処理（branch / task-log 初期化）
+Phase 2  MCP 生成
+Phase 3  ファイル配置（必須全ファイル）
+Phase 4  L0 機械レビュー
+Phase 5  L1 セルフ構造ゲート
+Phase 6  L2 独立 LLM レビュー
+Phase 7  PR 作成 & 自動マージ（gh pr merge --auto --squash --delete-branch）
+Phase 8  task-log 完了更新 + Issue 作成 + 報告
+```
+
+`/company-daily-digest` は Phase 0 なし（Q&A 不要、固定入力）、Phase 7 の後に main 直コミットの HTML 再生成工程が追加される 8 フェーズ構成。
+
+## 必須セクション欠落の検出設計
+
+**1 セクション欠落で composite 0.5 減点程度の均し込みでは検出漏れが発生する**（6軸平均で (0.3+5)/6 = 0.88 となり 0.85 を超えてしまう）。対策:
+
+1. L1 で機械的に grep → 1 つでも欠落で retry
+2. L2 review-prompt.md に **「必須セクションのうち 1 つでも欠落している場合、他のスコアに関わらず critical_triggered = true かつ verdict = fail を強制」** を明記
+3. s1（構造準拠）を致命軸に昇格
+
+過去の教訓: 2026-04-11 /company-diagram 初回実運用で コスト概算 と 学習ポイント の欠落が L2 通過し、PR #251 → #253 → #254 の 3 段階ですり抜け修正が発生（`feedback_skill_rewrite_regression.md`）。
+
+## task-log への記録
+
+L0/L1/L2 の結果は task-log の YAML フロントマターに必ず記録:
+
+```yaml
+l0_gate: pass
+l0_retries: 0
+l1_gate: pass
+l1_retries: 0
+l2_composite: 0.98
+l2_retries: 0
+l2_scores:
+  s1_structure: 1.00
+  s2_iac: 1.00
+  ...
+```
+
+## 関連
+
+- @.claude/rules/skill-development.md — SKILL.md リライト時の取りこぼし防止
+- @.claude/rules/task-log.md — task-log 形式
+- @.claude/rules/git-workflow.md — PR + auto-merge

--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -1,0 +1,101 @@
+# Skill 開発ルール
+
+`plugins/cc-sier/skills/` 配下の Skill 開発ルールと、ランタイム同期の手順。
+
+## SKILL.md の制約
+
+### プログレッシブ・ディスクロージャ
+
+- **1,500〜2,000語以内**に収める
+- 詳細テンプレート・HTML スニペット・採点プロンプトは `references/` 配下に外出し
+- SKILL.md 本体は「何を・いつ・どう」の概要のみ
+
+### 標準ファイル構成
+
+```
+plugins/cc-sier/skills/{skill-name}/
+├── SKILL.md                 ← メインファイル（1,500〜2,000語）
+└── references/              ← 詳細定義（必要時のみ参照）
+    ├── review-prompt.md     ← L2 採点プロンプト（レビュー付きSkill）
+    └── *.md                 ← その他テンプレート
+```
+
+## plugins/ ↔ .claude/skills/ の同期ルール
+
+### 背景
+
+Claude Code ランタイムは `.claude/skills/` を読む。`plugins/cc-sier/skills/` に追加しただけでは `/` コマンドリストに現れない。
+
+### 同期コマンド
+
+```bash
+# 新規 Skill 追加時
+cp -r plugins/cc-sier/skills/{new-skill-name} .claude/skills/
+
+# 既存 Skill 更新時
+cp plugins/cc-sier/skills/{name}/SKILL.md .claude/skills/{name}/SKILL.md
+cp plugins/cc-sier/skills/{name}/references/*.md .claude/skills/{name}/references/
+
+# 同期確認
+diff -rq plugins/cc-sier/skills/{name}/ .claude/skills/{name}/
+```
+
+### VCS の真ソース
+
+`plugins/cc-sier/skills/` が VCS 真ソース。`.claude/skills/` 側に独自編集を入れない（legacy リファレンスのみ例外）。
+
+## SKILL.md リライト時の取りこぼし防止プロセス
+
+過去に /company-diagram 9フェーズ化リライトで `aws-cost-estimation.md` 参照と 学習ポイントセクション生成を取りこぼし、3 段階（PR #251→#253→#254）ですり抜け修正した経験あり。
+
+### Step 0（最重要）: 既存成果物の必須セクションを grep で抽出
+
+```bash
+# HTML 成果物の場合
+for f in docs/diagrams/*.html; do
+  [[ "$f" == *-iac.html || "$f" == *index.html ]] && continue
+  echo "=== $(basename $f) ==="
+  grep -o "<h2>[^<]*</h2>" "$f"
+done
+
+# MD 成果物の場合
+for f in .companies/{org}/docs/daily-digest/*.md; do
+  echo "=== $(basename $f) ==="
+  grep -E "^##? " "$f"
+done
+```
+
+**6/10 以上の成果物に共通する見出し = 実質必須セクション**。新 SKILL.md と照合。
+
+### Step 1: 旧 SKILL.md の references/ 参照を抽出
+
+```bash
+grep -n "references/" plugins/cc-sier/skills/{name}/SKILL.md
+```
+
+### Step 2: references/ の orphan 検出
+
+```bash
+for ref in $(ls plugins/cc-sier/skills/{name}/references/); do
+  grep -q "$ref" plugins/cc-sier/skills/{name}/SKILL.md && echo "✓ $ref" || echo "✗ $ref (orphan)"
+done
+```
+
+### Step 3: L2 review-prompt.md の同時更新
+
+SKILL.md の必須セクション変更は **必ず** `references/review-prompt.md` の採点基準にも反映する。片方だけ更新すると L2 レビューが旧仕様で通過してしまう。
+
+### Step 4: 初回実運用前に --dry-run
+
+可能な限り、初回実運用前に `--dry-run` フラグで Phase 5 までを実行し、既存成果物と diff を取る。
+
+## Subagent との関係
+
+- `plugins/cc-sier/agents/` に定義（VCS 真ソース、19種）
+- `.claude/agents/` にコピーされランタイムで使用
+- 代表: secretary / project-manager / data-architect / tech-researcher / retail-domain-researcher 等
+
+## 関連
+
+- @.claude/rules/review-pattern.md — 3層レビューの標準設計
+- @.claude/rules/git-workflow.md — PR・auto-merge

--- a/.claude/rules/task-log.md
+++ b/.claude/rules/task-log.md
@@ -1,0 +1,120 @@
+# タスクログと Issue 自動作成
+
+ファイル生成を伴うタスクの実行過程を `.task-log/` に記録し、完了時に GitHub Issue として自動作成する。
+
+## .task-log/ ディレクトリ
+
+```
+.companies/{org-slug}/
+├── CLAUDE.md
+├── masters/
+├── docs/
+└── .task-log/                      ← タスク実行ログ（Git管理対象）
+    └── {task-id}.md                ← 1タスク1ファイル
+```
+
+- **task-id**: `YYYYMMDD-HHMMSS-{概要slug}`（例: `20260411-121507-daily-digest`）
+- docs/ とは分離（成果物の可読性を保つ）
+- タスク完了時のコミットに含める（PR の一部）
+
+## YAML フロントマター形式（必須）
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: in-progress          # in-progress / completed / blocked
+mode: "agent-teams"          # agent-teams / subagent / direct
+started: "2026-04-11T12:15:07"
+completed: ""
+request: "{ユーザー依頼原文}"
+issue_number: null
+pr_number: null
+subagents: [general-purpose-tech, general-purpose-retail, general-purpose-reviewer]
+l0_gate: null                # pass / fail / null（レビュー付き Skill のみ）
+l0_retries: 0
+l1_gate: null                # pass / fail / null
+l1_retries: 0
+l2_composite: null           # 0.00 - 1.00（レビュー付き Skill のみ）
+l2_retries: 0
+---
+```
+
+**重要**:
+- **Subagent 名は必ず英字**で記録（日本語名だと Case Bank 検出不可）
+- **YAML フロントマター形式必須**（MD リスト形式はパーサ検出不可）
+- judge 評価済みなのに reward が null のまま残らないよう post-merge hook で補完される
+
+## セクション構成
+
+```markdown
+## 実行計画
+- **実行モード**: agent-teams / subagent / direct
+- **アサインされたロール**: {ロール一覧}
+- **参照したマスタ**: {workflows.md, quality-gates 等}
+- **判断理由**: {なぜこの実行方式を選んだか}
+
+## エージェント作業ログ
+### [2026-04-11 12:15:07] secretary
+受付: {依頼原文の要約}
+
+### [2026-04-11 12:18:30] secretary → general-purpose-tech
+委譲: Phase 2 Web巡回
+
+### [2026-04-11 12:22:00] general-purpose-tech
+完了: tech team 73件収集
+
+## reward
+（post-merge hook が自動追記）
+```
+
+## Issue 自動作成
+
+タスク完了時に `gh issue create` で Issue を作成:
+
+```bash
+gh issue create \
+  --title "[{org-slug}] {タスク概要}" \
+  --label "org:{org-slug},mode:{mode},type:{type},dept:{dept}" \
+  --body "$(Issue本文)"
+```
+
+### ラベル決定ルール
+
+- `org:{org-slug}` — 常に付与
+- `mode:agent-teams` / `mode:subagent` / `mode:direct` — 実行モード
+- `type:daily-digest` / `type:diagram` / `type:design` / `type:docs` 等 — タスク種別
+- `dept:secretary` / `dept:data` 等 — 関与部署
+
+### ラベル未定義時
+
+```bash
+gh label create "{label}" --color "{color}" --force 2>/dev/null
+```
+
+色の規則: `org:*` = #0075ca / `mode:*` = #e4e669 / `dept:*` = #7057ff / `type:*` = #008672
+
+## スキップ条件
+
+ファイル生成を伴わない作業は **task-log 作成・Issue 作成ともにスキップ**:
+
+- 壁打ち・雑談
+- ダッシュボード表示
+- 組織切り替え・選択
+
+Gitワークフロー（ブランチ作成）が必要な作業 = task-log 必要 と同じ基準。
+
+## Skill 直接実行時の扱い
+
+`/company` 経由でなく Skill を直接実行した場合も **task-log は必須**。理由: Case Bank 学習が漏れると、後続セッションで類似ケース参照ができなくなる。
+
+## gh CLI 利用不可時のフォールバック
+
+1. `.task-log/{task-id}.md` にログは記録する（ローカル証跡として有効）
+2. Issue 作成はスキップし、完了報告に gh CLI 必須を明示
+
+## 関連
+
+- @.claude/rules/git-workflow.md — コミット・PR
+- @.claude/rules/review-pattern.md — L0/L1/L2 の task-log 記録形式

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,184 +1,184 @@
 # CC-SIer 開発リポジトリ
 
-このリポジトリは Claude Code プラグイン **cc-sier**（SIer業務特化の仮想組織プラグイン）の開発リポジトリです。
+## AI 運用ルール
 
-## ディレクトリ構成
+### 基本原則
+
+- **言語**: 応答・ドキュメント・コメントは日本語（コード内コメントは英語可）
+- **業務成果物の配置**: 必ず `.companies/{org-slug}/docs/` または `docs/` 配下（リポジトリルート直下は禁止）
+- **破壊的操作**: `git reset --hard` / `git push --force` / `rm -rf` 等は事前承認必須
+- **リファクタのスコープ遵守**: 依頼外の改善・コメント追加・過剰な抽象化は禁止
+- **不明点の解消**: 既存成果物や rules/ を先に確認し、推測で埋めない
+
+### 作業ルール
+
+- ファイル生成を伴う作業は必ずブランチ＋PR（例外は @.claude/rules/git-workflow.md 参照）
+- `plugins/cc-sier/skills/` を編集したら `.claude/skills/` にも必ず同期
+- 3層レビュー（L0/L1/L2）を通さずに auto-merge しない
+- タスクログは YAML フロントマター形式で `.task-log/` に記録
+
+詳細: @.claude/rules/git-workflow.md / @.claude/rules/task-log.md
+
+---
+
+## プロジェクト概要
+
+このリポジトリは Claude Code プラグイン **cc-sier**（SIer 業務特化の仮想組織プラグイン）の開発リポジトリです。マスタデータ駆動で部署・ロール・ワークフローを動的に編成し、Agent Teams で並列作業を実行します。
+
+主要機能:
+
+- **マルチ組織運営**: `.companies/` 配下で複数組織を並列管理（現在 3 組織）
+- **Skill による業務自動化**: 12 種類の `/company-*` コマンド
+- **Subagent による専門領域**: 19 種類のロール別エージェント
+- **3 層レビュー + auto-merge**: Skill 成果物を機械的・構造的・LLM的に 3 層で品質担保
+- **Case Bank 継続学習**: 過去タスクログを報酬スコア付きで蓄積し次セッションで参照
+
+要件定義書 v0.3: @docs/requirements.md (1,515 行)
+
+---
+
+## 技術スタック
+
+| 領域 | 技術 | バージョン |
+|---|---|---|
+| プラグイン基盤 | Claude Code Plugin（Skill + Subagent） | - |
+| MCP サーバー | aws-knowledge / aws-diagram / aws-iac / drawio | 各 latest |
+| ランタイム（Python） | Python + uv + GraphViz（aws-diagram 用） | 3.10+ |
+| ランタイム（Node） | Node.js + npx（drawio MCP, review-drawio.js） | 20+ |
+| シェル | Bash（`.claude/hooks/` 配下 15 本） | 5.x |
+| CLI | GitHub CLI (`gh`) | latest |
+| ドキュメント配信 | GitHub Pages (`docs/` 配下) | - |
+
+---
+
+## 開発コマンド
+
+### Skill 実行（`/` プレフィックス）
+
+| コマンド | 用途 |
+|---|---|
+| `/company` | 秘書・組織運営・壁打ち・部署追加 |
+| `/company-admin` | マスタデータ管理（部署・ロール・ワークフロー） |
+| `/company-daily-digest` | 日次ニュース巡回 → MD → 3層レビュー → PR → HTML公開（8フェーズ） |
+| `/company-diagram` | AWS 構成図生成 + L0/L1/L2 レビュー + auto-merge（9フェーズ） |
+| `/company-drawio` | draw.io 汎用図生成 + 3層レビュー + auto-merge（9フェーズ） |
+| `/company-dashboard` | 組織活動ダッシュボード HTML 生成 |
+| `/company-digest-html` | 日次ダイジェスト HTML 再生成（main 直コミット） |
+| `/company-handover` | 全活動のナレッジポータル HTML 生成 |
+| `/company-spawn` | アプリケーションリポジトリ切り出し |
+| `/company-report` | 組織活動サマリーレポート（日次/週次/月次） |
+| `/company-evolve` | Case Bank 継続学習・Skill トリガー語拡張 |
+| `/company-quality-setup` | `masters/quality-gates/` チェックリスト配置 |
+
+### Git / PR
+
+```bash
+# ブランチ作成
+git checkout -b {org-slug}/{type}/{YYYY-MM-DD}-{summary}
+
+# PR 作成 + auto-merge
+gh pr create --title "..." --body "..."
+gh pr merge {N} --auto --squash --delete-branch
+```
+
+### Skill 同期（新規追加・更新時）
+
+```bash
+cp -r plugins/cc-sier/skills/{name} .claude/skills/
+diff -rq plugins/cc-sier/skills/{name}/ .claude/skills/{name}/
+```
+
+### L0 レビュースクリプト
+
+```bash
+node .claude/skills/company-drawio/references/review-drawio.js docs/drawio/{filename}.drawio
+```
+
+---
+
+## ディレクトリ構造
 
 ```
 cc-sier-organization/
-├── .claude-plugin/           ← プラグインメタデータ（marketplace.json, plugin.json）
+├── .claude-plugin/           ← plugin.json / marketplace.json
+├── .claude/
+│   ├── skills/               ← ランタイム Skill（plugins からの同期先、12種）
+│   ├── agents/               ← 19 種の Subagent
+│   ├── hooks/                ← 15 本の Shell スクリプト（Case Bank / Dashboard 等）
+│   └── rules/                ← 詳細ルール（本 CLAUDE.md から @参照）
 ├── .companies/               ← 組織データ（マルチ組織対応）
-│   ├── .active               ← アクティブ組織のslug
-│   └── {org-slug}/           ← 組織ごとのディレクトリ
-├── plugins/cc-sier/
-│   ├── skills/
-│   │   ├── company/          ← メインSkill（/company コマンド）
-│   │   │   ├── SKILL.md
-│   │   │   └── references/   ← 部署テンプレート、ワークフロー定義等
-│   │   ├── company-admin/    ← マスタ管理Skill（/company-admin コマンド）
-│   │   │   ├── SKILL.md
-│   │   │   └── references/
-│   │   └── company-spawn/    ← アプリリポジトリ切り出しSkill
-│   │       ├── SKILL.md
-│   │       └── references/
-│   └── agents/               ← Subagent定義（secretary.md, project-manager.md 等）
-├── docs/
-│   └── requirements.md       ← 要件定義書（実装時は必ず参照すること）
-├── requirements/             ← 要件定義書の原本
-├── CLAUDE.md                 ← このファイル
-├── README.md
-└── LICENSE
+│   ├── .active               ← .gitignore で除外、ローカル設定
+│   └── {org-slug}/
+│       ├── masters/          ← organization/departments/roles/workflows/projects/mcp-services/quality-gates
+│       ├── docs/             ← 全業務成果物（部署別）
+│       ├── .task-log/        ← タスクログ（Git 管理）
+│       └── CLAUDE.md         ← 組織文脈
+├── plugins/cc-sier/          ← プラグインソース（VCS 真ソース）
+│   ├── skills/               ← 9 種の Skill（company / -admin / -diagram 等）
+│   └── agents/               ← Subagent 定義
+├── docs/                     ← GitHub Pages 配信 + 要件定義
+│   ├── requirements.md       ← 要件定義 v0.3（実装時必読）
+│   ├── diagrams/             ← AWS 構成図（PNG/HTML/YAML/iac-viewer）
+│   ├── drawio/               ← draw.io 汎用図
+│   ├── daily-digest/         ← 日次ダイジェスト HTML
+│   ├── secretary/            ← ダッシュボード HTML
+│   └── handover/             ← ナレッジポータル
+├── CLAUDE.md                 ← このファイル（開発用）
+└── README.md
 ```
 
-## 要件定義書
-
-**docs/requirements.md** に要件定義書 v0.3 があります。実装時は必ず該当セクションを参照してください。
-
-主要セクション:
-- セクション 2: Claude Code 機能マッピング
-- セクション 3: Skill 設計（/company, /company-admin）
-- セクション 4: Subagent 設計（13種のエージェント定義）
-- セクション 5: CLAUDE.md 設計（階層構造）
-- セクション 6: マスタデータ設計（スキーマ、連鎖更新ルール）
-- セクション 7: Agent Teams 統合設計
-- セクション 8: SIer特化テンプレート（ADR、ポストモーテム等）
-
-## マルチ組織構造
-
-### .companies/ ディレクトリ
-
-複数の仮想組織を並列管理するためのルートディレクトリ。各組織のマスタデータ・成果物はすべてこのディレクトリ配下の組織ディレクトリに格納される。
-
-```
-.companies/
-├── .active                  ← 現在操作対象のorg-slugを1行で記載
-├── a-sha-dwh-project/       ← 組織ディレクトリの例
-│   ├── masters/             ← マスタデータ
-│   ├── CLAUDE.md            ← 組織の文脈情報
-│   └── docs/                ← 全成果物はここに集約
-│       └── {dept}/          ← 部署ごとの成果物
-└── standardization-initiative/
-    └── ...
-```
-
-### org-slug 命名ルール
-
-- kebab-case（小文字英数字とハイフンのみ）
-- 日本語はローマ字または英訳に変換
-- 例: 「A社DWH構築プロジェクト」→ `a-sha-dwh-project`
-- 例: 「社内標準化推進」→ `standardization-initiative`
-- `.companies/` 直下のディレクトリ名として一意であること
-- 既存と重複する場合はサフィックス（-2, -3等）を付与
-
-### .active ファイル
-
-`.companies/.active` はローカル設定ファイル（`.gitignore` で除外）。各ユーザーが独立して組織を切り替え可能。
-アクティブ組織の org-slug を1行で記載する。Skillはこのファイルを起動時に読み取り、操作対象組織を特定する。
-
-```
-# .companies/.active の例
-a-sha-dwh-project
-```
+詳細: @.claude/rules/multi-org.md / @.claude/rules/artifact-placement.md
 
 ---
 
-## 成果物格納ルール
+## コーディング規約
 
-- **全成果物は `.companies/{org-slug}/docs/` 配下に作成すること**
-- CLAUDE.md（組織ルール）と masters/（マスタデータ）は組織ルート直下に配置
-- リポジトリルートや `.claude/` 配下に業務成果物ファイルを作成してはならない
-- Subagentへの委譲時も、組織パス（`.companies/{org-slug}/docs/`）を明示して指示すること
-- Subagentファイル（`.claude/agents/`）はグローバルリソースのため例外とする
+- **コミットメッセージ**: Conventional Commits（`feat:` / `fix:` / `docs:` / `refactor:` / `chore:` / `admin:`）
+- **コミット本文形式**: `{type}: {概要} [{org-slug}] by {operator}`
+- **ブランチ命名**: `{org-slug}/{type}/{YYYY-MM-DD}-{summary}`
+- **SKILL.md の長さ**: 1,500〜2,000 語以内（プログレッシブ・ディスクロージャ、詳細は `references/` に外出し）
+- **MD リンクタイトル**: 半角 `[...]` は全角 `【...】` に置換（HTML 変換時のリンク消失防止）
+- **インデント**: 2 スペース（HTML/YAML/Markdown）、タブ使用禁止
 
----
-
-## Gitワークフロー
-
-ファイル生成を伴うすべての業務作業はブランチを作成してPRで管理する。
-
-### ブランチ命名規則
-
-```
-{org-slug}/{type}/{YYYY-MM-DD}-{summary}
-```
-
-- `{type}`: 作業種別（`feat`, `fix`, `docs`, `admin` 等）
-- `{summary}`: 作業概要をkebab-caseで記述
-- 例: `a-sha-dwh-project/feat/2026-03-19-add-security-dept`
-- 例: `a-sha-dwh-project/admin/2026-03-19-update-roles`
-
-### コミットメッセージ
-
-```
-{type}: {概要} [{org-slug}] by {operator}
-```
-
-- 例: `feat: セキュリティ部門を追加 [a-sha-dwh-project]`
-- 例: `docs: 要件定義書を更新 [standardization-initiative]`
-
-### フロー
-
-1. mainから作業ブランチを作成
-2. 成果物を `.companies/{org-slug}/docs/` 配下に生成
-3. コミット（メッセージは上記規則に従う）
-4. PR作成（変更サマリーをPR本文に記載）
-5. mainブランチに戻る
-
-## タスクログと Issue 自動作成
-
-ファイル生成を伴うタスクの実行過程を `.companies/{org-slug}/.task-log/` に記録し、完了時に GitHub Issue として自動作成する。
-
-### .task-log/ ディレクトリ
-
-```
-.companies/{org-slug}/
-├── CLAUDE.md
-├── masters/
-├── docs/
-└── .task-log/                        ← タスク実行ログ（Git管理対象）
-    └── {task-id}.md                  ← 1タスク1ファイル
-```
-
-- task-id: `YYYYMMDD-HHMMSS-{概要slug}`
-- ログファイルは成果物（docs/）とは分離して配置
-- タスク完了時のコミットに含める（PRの一部になる）
-
-### Issue 作成
-
-- タスク完了時に `gh issue create` で自動作成
-- ラベル: `org:{org-slug}`, `mode:{mode}`, `dept:{dept}`, `type:{type}`
-- テンプレート: `.claude/skills/company/references/task-log-template.md`
-- ファイル生成を伴わない作業（壁打ち、ダッシュボード等）ではスキップ
+詳細: @.claude/rules/git-workflow.md / @.claude/rules/skill-development.md
 
 ---
 
-## 開発ルール
+## 注意事項
 
-### コミットメッセージ
-Conventional Commits に従うこと:
-- `feat:` 新機能
-- `fix:` バグ修正
-- `docs:` ドキュメントのみの変更
-- `refactor:` リファクタリング
-- `chore:` ビルド・設定等の変更
+- ❌ リポジトリルートや `.claude/skills/agents/hooks/rules` 以外の `.claude/` 配下に業務成果物を作成しない
+- ❌ `main` への force push 禁止（緊急時も明示承認必要）
+- ❌ `.companies/.active` のコミット禁止（ローカル専用、`.gitignore` で除外済み）
+- ❌ SKILL.md リライト時の旧版 references/ 取りこぼし禁止（事前に既存成果物を `grep -o "<h2>"` で必須セクション抽出）
+- ❌ 必須セクション欠落のまま auto-merge 禁止（L2 で `critical_triggered = true` を強制する設計）
+- ❌ `--no-verify` でのフック skip
+- ⚠️ `/company-diagram` 詳細ページは **必須 7 セクション固定順序**: 凡例 → 概要 → データフロー → レイヤー構成 → 設計のポイント → コスト概算 → 学習ポイント
+- ⚠️ 日次ダイジェストは章順固定（A → B → C → D）・テーブル形式・テーマ別分類
+- ⚠️ AWS Diagram Python コードのラベルに `\n` 改行を含めない（silent error）
+- ⚠️ Subagent 名は task-log に英字で記録（日本語名だと Case Bank 検出不可）
 
-### 言語
-- ドキュメント・コメント: 日本語
-- コード内コメント: 英語可
+詳細: @.claude/rules/review-pattern.md
 
-### SKILL.md の制約
-- **1,500〜2,000語以内に収めること**（プログレッシブ・ディスクロージャ）
-- 詳細な定義は `references/` 配下に外出しし、必要時のみ参照する
+---
 
-### 実装時の必須事項
-- 実装前に必ず `docs/requirements.md` の該当セクションを読むこと
-- マスタスキーマの変更は `references/master-schemas.md` のバリデーションルールに従うこと
+## 外部参照
 
-## 重要な注意
+| ファイル | 内容 |
+|---|---|
+| @docs/requirements.md | 要件定義書 v0.3（§2 機能マッピング / §3 Skill / §4 Subagent / §5 CLAUDE.md 階層 / §6 マスタ / §7 Agent Teams / §8 SIer テンプレート） |
+| @.claude/rules/git-workflow.md | ブランチ命名・コミット・PR 運用・auto-merge の詳細 |
+| @.claude/rules/skill-development.md | SKILL.md 制約・plugins↔.claude 同期・リライト時の取りこぼし防止 |
+| @.claude/rules/multi-org.md | `.companies/` マルチ組織運用・org-slug 命名・.active |
+| @.claude/rules/artifact-placement.md | 成果物配置マトリクス（`docs/` vs `.companies/{org}/docs/`） |
+| @.claude/rules/task-log.md | YAML フロントマター形式・Issue 自動作成・ラベル決定 |
+| @.claude/rules/review-pattern.md | L0/L1/L2 3 層レビュー + auto-merge 設計 |
 
-- `plugins/cc-sier/skills/` 配下が **Skill ファイル**（プラグインインストール時に `.claude/skills/` に配置される）
-- `plugins/cc-sier/agents/` 配下が **Subagent ファイル**（プラグインインストール時に `.claude/agents/` に配置される）
-- プロジェクトルートの `CLAUDE.md`（このファイル）は開発用。ユーザー環境に生成される `.companies/{org-slug}/CLAUDE.md` とは別物
-- `/company-spawn` でアプリケーションリポジトリを新規作成できる
-- 設計成果物とSubagentを新リポにコピーし、パスを自動書き換えする
-- コピー元の追跡情報は新リポの `docs/design/origin.md` に記録される
+---
+
+## 重要な前提
+
+- `plugins/cc-sier/` = プラグインソース（VCS 真ソース）
+- `.claude/skills/` と `.claude/agents/` = インストール済みランタイム（`plugins/` から手動 `cp` 同期）
+- プロジェクトルート `CLAUDE.md`（本ファイル）= 開発用
+- `.companies/{org-slug}/CLAUDE.md` = 組織文脈（ランタイム、別物）
+- `/company-spawn` でアプリケーションリポジトリ新規作成可、設計成果物とSubagent を自動コピー、追跡情報は新リポ `docs/design/origin.md` に記録


### PR DESCRIPTION
## Summary

旧 CLAUDE.md は実装初期の状態で止まっており、現状（12 Skill / 19 Subagent / 3 組織 / 15 hooks / 3層レビュー + auto-merge）を反映していなかった。sas-dx/claude-code-starter-kit の推奨構成に合わせて **8 セクション / 200 行以内** に再編し、詳細ルールは `.claude/rules/` に分割。

## 変更内容

### 1. CLAUDE.md（184 行、200 以内）

starter-kit の 8 セクション構成:
1. AI 運用ルール（基本原則・作業ルール）
2. プロジェクト概要
3. 技術スタック
4. 開発コマンド（12 Skill 一覧 + Git + 同期 + L0 スクリプト）
5. ディレクトリ構造
6. コーディング規約
7. 注意事項（過去の学習を反映した禁止・警告）
8. 外部参照（rules/ と requirements.md への @リンク）

### 2. .claude/rules/ 新設（6 ファイル、549 行）

| ファイル | 内容 |
|---|---|
| \`git-workflow.md\` | ブランチ・コミット・PR・main 直コミット許可対象・auto-merge |
| \`skill-development.md\` | SKILL.md 制約 / plugins↔.claude 同期 / リライト時取りこぼし防止 grep |
| \`multi-org.md\` | \`.companies/\` マルチ組織運用・org-slug 命名・.active |
| \`artifact-placement.md\` | 成果物配置マトリクス（Pages 配信 vs 組織スコープ） |
| \`task-log.md\` | YAML フロントマター・Subagent 英字記録・Issue 自動作成 |
| \`review-pattern.md\` | L0/L1/L2 3層レビュー・6軸採点・致命軸・必須セクション critical |

## 反映した学び（今日までに積み上げた教訓）

- SKILL.md リライト時の旧版 references/ 取りこぼし禁止 → \`skill-development.md\` に grep ワンライナー付きプロセス
- 必須セクション欠落のまま auto-merge 禁止 → \`review-pattern.md\` に「数値均し込みでなくブール critical」ルール
- /company-diagram 詳細ページ 7 セクション固定順序 → 注意事項に明記
- AWS Diagram Python ラベル \\n 禁止 → 注意事項に明記
- Subagent 名 task-log 英字記録 → \`task-log.md\` に明記
- plugins/↔.claude/ 同期ルール → \`skill-development.md\` に手順と orphan 検出ワンライナー

## 行数確認

| ファイル | 行数 |
|---|---|
| CLAUDE.md | **184** ✓ |
| .claude/rules/git-workflow.md | 82 |
| .claude/rules/skill-development.md | 101 |
| .claude/rules/multi-org.md | 80 |
| .claude/rules/artifact-placement.md | 59 |
| .claude/rules/task-log.md | 120 |
| .claude/rules/review-pattern.md | 107 |

## @参照記法

starter-kit の \`@path/to/file\` 構文で rules/ と docs/ を参照。CLAUDE.md 本体を簡潔に保ちながら、必要時に詳細へアクセス可能な構造に。

## Test plan

- [x] CLAUDE.md が 200 行以内
- [x] 全 rules/ ファイルが CLAUDE.md から @参照されている
- [ ] 次回 /company 等の Skill 実行時に新 CLAUDE.md / rules/ の内容が適用されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)