### PR TITLE
docs: CLAUDE.md & rules nightly update (2026-04-11, daily-24h) [初回成功]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,10 @@ cc-sier-organization/
 - ⚠️ 日次ダイジェストは章順固定（A → B → C → D）・テーブル形式・テーマ別分類
 - ⚠️ AWS Diagram Python コードのラベルに `\n` 改行を含めない（silent error）
 - ⚠️ Subagent 名は task-log に英字で記録（日本語名だと Case Bank 検出不可）
+- ⚠️ `claude-code-action@v1` は `claude_code_oauth_token` / `anthropic_api_key` を **input parameter で渡す**（action.yml が env を input で上書きするため env block だけでは効かない）
+- ⚠️ claude-code-action を挟む workflow では post step にも env が必要なため env は **job レベル** に配置（step-level は post step に伝播しない）
+- ⚠️ claude-code-action 実行後の `git push` 前に `git remote set-url origin https://x-access-token:${GH_TOKEN}@...` を再設定（action が remote URL を書き換える可能性）
+- ⚠️ 必須セクションの**順序違反**も `critical_triggered = true` 扱い（欠落と同じく均し込み禁止）
 
 詳細: @.claude/rules/review-pattern.md
 


### PR DESCRIPTION
## Summary

🎉 **nightly-claude-md-update workflow の初回成功 PR**（手動で createPR ステップを実行）

run [24276269514](https://github.com/SAS-Sasao/cc-sier-organization/actions/runs/24276269514) にて Claude Code Action は完走したが、当時はリポジトリ設定で `Actions が PR を作成すること` が禁止されていたため `gh pr create` のみ失敗。設定変更後に手動で作成。

## 分析シグナル

| 項目 | 値 |
|---|---|
| 期間 | 日次（過去 24 時間） |
| since | `2026-04-10T06:04:18+00:00` |
| Merged PR | 12 件 |
| Task-log | 3 件 |
| Conversation-log | 0 件 |
| 直接 commit | 21 件 |

## 変更ファイル

```
CLAUDE.md
```

CLAUDE.md 行数: **188 / 200** ✅

## Claude が抽出した学び（注意事項に 4 行追加）

過去 24h で発生した workflow セットアップの 4 つの失敗パターン (PR #258, #259, #260, #261) を、原理原則レベルの注意事項として CLAUDE.md に統合:

1. ⚠️ `claude-code-action@v1` は `claude_code_oauth_token` / `anthropic_api_key` を **input parameter で渡す**（action.yml が env を input で上書きするため env block だけでは効かない）
2. ⚠️ claude-code-action を挟む workflow では post step にも env が必要なため env は **job レベル** に配置
3. ⚠️ claude-code-action 実行後の `git push` 前に `git remote set-url origin https://x-access-token:${GH_TOKEN}@...` を再設定
4. ⚠️ 必須セクションの**順序違反**も `critical_triggered = true` 扱い

## レビュー観点

- [x] 追加された学びが実際の PR から導出されている（PR #258-#261 の根本原因と一致）
- [x] 既存 `.claude/rules/*.md` と重複していない（新しい claude-code-action 固有の知見）
- [x] starter-kit の 200 行以内を維持（188 行）
- [x] 注意事項セクションに 1 行で統合、rules/ に詳細を分離する余地は将来検討
- [x] 記述が具体的（コマンド・パラメータ名を明示）

## 運用ステージ

**Phase 1（保守型）**: PR 作成のみ、手動マージ → 本 PR が初回成功例

🤖 Generated by `.github/workflows/nightly-claude-md-update.yml` (run #24276269514)