### PR TITLE
feat: /company-cycle Skill + daily-cycle-supplement workflow（解決策 X）

### DIFF
--- a/.claude/skills/company-cycle/SKILL.md
+++ b/.claude/skills/company-cycle/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: company-cycle
+description: >
+  /company-report → /company-evolve → /company-dashboard を直列実行する
+  オーケストレータ Skill（軽量型）。組織の活動レポート・継続学習・
+  ダッシュボード更新を 1 コマンドで完了する。
+  ローカル実行が前提（gitignored データを使うため、GitHub Actions では非対応）。
+  「サイクル」「ローテーション」「定期処理」「サイクル回して」「日次サイクル」
+  「/company-cycle」と言われたとき、または毎日の終業時に実行する。
+---
+
+# CC-SIer サイクルオーケストレータ Skill（軽量型）
+
+3 つの skill (`company-report` / `company-evolve` / `company-dashboard`) を直列実行する軽量オーケストレータ。
+
+## 1. 適用条件
+
+- **必ずローカル Claude Code 実行**（GitHub Actions では gitignored データが欠落するため非対応）
+- `.companies/.active` に org-slug が存在する
+- `.claude/skills/company-report/`, `company-evolve/`, `company-dashboard/` がインストール済み
+- 既存 sub-skill の git 動作を尊重する（複数 PR + main 直コミットの混在を許容）
+
+---
+
+## 2. 4 フェーズ概要
+
+| Phase | 名称 | 中断条件 |
+|---|---|---|
+| 0 | 前処理（org / period / git clean / task-log 初期化） | git dirty |
+| 1 | `/company-report` 実行（内部で `/company-evolve` を自動連携） | report 失敗 |
+| 2 | `/company-dashboard` 実行 | dashboard 失敗 |
+| 3 | 統合 task-log 更新 + tracking Issue にコメント + 最終報告 | - |
+
+各 phase 失敗時は task-log を `status: blocked` で保存し、ユーザーに復旧手順を報告する。
+
+---
+
+## 3. Phase 0: 前処理
+
+```
+1. .companies/.active から {org-slug} を取得
+2. git config user.name → {operator}
+3. period を解釈（today / week / month / カスタム、デフォルト today）
+4. git status --porcelain が空でなければ中断
+5. {date_jst} = TZ=Asia/Tokyo date +%Y-%m-%d
+6. {task-id} = YYYYMMDD-HHMMSS-cycle-{period}
+7. .companies/{org}/.task-log/{task-id}.md を YAML フロントマター形式で作成
+   subagents: [company-report, company-evolve, company-dashboard]
+```
+
+task-log の `subagents` 欄には必ず英字で記録する（Case Bank 検出のため）。
+
+---
+
+## 4. Phase 1: /company-report 実行
+
+`@.claude/skills/company-report/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- report の **Section 6** で `/company-evolve` が自動起動される（既存仕様）
+- evolve の副作用（synthesizer / refiner / wf-auto-generation の **複数 PR 生成**）はそのまま許容
+- evolve の `enrich-case-bank.sh` `rebuild-case-bank.sh` などの hook は全て発火する（ローカル実行のため）
+- 各 sub-skill の git 動作（report の PR、evolve の複数 PR）は変更しない
+
+### 完了時に記録する情報
+
+- report MD ファイルパス: `.companies/{org}/docs/secretary/reports/{date}-{period}.md`
+- report Issue URL
+- evolve が生成した PR URL 一覧（synthesizer / refiner / auto-workflow ぞれぞれあれば）
+- evolve のサマリー（評価タスク件数 / 平均 reward / Case Bank 件数）
+
+### Phase 1 の実行方法
+
+ユーザー（あなた = Claude）は以下を順次行う:
+
+1. `@.claude/skills/company-report/SKILL.md` を Read
+2. report の指示に従って Phase 2-1 から Phase 2-5 のデータ収集を実行
+3. AI 要約してレポート MD を生成
+4. ファイル保存・Git commit・Issue 投稿
+5. report Section 6 に従って `/company-evolve` を自動起動
+6. evolve の Phase 2 (Write) と Phase 5.5 を実行
+7. 完了情報を Phase 0 で作成した task-log に追記
+
+---
+
+## 5. Phase 2: /company-dashboard 実行
+
+`@.claude/skills/company-dashboard/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- dashboard は **main 直コミット**（PR 経由ではない、既存仕様）
+- `bash .claude/hooks/generate-dashboard.sh {org-slug}` を実行するだけ
+- 出力: `.companies/{org}/docs/secretary/dashboard.html` および `docs/index.html`
+- **Phase 1 で evolve が更新した Case Bank がここで反映される**（順序が重要）
+
+### 完了時に記録する情報
+
+- dashboard HTML ファイルパス
+- 生成サイズ (KB)
+- GitHub Pages URL
+
+---
+
+## 6. Phase 3: 統合 task-log + Issue + 最終報告
+
+### 6.1 統合 task-log 更新
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: completed
+mode: "direct"
+started: "..."
+completed: "..."
+request: "/company-cycle {period}"
+issue_number: null
+pr_number: null
+subagents: [company-report, company-evolve, company-dashboard]
+sub_skill_results:
+  report:
+    file: ".companies/{org}/docs/secretary/reports/{date}-{period}.md"
+    issue: "https://github.com/.../issues/N"
+    pr: "https://github.com/.../pull/N"
+  evolve:
+    case_bank_count: N
+    avg_reward: 0.00
+    pr_synthesizer: "..." or null
+    pr_refiner: "..." or null
+    pr_workflow: "..." or null
+  dashboard:
+    file: ".companies/{org}/docs/secretary/dashboard.html"
+    size_kb: N
+---
+```
+
+### 6.2 統合 tracking Issue にコメント
+
+label: `cycle-tracker`
+
+既存 Issue があればコメント追加、なければ新規作成:
+
+- title: `cycle: 統合実行ログ（継続トラッキング）`
+- body 冒頭: workflow の説明 + ローカル実行が必要な理由
+
+コメント内容:
+
+```markdown
+## 🔄 {date_jst} ({DOW_JP}) - /company-cycle {period} 完了
+
+| Phase | 状態 | 成果物 |
+|---|---|---|
+| 1. report | ✅ | [Issue #N](url) / [PR #N](url) |
+| 1.5 evolve (auto) | ✅ | case bank: N 件 / avg reward: X / 生成 PR: N 件 |
+| 2. dashboard | ✅ | [HTML](url) ({size} KB) |
+
+実行時間: N 分
+```
+
+### 6.3 最終報告（ユーザーへ）
+
+```
+✅ /company-cycle {period} 完了
+
+Phase 1 (report):    {report_issue_url}
+  └ 自動連携 evolve: case_bank {N}件 / avg reward {X}
+                    生成 PR: {N}件
+Phase 2 (dashboard): {dashboard_url}
+
+統合 tracking: #{tracking_issue_number}
+合計時間: {duration}
+```
+
+---
+
+## 7. オプションフラグ
+
+| フラグ | 既定 | 効果 |
+|---|---|---|
+| `--period` | today | today / week / month / カスタム日付範囲 |
+| `--skip-evolve` | off | report の自動 evolve 連携をスキップ（debug 用） |
+| `--dashboard-only` | off | report/evolve をスキップし dashboard のみ実行 |
+| `--report-only` | off | dashboard をスキップし report (+ auto evolve) のみ |
+
+---
+
+## 8. なぜローカル実行が必須か
+
+GitHub Actions runner では以下のデータが**完全に存在しない**:
+
+| データ | gitignore | 影響 |
+|---|---|---|
+| `.session-summaries/` | ✅ | report の Section 2.1（最優先） / dashboard のセッション統計 |
+| `.conversation-log/` | ✅ | report の「会話トピック」/ dashboard の頻出フレーズ・enrich-case-bank.sh |
+| `.quality-gate-log/` | ✅ | dashboard の品質ゲート通過率（ドーナツチャート） |
+| `.case-bank/` | ✅ | 毎回 rebuild 必要、永続化されない |
+| `~/.claude/.../memory/feedback_*.md` | - | rebuild-case-bank.sh の feedback memory 統合 |
+
+加えて、`enrich-case-bank.sh` などの hook はローカル Claude Code セッション内で発火する設計のため、Actions 環境では動作しない。
+
+→ **完全な observability を得るためにはローカル実行が必須**。GitHub Actions は補完的に `daily-cycle-supplement.yml` で git tracked データのみの軽量サマリーを生成し、ユーザーに「今日 cycle がまだ走っていない」をリマインドする。
+
+---
+
+## 9. エラー時の中断ポリシー
+
+- 各 Phase で fail → task-log を `status: blocked` で保存
+- ユーザーへの報告に Phase 名・原因・手動復旧コマンドを含める
+- 部分作成済みの PR / コミットは削除しない（手動引き継ぎ用）
+- Phase 1 の report/evolve が部分成功している場合、Phase 2 dashboard はスキップして報告
+
+---
+
+## 10. 関連
+
+- @.claude/skills/company-report/SKILL.md — Phase 1 の本体
+- @.claude/skills/company-evolve/SKILL.md — Phase 1.5 の本体（report から自動起動）
+- @.claude/skills/company-dashboard/SKILL.md — Phase 2 の本体
+- @.github/workflows/daily-cycle-supplement.yml — 19:00 JST の補完 Actions
+- @.claude/rules/review-pattern.md — 将来的な L0/L1/L2 統合（Phase 2 昇格時）
+- @.claude/rules/git-workflow.md — ブランチ・コミット・PR 規約

--- a/.github/workflows/daily-cycle-supplement.yml
+++ b/.github/workflows/daily-cycle-supplement.yml
@@ -1,0 +1,262 @@
+name: Daily Cycle Supplement (19:00 JST)
+
+# 解決策 X の Actions 補完部分。
+# 毎日 19:00 JST に git tracked データのみから軽量サマリーを生成し、
+# 単一の継続トラッキング Issue にコメント追記する。
+#
+# - Claude Code Action は使わない（純粋 shell + gh CLI で完結、無料・高速）
+# - 完全な observability（会話統計・session 統計・品質ゲート・Case Bank）は
+#   ローカル `/company-cycle` で生成される（gitignored データ依存のため Actions では非対応）
+# - 本日 cycle がローカル実行されているかを git log で検知してリマインダー通知
+
+on:
+  schedule:
+    # 19:00 JST = 10:00 UTC（JST は夏時間なし、年中固定）
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+# 同時実行防止
+concurrency:
+  group: daily-cycle-supplement
+  cancel-in-progress: false
+
+env:
+  TRACKING_ISSUE_LABEL: cycle-supplement-tracker
+
+jobs:
+  summary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # -----------------------------------------------------------------
+      # Step 1: Checkout（全履歴）
+      # -----------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------
+      # Step 2: 日付ウィンドウの決定（JST 基準）
+      # -----------------------------------------------------------------
+      - name: Determine date window
+        id: date
+        run: |
+          DATE_JST=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          DOW_JST=$(TZ=Asia/Tokyo date +%u)
+          case $DOW_JST in
+            1) DOW_JP=月 ;;
+            2) DOW_JP=火 ;;
+            3) DOW_JP=水 ;;
+            4) DOW_JP=木 ;;
+            5) DOW_JP=金 ;;
+            6) DOW_JP=土 ;;
+            7) DOW_JP=日 ;;
+          esac
+          # JST 00:00 を ISO8601 形式で
+          SINCE=$(TZ=Asia/Tokyo date -d "${DATE_JST} 00:00:00" --iso-8601=seconds)
+
+          {
+            echo "date_jst=$DATE_JST"
+            echo "dow_jp=$DOW_JP"
+            echo "since=$SINCE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::JST window: $DATE_JST ($DOW_JP) since $SINCE"
+
+      # -----------------------------------------------------------------
+      # Step 3: git-tracked シグナル収集
+      # -----------------------------------------------------------------
+      - name: Collect git-tracked signals
+        id: signals
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE: ${{ steps.date.outputs.date_jst }}
+          SINCE: ${{ steps.date.outputs.since }}
+        run: |
+          mkdir -p /tmp/signals
+
+          # ---- task-log files modified today (git tracked のみ) ----
+          git log --since="$SINCE" --name-only --format='' main \
+            -- '.companies/**/.task-log/*.md' 2>/dev/null \
+            | grep -v '^$' | sort -u > /tmp/signals/tasklogs.txt || true
+          TASKLOG_COUNT=$(wc -l < /tmp/signals/tasklogs.txt 2>/dev/null || echo 0)
+
+          # ---- commit count (main, today) ----
+          COMMIT_COUNT=$(git log --since="$SINCE" --format='%h' main 2>/dev/null | wc -l)
+
+          # ---- merged PRs today ----
+          gh pr list --state merged \
+            --search "merged:>=${DATE}" \
+            --json number,title,mergedAt \
+            --limit 50 \
+            > /tmp/signals/prs.json 2>/dev/null || echo '[]' > /tmp/signals/prs.json
+          PR_COUNT=$(jq length /tmp/signals/prs.json)
+
+          # ---- opened Issues today (除外: tracking 系ラベル) ----
+          gh issue list --state all \
+            --search "created:>=${DATE} -label:cycle-supplement-tracker -label:nightly-claude-md-tracker -label:nightly-claude-md-update" \
+            --json number,title,createdAt \
+            --limit 50 \
+            > /tmp/signals/issues_opened.json 2>/dev/null || echo '[]' > /tmp/signals/issues_opened.json
+          ISSUE_OPENED_COUNT=$(jq length /tmp/signals/issues_opened.json)
+
+          # ---- closed Issues today ----
+          gh issue list --state closed \
+            --search "closed:>=${DATE}" \
+            --json number,title,closedAt \
+            --limit 50 \
+            > /tmp/signals/issues_closed.json 2>/dev/null || echo '[]' > /tmp/signals/issues_closed.json
+          ISSUE_CLOSED_COUNT=$(jq length /tmp/signals/issues_closed.json)
+
+          # ---- /company-cycle がローカル実行されたか検知 ----
+          # cycle Skill の task-log は YYYYMMDD-HHMMSS-cycle-{period}.md 形式
+          CYCLE_TASKLOG=$(git log --since="$SINCE" --name-only --format='' main \
+            -- '.companies/**/.task-log/*-cycle-*.md' 2>/dev/null \
+            | grep -v '^$' | head -1 || true)
+          if [ -n "$CYCLE_TASKLOG" ]; then
+            CYCLE_RAN=true
+          else
+            CYCLE_RAN=false
+          fi
+
+          {
+            echo "tasklog_count=$TASKLOG_COUNT"
+            echo "commit_count=$COMMIT_COUNT"
+            echo "pr_count=$PR_COUNT"
+            echo "issue_opened_count=$ISSUE_OPENED_COUNT"
+            echo "issue_closed_count=$ISSUE_CLOSED_COUNT"
+            echo "cycle_ran=$CYCLE_RAN"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::today: tasklog=$TASKLOG_COUNT commit=$COMMIT_COUNT pr=$PR_COUNT issue_opened=$ISSUE_OPENED_COUNT issue_closed=$ISSUE_CLOSED_COUNT cycle_ran=$CYCLE_RAN"
+
+      # -----------------------------------------------------------------
+      # Step 4: サマリー作成 + tracking Issue に投稿
+      # -----------------------------------------------------------------
+      - name: Compose and post summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE_JST: ${{ steps.date.outputs.date_jst }}
+          DOW_JP: ${{ steps.date.outputs.dow_jp }}
+          TC: ${{ steps.signals.outputs.tasklog_count }}
+          CC: ${{ steps.signals.outputs.commit_count }}
+          PC: ${{ steps.signals.outputs.pr_count }}
+          IO: ${{ steps.signals.outputs.issue_opened_count }}
+          IC: ${{ steps.signals.outputs.issue_closed_count }}
+          CR: ${{ steps.signals.outputs.cycle_ran }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # ---- cycle 実行有無に基づく hint ----
+          if [ "$CR" = "true" ]; then
+            HINT="✅ 本日 \`/company-cycle\` ローカル実行済み — 完全な observability データが反映済みです"
+          else
+            HINT=$(cat <<'HINTEOF'
+          ⚠️ **本日 `/company-cycle` がまだローカル実行されていません**
+
+          ローカル Claude Code で以下を実行してください:
+
+          ```
+          /company-cycle
+          ```
+
+          これにより以下の **gitignored 観測データ** が反映されます:
+
+          - `.session-summaries/` ベースのツール実行統計
+          - `.conversation-log/` ベースの会話統計・頻出フレーズ
+          - `.quality-gate-log/` ベースの品質ゲート通過率（ドーナツチャート）
+          - `~/.claude/.../memory/feedback_*.md` 統合の Case Bank
+          - reward / judge スコアの自動採点
+          - Subagent 評価軸レーダー（completeness / accuracy / clarity）
+
+          GitHub Actions では gitignored データが取れないため、これらは **ローカル実行が必須** です。
+          HINTEOF
+          )
+          fi
+
+          # ---- 本日の merged PR 上位 5 件 ----
+          if [ "$PC" -gt 0 ]; then
+            PR_LIST=$(jq -r '.[] | "- #\(.number) \(.title)"' /tmp/signals/prs.json | head -5)
+            if [ "$PC" -gt 5 ]; then
+              PR_LIST="${PR_LIST}
+          - … 他 $((PC - 5)) 件"
+            fi
+          else
+            PR_LIST="（なし）"
+          fi
+
+          # ---- summary 本文 ----
+          SUMMARY=$(cat <<EOF
+          ## 📊 ${DATE_JST} (${DOW_JP}) — Daily Activity Summary
+
+          | 項目 | 件数 |
+          |---|---|
+          | task-log 編集 | ${TC} 件 |
+          | commit (main) | ${CC} 件 |
+          | merged PR | ${PC} 件 |
+          | opened Issue | ${IO} 件 |
+          | closed Issue | ${IC} 件 |
+
+          ### 本日マージされた主な PR
+
+          ${PR_LIST}
+
+          ---
+
+          ${HINT}
+
+          ---
+
+          *この summary は **git tracked データのみ** から生成されています。会話統計・session 統計・品質ゲート通過率・Case Bank は \`/company-cycle\` をローカルで実行してください。*
+
+          *workflow run: ${RUN_URL}*
+          EOF
+          )
+
+          # ---- tracking Issue を確保（なければ作成） ----
+          gh label create "$TRACKING_ISSUE_LABEL" --color "0e8a16" --description "daily cycle supplement tracker" 2>/dev/null || true
+
+          ISSUE_NUMBER=$(gh issue list \
+            --label "$TRACKING_ISSUE_LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_URL=$(gh issue create \
+              --title "daily: cycle 補完サマリー（継続トラッキング 19:00 JST）" \
+              --label "$TRACKING_ISSUE_LABEL" \
+              --body "$(cat <<'INITBODY'
+          この Issue は \`daily-cycle-supplement.yml\` workflow の実行履歴を記録します。
+
+          ## ワークフローの目的
+
+          - **毎日 19:00 JST** に発火（cron: \`0 10 * * *\`）
+          - **git tracked データのみ** から軽量サマリーを生成
+          - 本日 \`/company-cycle\` がローカル実行されているかをチェック
+          - されていなければユーザーにリマインダーを通知
+
+          ## なぜ補完が必要か
+
+          完全な observability データ（会話統計・session 統計・品質ゲート・Case Bank・feedback memory）は \`.gitignored\` でローカル限定のため、GitHub Actions では取れません。
+
+          観測完全性のためには、ローカル Claude Code で以下を実行する必要があります:
+
+          \`\`\`
+          /company-cycle
+          \`\`\`
+
+          本 Issue の毎日のコメントは「ローカル実行を促すリマインダー」と「git tracked データの軽量集計」を兼ねています。
+          INITBODY
+          )")
+            ISSUE_NUMBER="${ISSUE_URL##*/}"
+            echo "::notice::created tracking issue: $ISSUE_URL"
+          fi
+
+          # ---- コメント投稿 ----
+          gh issue comment "$ISSUE_NUMBER" --body "$SUMMARY"
+          echo "::notice::posted summary to issue #$ISSUE_NUMBER"

--- a/plugins/cc-sier/skills/company-cycle/SKILL.md
+++ b/plugins/cc-sier/skills/company-cycle/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: company-cycle
+description: >
+  /company-report → /company-evolve → /company-dashboard を直列実行する
+  オーケストレータ Skill（軽量型）。組織の活動レポート・継続学習・
+  ダッシュボード更新を 1 コマンドで完了する。
+  ローカル実行が前提（gitignored データを使うため、GitHub Actions では非対応）。
+  「サイクル」「ローテーション」「定期処理」「サイクル回して」「日次サイクル」
+  「/company-cycle」と言われたとき、または毎日の終業時に実行する。
+---
+
+# CC-SIer サイクルオーケストレータ Skill（軽量型）
+
+3 つの skill (`company-report` / `company-evolve` / `company-dashboard`) を直列実行する軽量オーケストレータ。
+
+## 1. 適用条件
+
+- **必ずローカル Claude Code 実行**（GitHub Actions では gitignored データが欠落するため非対応）
+- `.companies/.active` に org-slug が存在する
+- `.claude/skills/company-report/`, `company-evolve/`, `company-dashboard/` がインストール済み
+- 既存 sub-skill の git 動作を尊重する（複数 PR + main 直コミットの混在を許容）
+
+---
+
+## 2. 4 フェーズ概要
+
+| Phase | 名称 | 中断条件 |
+|---|---|---|
+| 0 | 前処理（org / period / git clean / task-log 初期化） | git dirty |
+| 1 | `/company-report` 実行（内部で `/company-evolve` を自動連携） | report 失敗 |
+| 2 | `/company-dashboard` 実行 | dashboard 失敗 |
+| 3 | 統合 task-log 更新 + tracking Issue にコメント + 最終報告 | - |
+
+各 phase 失敗時は task-log を `status: blocked` で保存し、ユーザーに復旧手順を報告する。
+
+---
+
+## 3. Phase 0: 前処理
+
+```
+1. .companies/.active から {org-slug} を取得
+2. git config user.name → {operator}
+3. period を解釈（today / week / month / カスタム、デフォルト today）
+4. git status --porcelain が空でなければ中断
+5. {date_jst} = TZ=Asia/Tokyo date +%Y-%m-%d
+6. {task-id} = YYYYMMDD-HHMMSS-cycle-{period}
+7. .companies/{org}/.task-log/{task-id}.md を YAML フロントマター形式で作成
+   subagents: [company-report, company-evolve, company-dashboard]
+```
+
+task-log の `subagents` 欄には必ず英字で記録する（Case Bank 検出のため）。
+
+---
+
+## 4. Phase 1: /company-report 実行
+
+`@.claude/skills/company-report/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- report の **Section 6** で `/company-evolve` が自動起動される（既存仕様）
+- evolve の副作用（synthesizer / refiner / wf-auto-generation の **複数 PR 生成**）はそのまま許容
+- evolve の `enrich-case-bank.sh` `rebuild-case-bank.sh` などの hook は全て発火する（ローカル実行のため）
+- 各 sub-skill の git 動作（report の PR、evolve の複数 PR）は変更しない
+
+### 完了時に記録する情報
+
+- report MD ファイルパス: `.companies/{org}/docs/secretary/reports/{date}-{period}.md`
+- report Issue URL
+- evolve が生成した PR URL 一覧（synthesizer / refiner / auto-workflow ぞれぞれあれば）
+- evolve のサマリー（評価タスク件数 / 平均 reward / Case Bank 件数）
+
+### Phase 1 の実行方法
+
+ユーザー（あなた = Claude）は以下を順次行う:
+
+1. `@.claude/skills/company-report/SKILL.md` を Read
+2. report の指示に従って Phase 2-1 から Phase 2-5 のデータ収集を実行
+3. AI 要約してレポート MD を生成
+4. ファイル保存・Git commit・Issue 投稿
+5. report Section 6 に従って `/company-evolve` を自動起動
+6. evolve の Phase 2 (Write) と Phase 5.5 を実行
+7. 完了情報を Phase 0 で作成した task-log に追記
+
+---
+
+## 5. Phase 2: /company-dashboard 実行
+
+`@.claude/skills/company-dashboard/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- dashboard は **main 直コミット**（PR 経由ではない、既存仕様）
+- `bash .claude/hooks/generate-dashboard.sh {org-slug}` を実行するだけ
+- 出力: `.companies/{org}/docs/secretary/dashboard.html` および `docs/index.html`
+- **Phase 1 で evolve が更新した Case Bank がここで反映される**（順序が重要）
+
+### 完了時に記録する情報
+
+- dashboard HTML ファイルパス
+- 生成サイズ (KB)
+- GitHub Pages URL
+
+---
+
+## 6. Phase 3: 統合 task-log + Issue + 最終報告
+
+### 6.1 統合 task-log 更新
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: completed
+mode: "direct"
+started: "..."
+completed: "..."
+request: "/company-cycle {period}"
+issue_number: null
+pr_number: null
+subagents: [company-report, company-evolve, company-dashboard]
+sub_skill_results:
+  report:
+    file: ".companies/{org}/docs/secretary/reports/{date}-{period}.md"
+    issue: "https://github.com/.../issues/N"
+    pr: "https://github.com/.../pull/N"
+  evolve:
+    case_bank_count: N
+    avg_reward: 0.00
+    pr_synthesizer: "..." or null
+    pr_refiner: "..." or null
+    pr_workflow: "..." or null
+  dashboard:
+    file: ".companies/{org}/docs/secretary/dashboard.html"
+    size_kb: N
+---
+```
+
+### 6.2 統合 tracking Issue にコメント
+
+label: `cycle-tracker`
+
+既存 Issue があればコメント追加、なければ新規作成:
+
+- title: `cycle: 統合実行ログ（継続トラッキング）`
+- body 冒頭: workflow の説明 + ローカル実行が必要な理由
+
+コメント内容:
+
+```markdown
+## 🔄 {date_jst} ({DOW_JP}) - /company-cycle {period} 完了
+
+| Phase | 状態 | 成果物 |
+|---|---|---|
+| 1. report | ✅ | [Issue #N](url) / [PR #N](url) |
+| 1.5 evolve (auto) | ✅ | case bank: N 件 / avg reward: X / 生成 PR: N 件 |
+| 2. dashboard | ✅ | [HTML](url) ({size} KB) |
+
+実行時間: N 分
+```
+
+### 6.3 最終報告（ユーザーへ）
+
+```
+✅ /company-cycle {period} 完了
+
+Phase 1 (report):    {report_issue_url}
+  └ 自動連携 evolve: case_bank {N}件 / avg reward {X}
+                    生成 PR: {N}件
+Phase 2 (dashboard): {dashboard_url}
+
+統合 tracking: #{tracking_issue_number}
+合計時間: {duration}
+```
+
+---
+
+## 7. オプションフラグ
+
+| フラグ | 既定 | 効果 |
+|---|---|---|
+| `--period` | today | today / week / month / カスタム日付範囲 |
+| `--skip-evolve` | off | report の自動 evolve 連携をスキップ（debug 用） |
+| `--dashboard-only` | off | report/evolve をスキップし dashboard のみ実行 |
+| `--report-only` | off | dashboard をスキップし report (+ auto evolve) のみ |
+
+---
+
+## 8. なぜローカル実行が必須か
+
+GitHub Actions runner では以下のデータが**完全に存在しない**:
+
+| データ | gitignore | 影響 |
+|---|---|---|
+| `.session-summaries/` | ✅ | report の Section 2.1（最優先） / dashboard のセッション統計 |
+| `.conversation-log/` | ✅ | report の「会話トピック」/ dashboard の頻出フレーズ・enrich-case-bank.sh |
+| `.quality-gate-log/` | ✅ | dashboard の品質ゲート通過率（ドーナツチャート） |
+| `.case-bank/` | ✅ | 毎回 rebuild 必要、永続化されない |
+| `~/.claude/.../memory/feedback_*.md` | - | rebuild-case-bank.sh の feedback memory 統合 |
+
+加えて、`enrich-case-bank.sh` などの hook はローカル Claude Code セッション内で発火する設計のため、Actions 環境では動作しない。
+
+→ **完全な observability を得るためにはローカル実行が必須**。GitHub Actions は補完的に `daily-cycle-supplement.yml` で git tracked データのみの軽量サマリーを生成し、ユーザーに「今日 cycle がまだ走っていない」をリマインドする。
+
+---
+
+## 9. エラー時の中断ポリシー
+
+- 各 Phase で fail → task-log を `status: blocked` で保存
+- ユーザーへの報告に Phase 名・原因・手動復旧コマンドを含める
+- 部分作成済みの PR / コミットは削除しない（手動引き継ぎ用）
+- Phase 1 の report/evolve が部分成功している場合、Phase 2 dashboard はスキップして報告
+
+---
+
+## 10. 関連
+
+- @.claude/skills/company-report/SKILL.md — Phase 1 の本体
+- @.claude/skills/company-evolve/SKILL.md — Phase 1.5 の本体（report から自動起動）
+- @.claude/skills/company-dashboard/SKILL.md — Phase 2 の本体
+- @.github/workflows/daily-cycle-supplement.yml — 19:00 JST の補完 Actions
+- @.claude/rules/review-pattern.md — 将来的な L0/L1/L2 統合（Phase 2 昇格時）
+- @.claude/rules/git-workflow.md — ブランチ・コミット・PR 規約


### PR DESCRIPTION
## Summary

**解決策 X（ローカル実行優先 + Actions は補完のみ）の完全実装**。3 つの既存 skill を直列実行する `/company-cycle` Skill と、19:00 JST に補完サマリーを生成する GitHub Actions の 2 本立て。

## 設計判断の根拠

ユーザーから「reward / judge / Subagent 評価軸レーダー / AI 学習内容を Actions で取得できるか」と問われ、データソースを実証した結果:

| データ | git tracked | Actions で取れる |
|---|---|---|
| task-log YAML（reward/judge/l2_composite） | ✅ | ✅ |
| .session-summaries/ | ❌ gitignored | ❌ |
| .conversation-log/ | ❌ gitignored | ❌ |
| .quality-gate-log/ | ❌ gitignored | ❌ |
| .case-bank/index.json | ❌ gitignored | ❌（毎回 rebuild 必要） |
| feedback memory (~/.claude/) | - | ❌ |

→ **完全な observability にはローカル実行が必須**。Actions は git tracked データのみで補完。

## 1. /company-cycle Skill（軽量オーケストレータ）

ファイル: \`plugins/cc-sier/skills/company-cycle/SKILL.md\` + \`.claude/skills/\` 同期

| Phase | 名称 | 内容 |
|---|---|---|
| 0 | 前処理 | org / period / git clean / task-log 初期化 |
| 1 | /company-report | 内部で /company-evolve を Section 6 で自動連携 |
| 2 | /company-dashboard | main 直コミット |
| 3 | 統合 task-log + tracking Issue + 報告 | - |

**ローカル実行専用** — Section 8 に gitignored データ依存を明記。

オプション: \`--period\` / \`--skip-evolve\` / \`--dashboard-only\` / \`--report-only\`

## 2. daily-cycle-supplement.yml（19:00 JST 補完）

ファイル: \`.github/workflows/daily-cycle-supplement.yml\`

- **cron**: \`0 10 * * *\`（19:00 JST）+ workflow_dispatch
- **Claude Code Action は使わない**（純粋 shell + gh CLI、無料・5 分以内）
- permissions: contents:read, issues:write のみ

### 動作

1. 本日の git tracked 活動を集計（task-log / commit / PR / Issue）
2. \`*-cycle-*.md\` task-log を git log で検索 → 本日 cycle が実行されたかチェック
3. 単一の継続トラッキング Issue（label: \`cycle-supplement-tracker\`）にコメント追記
4. cycle 未実行ならリマインダー通知付き

### 通知例

\`\`\`
## 📊 2026-04-11 (土) — Daily Activity Summary

| 項目 | 件数 |
|---|---|
| task-log 編集 | N 件 |
| commit (main) | N 件 |
| merged PR | N 件 |
| opened Issue | N 件 |
| closed Issue | N 件 |

⚠️ 本日 /company-cycle がまだローカル実行されていません
→ ローカル Claude Code で /company-cycle を実行してください
\`\`\`

## 既存ワークフローとの棲み分け

| 時刻 | workflow | 用途 |
|---|---|---|
| **19:00 JST** | **daily-cycle-supplement**（本 PR） | git tracked データ集計 + cycle 実行リマインダー |
| 23:00 JST | nightly-claude-md-update（既存） | CLAUDE.md/rules の自動学習更新 |
| local on-demand | /company-cycle（本 PR） | report → evolve → dashboard 完全実行 |

## 段階的昇格パス

- **Phase 1（本 PR）**: 軽量型、各 sub-skill の既存 git 動作尊重
- **Phase 2（2-3 週間運用後）**: report + dashboard を統合 PR + L1/L2 レビュー化（案 C）

## Test plan

- [x] YAML 構文検証 (262 行)
- [ ] PR auto-merge 後に workflow_dispatch で初回テスト
- [ ] tracking Issue が作成されコメント追記されることを確認
- [ ] cycle 実行検知（本日 cycle 走っていないので ⚠️ メッセージが出るはず）

🤖 Generated with [Claude Code](https://claude.com/claude-code)