### PR TITLE
fix: claude_code_oauth_token を input parameter として復活（action.yml 真因対応）

### DIFF
--- a/.github/workflows/nightly-claude-md-update.yml
+++ b/.github/workflows/nightly-claude-md-update.yml
@@ -176,15 +176,22 @@ jobs:
       # -----------------------------------------------------------------
       # Step 4: Claude Code Action による更新提案
       #
-      # v1 GA では `claude_code_oauth_token` という input parameter は無く、
-      # アクションの post-step は env から ANTHROPIC_API_KEY または
-      # CLAUDE_CODE_OAUTH_TOKEN を読む。両方を env: で渡しておけば、
-      # どちらか登録済みの secret が使われる。
+      # 認証は claude_code_oauth_token / anthropic_api_key の **input parameter**
+      # で渡す必要がある。v1 GA の action.yml は内部で
+      #   env:
+      #     ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+      #     CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+      # と input から env を「上書き」設定するため、input を渡さないと
+      # job-level env も空文字列で上書きされてしまう。
+      # 公式 docs の parameter table には載っていないが、action.yml では定義されている。
+      # 参考: https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml
       # -----------------------------------------------------------------
       - name: Run Claude Code
         if: steps.signals.outputs.total != '0'
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             あなたは cc-sier リポジトリの **CLAUDE.md / .claude/rules/** の nightly 更新担当です。
             過去 ${{ steps.window.outputs.period_jp }} のシグナルから「運用ルールに追加すべき学び」を


### PR DESCRIPTION
## Summary

run [24276009563](https://github.com/SAS-Sasao/cc-sier-organization/actions/runs/24276009563) まで失敗継続。**action.yml を直接確認** して真因が判明した。

## 真因（action.yml ベース）

PR #258 で「v1 GA は \`claude_code_oauth_token\` input parameter を受け付けない」と判断したのが**間違い**。action.yml 直接参照で確認:

\`\`\`yaml
inputs:
  anthropic_api_key:
    description: "Anthropic API key (required for direct API)"
  claude_code_oauth_token:
    description: "Claude Code OAuth token (alternative to anthropic_api_key)"
\`\`\`

両方とも v1 GA の正規 input parameter として**存在する**。公式 docs の parameter table が不完全だっただけで、Zenn 記事は正しかった。

## なぜ env block でも効かなかったか（重要）

action.yml 内部で main step に以下が定義されている:

\`\`\`yaml
env:
  ANTHROPIC_API_KEY: \${{ inputs.anthropic_api_key }}
  CLAUDE_CODE_OAUTH_TOKEN: \${{ inputs.claude_code_oauth_token }}
\`\`\`

action 自身が **input から env を「上書き」設定** している。input が空なら env も空文字列で上書きされる。

GitHub Actions の env precedence は **step env > job env**。job-level で \`CLAUDE_CODE_OAUTH_TOKEN\` を設定しても、action 内部のこの step env (空) で潰される。

## 修正

input parameter を**復活**:

\`\`\`yaml
- name: Run Claude Code
  uses: anthropics/claude-code-action@v1
  with:
    claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
    prompt: ...
\`\`\`

job-level env も保持（pre-flight check 用 + 何らかの不具合時の保険）。

## 参考

- action.yml 真ソース: https://raw.githubusercontent.com/anthropics/claude-code-action/v1/action.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)