### PR TITLE
fix: nightly workflow の env を job レベルに移動（post step 伝播対策）

### DIFF
--- a/.github/workflows/nightly-claude-md-update.yml
+++ b/.github/workflows/nightly-claude-md-update.yml
@@ -45,6 +45,13 @@ jobs:
   update:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # 認証 env は job レベルで定義する。
+    # step レベルの env: は GitHub Actions の post step には伝播しないため、
+    # claude-code-action の post-buffered-inline-comments.ts の env validation が
+    # 失敗する。job レベルなら main / post 両方に伝播する。
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       # -----------------------------------------------------------------
       # Step 1: リポジトリ取得（git log 用に全履歴）
@@ -60,9 +67,6 @@ jobs:
       # シークレット未登録なら早期に明示的なエラーで停止する
       # -----------------------------------------------------------------
       - name: Pre-flight auth check
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
             cat <<'MSG' >&2
@@ -180,9 +184,6 @@ jobs:
       - name: Run Claude Code
         if: steps.signals.outputs.total != '0'
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           prompt: |
             あなたは cc-sier リポジトリの **CLAUDE.md / .claude/rules/** の nightly 更新担当です。


### PR DESCRIPTION
## Summary

run [24275935759](https://github.com/SAS-Sasao/cc-sier-organization/actions/runs/24275935759) の追加失敗対応。secret 登録は完了したが post step が依然として認証を読めない問題。

## 根本原因

- PR #258 で env block を Run Claude Code **step レベル** に追加した
- ❌ **step-level env は GitHub Actions の post step には伝播しない**（仕様）
- claude-code-action は main 終了後に \`post-buffered-inline-comments.ts\` を post step として実行
- post step で env validation が走り、step-level env が見えず fail

## 失敗時の挙動（証拠）

\`\`\`
- Using CLAUDE_CODE_OAUTH_TOKEN (OAuth auth)   ← Pre-flight (main) は通過
- signals - PR=9 tasklog=3 commit=18 total=30  ← signal 収集成功
- Action failed: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
                                                 ← post step で fail
\`\`\`

main step では env が見えるのに post step では見えない。これが step-level env の限界。

## 修正

env block を **job レベル** に移動:

\`\`\`yaml
jobs:
  update:
    runs-on: ubuntu-latest
    env:                                       # ← job レベルに昇格
      ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
      CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    steps:
      ...
\`\`\`

job-level env は main / post 両方の全 step に伝播する。step-level の重複定義を削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)