### PR TITLE
fix: PROJECTS_PAT を Classic PAT に変更（fine-grained は user-owned project 非対応）

### DIFF
--- a/.claude/hooks/bootstrap-todo-issues.sh
+++ b/.claude/hooks/bootstrap-todo-issues.sh
@@ -3,22 +3,30 @@
 #
 # 前提:
 #   - WBS markdown が拡張スキーマ (Iter/Pri/Type/Issue/ステータス) に移行済み
-#   - PROJECTS_PAT (fine-grained PAT, project:write) が設定済み
-#   - gh CLI が PROJECTS_PAT で認証済み、または GH_TOKEN/GITHUB_TOKEN env 経由で auth
+#   - PROJECTS_PAT (Classic PAT, project scope) が設定済み ※user-owned Project v2 の制約
+#   - GITHUB_TOKEN (Issues/labels 操作用、Actions 環境では自動注入)
+#
+# 認証トークンの役割分担（最小権限原則）:
+#   - GITHUB_TOKEN (fine-grained / auto):
+#       gh issue create, gh label create, gh issue list
+#       → Repository の Contents/Issues/Pull requests 権限で OK
+#   - PROJECTS_PAT (Classic PAT, project scope のみ):
+#       gh project item-add, gh project field-list, gh project field-create
+#       → user-owned Project v2 は fine-grained PAT 非対応 (GitHub 既知の制約)
 #
 # 動作:
 #   1. parse-wbs.py で全組織の WBS タスクを取得
 #   2. 各タスクについて対応 Issue を検索（label: wbs:{wbs_id}, org:{slug}）
-#   3. 未作成なら gh issue create で新規作成
-#   4. 作成した Issue を Project v2 (PROJECT_V2_NODE_ID) に追加
+#   3. 未作成なら gh issue create で新規作成（GITHUB_TOKEN で）
+#   4. 作成した Issue を Project v2 (PROJECT_V2_NODE_ID) に追加（PROJECTS_PAT で）
 #   5. Project v2 のフィールド (Status/Iteration/Priority/Org/WBS-ID/Type) を設定
 #   6. WBS markdown の Issue# 列を更新 (新規 Issue の番号を埋め込み)
 #
 # 環境変数:
-#   PROJECTS_PAT (required)     — Fine-grained PAT
-#   PROJECT_V2_NODE_ID (required) — 既存の Project v2 node ID
-#   GH_TOKEN (optional)         — GitHub Issue 作成用 (= PROJECTS_PAT でも可)
-#   DRY_RUN=1                   — 何もせず計画だけ表示
+#   GITHUB_TOKEN or GH_TOKEN (required) — Issue/label 操作用
+#   PROJECTS_PAT (required)             — Classic PAT (scope: project のみ)
+#   PROJECT_V2_NODE_ID (optional)       — 既存の Project v2 node ID (default: 既存)
+#   DRY_RUN=1                           — 何もせず計画だけ表示
 
 set -euo pipefail
 
@@ -29,15 +37,30 @@ cd "$REPO_ROOT"
 DRY_RUN="${DRY_RUN:-0}"
 PROJECT_V2_NODE_ID="${PROJECT_V2_NODE_ID:-PVT_kwHODAtE_84BUTl8}"
 
-if [ -z "${PROJECTS_PAT:-}" ] && [ "$DRY_RUN" != "1" ]; then
-  echo "::error::PROJECTS_PAT が未設定です" >&2
-  exit 1
+# Issues/labels 用のトークン（fine-grained or GITHUB_TOKEN）
+ISSUES_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+# Project v2 用のトークン（Classic PAT, project scope）
+PROJECTS_TOKEN="${PROJECTS_PAT:-}"
+
+if [ "$DRY_RUN" != "1" ]; then
+  if [ -z "$ISSUES_TOKEN" ]; then
+    echo "::error::GITHUB_TOKEN または GH_TOKEN が必要 (Issues/labels 操作用)" >&2
+    exit 1
+  fi
+  if [ -z "$PROJECTS_TOKEN" ]; then
+    echo "::error::PROJECTS_PAT (Classic PAT, project scope) が必要" >&2
+    echo "::error::user-owned Project v2 は fine-grained PAT では操作できない制約のため" >&2
+    exit 1
+  fi
 fi
 
-# gh CLI は PROJECTS_PAT で認証する
-if [ "$DRY_RUN" != "1" ]; then
-  export GH_TOKEN="${PROJECTS_PAT}"
-fi
+# デフォルトは Issues 用トークンで auth
+export GH_TOKEN="$ISSUES_TOKEN"
+
+# Project v2 操作用の wrapper (トークンを一時的に切り替え)
+gh_project() {
+  GH_TOKEN="$PROJECTS_TOKEN" gh project "$@"
+}
 
 echo "=== Phase 1: WBS parse ==="
 TASKS_JSON=$(python3 .claude/hooks/parse-wbs.py 2>/dev/null || echo '[]')
@@ -95,9 +118,9 @@ ensure_project_field() {
     return 0
   fi
 
-  # 既存フィールドチェック
+  # 既存フィールドチェック（Project 操作は PROJECTS_PAT）
   local existing
-  existing=$(gh project field-list 1 --owner SAS-Sasao --format json 2>/dev/null \
+  existing=$(gh_project field-list 1 --owner SAS-Sasao --format json 2>/dev/null \
     | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(' '.join(f['name'] for f in d.get('fields',[])))" 2>/dev/null || echo "")
 
   if echo " $existing " | grep -q " $field_name "; then
@@ -107,11 +130,11 @@ ensure_project_field() {
 
   case "$data_type" in
     TEXT|NUMBER|DATE)
-      gh project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type "$data_type" 2>&1 \
+      gh_project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type "$data_type" 2>&1 \
         || echo "::warning::Failed to create field $field_name"
       ;;
     SINGLE_SELECT)
-      gh project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type SINGLE_SELECT \
+      gh_project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type SINGLE_SELECT \
         --single-select-options "$options" 2>&1 \
         || echo "::warning::Failed to create field $field_name"
       ;;
@@ -222,8 +245,8 @@ EOF
   ISSUE_NUMBER="${ISSUE_URL##*/}"
   echo "[created] $org $wbs_id -> #$ISSUE_NUMBER ($ISSUE_URL)"
 
-  # Project v2 に追加 (gh project item-add)
-  gh project item-add 1 --owner SAS-Sasao --url "$ISSUE_URL" 2>&1 | tail -1 || \
+  # Project v2 に追加 (Project 操作は PROJECTS_PAT)
+  gh_project item-add 1 --owner SAS-Sasao --url "$ISSUE_URL" 2>&1 | tail -1 || \
     echo "::warning::Failed to add $ISSUE_URL to project"
 
   # 少し待機 (rate limit 対策)

--- a/.github/workflows/daily-todo-sync.yml
+++ b/.github/workflows/daily-todo-sync.yml
@@ -14,9 +14,20 @@ name: Daily TODO Sync (05:00 JST)
 #   - mode: bootstrap        : 初回 Issue バルク作成 + Project v2 setup
 #
 # 認証:
-#   - PROJECTS_PAT (required)           : Fine-grained PAT, project:write + issues:write + contents:write
+#   - PROJECTS_PAT (required)           : **Classic PAT, scope: project のみ**
+#                                         （user-owned Project v2 は fine-grained PAT 非対応）
 #   - CLAUDE_CODE_OAUTH_TOKEN (required): Max plan OAuth
-#   - GITHUB_TOKEN                      : 自動注入、PR 作成用
+#   - GITHUB_TOKEN                      : 自動注入、Issue/label/PR 作成用 (Issues/Contents/PR 権限)
+#
+# トークンの役割分担:
+#   Issues/labels/PR の作成・操作 → GITHUB_TOKEN (auto-injected)
+#   Project v2 (user-owned) の操作 → PROJECTS_PAT (Classic PAT with 'project' scope)
+#
+# PROJECTS_PAT 発行手順:
+#   1. https://github.com/settings/tokens (Classic, NOT fine-grained)
+#   2. Generate new token (classic)
+#   3. Select scopes: [project] のみチェック（最小権限）
+#   4. Generate → copy → repo secret 'PROJECTS_PAT' に登録
 
 on:
   schedule:
@@ -82,14 +93,16 @@ jobs:
       - name: Pre-flight auth check
         run: |
           if [ -z "${PROJECTS_PAT:-}" ]; then
-            echo "::error::PROJECTS_PAT が未設定です (Fine-grained PAT, project:write)"
+            echo "::error::PROJECTS_PAT が未設定です"
+            echo "::error::user-owned Project v2 の操作には Classic PAT (scope: project) が必要"
+            echo "::error::発行手順: https://github.com/settings/tokens → Generate (classic) → project スコープのみ選択"
             exit 1
           fi
           if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             echo "::error::CLAUDE_CODE_OAUTH_TOKEN または ANTHROPIC_API_KEY が必要"
             exit 1
           fi
-          echo "::notice::Auth OK"
+          echo "::notice::Auth OK (GITHUB_TOKEN for Issues/PR, PROJECTS_PAT for Project v2)"
 
       # -----------------------------------------------------------------
       # Step 3: 日付計算
@@ -141,6 +154,8 @@ jobs:
         if: steps.mode.outputs.mode == 'bootstrap'
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
         run: |
           chmod +x .claude/hooks/bootstrap-todo-issues.sh
           bash .claude/hooks/bootstrap-todo-issues.sh 2>&1 | tee /tmp/bootstrap.log


### PR DESCRIPTION
## 問題

PR #275 で PROJECTS_PAT を Fine-grained PAT として発行する手順を提示したが、
**Fine-grained PAT では user-owned Project v2 を操作できない** という
GitHub の既知の制約があることが判明（ユーザ指摘）。

### GitHub 公式ドキュメントの既知制約

> "Major gaps in fine-grained token capabilities":
> Using fine-grained personal access token to access Projects owned by a user account

引用元: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens

現在のプロジェクト \`PVT_kwHODAtE_84BUTl8\` は https://github.com/users/SAS-Sasao/projects/1 で **user-owned**、したがって fine-grained PAT で動かない。

## 修正内容

### \`.claude/hooks/bootstrap-todo-issues.sh\`

**最小権限原則でトークンを 2 つに分離**:

| 操作 | トークン | 権限 |
|---|---|---|
| \`gh issue create\` / \`gh label create\` | \`GITHUB_TOKEN\` (自動注入) | Repository の Contents / Issues / PR 権限 |
| \`gh project item-add\` / \`field-create\` | \`PROJECTS_PAT\` (Classic PAT) | \`project\` scope のみ |

実装:
- \`ISSUES_TOKEN\` / \`PROJECTS_TOKEN\` の 2 変数に分離
- \`gh_project()\` wrapper 関数で project コマンド呼び出し時だけ \`GH_TOKEN\` を切替
- \`gh project field-list/create\` / \`gh project item-add\` 3 箇所を \`gh_project\` に置換
- Pre-flight check で 2 トークン別々に検証

### \`.github/workflows/daily-todo-sync.yml\`

- ヘッダーコメントにトークン役割分担を明記
- Pre-flight check のエラーメッセージを更新（Classic PAT + 発行手順）
- bootstrap step の env に \`GITHUB_TOKEN\` と \`PROJECTS_PAT\` の両方を明示指定

## マージ後に必要なアクション

⚠️ **既に PROJECTS_PAT を fine-grained で発行済みの場合は再発行が必要**:

1. https://github.com/settings/tokens （**Classic** タブ、NOT fine-grained）
2. **Generate new token (classic)**
3. Note: \`cc-sier-projects-pat-classic\`
4. Expiration: 1 year
5. Select scopes: **\`project\`** のみチェック（最小権限）
6. Generate → コピー
7. リポジトリ Settings → Secrets and variables → Actions
   → 既存の \`PROJECTS_PAT\` を **Update** して上書き（Secret 名はそのまま）

## 補足

この制約は GitHub が「時間をかけて解消する」と公式コメント済みだが、2026-04 現在は未対応。他の選択肢:

| 方式 | 実現性 | 評価 |
|---|---|---|
| **Classic PAT (\`project\` scope)** ← 本 PR | ✅ 即動く | ⭐ 採用 |
| Project を Org に移管 → fine-grained PAT | 組織作成が必要 | — |
| GitHub App 自作 | setup コスト高 | — |
| Project v2 同期を諦める | 機能縮小 | — |

## 関連

- 親 PR: #275 (基盤実装)
- GitHub Docs: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens