### PR TITLE
fix: Create PR step の git push に GITHUB_TOKEN 付き remote URL を設定

### DIFF
--- a/.github/workflows/nightly-claude-md-update.yml
+++ b/.github/workflows/nightly-claude-md-update.yml
@@ -358,6 +358,12 @@ jobs:
         run: |
           BRANCH="docs/nightly-${DATE_JST}-claude-md-update"
 
+          # claude-code-action が git config / remote を変更している可能性が
+          # あるため、push する前に GITHUB_TOKEN 付きの remote URL を再設定する。
+          # actions/checkout の persist-credentials が無効化されたケースの保険。
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           git config user.email "claude-nightly[bot]@users.noreply.github.com"
           git config user.name "Claude Nightly Bot"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary

run [24276102231](https://github.com/SAS-Sasao/cc-sier-organization/actions/runs/24276102231) — **認証問題はついに解決**し Claude Code Action が完走したが、最後の \`Create PR\` ステップで git push が auth failed。

## 失敗状況

\`\`\`
✅ Pre-flight check
✅ Signal collection
✅ Run Claude Code（Claude が実際に CLAUDE.md/rules を編集）
✅ Detect changes（変更を検知）
❌ Create PR: fatal: Authentication failed for 'https://github.com/SAS-Sasao/cc-sier-organization.git/'
\`\`\`

## 原因

claude-code-action は内部で git config / remote URL を書き換える可能性があり、その後の workflow shell から git push しようとすると \`actions/checkout\` の \`persist-credentials\` が無効化されている場合がある。

## 修正

push 前に GITHUB_TOKEN を明示的に埋め込んだ remote URL を再設定:

\`\`\`bash
git remote set-url origin \\
  "https://x-access-token:\${GH_TOKEN}@github.com/\${GITHUB_REPOSITORY}.git"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)