### PR TITLE
fix: bootstrap-todo-issues.sh の column shift & owner type バグ修正

### DIFF
--- a/.claude/hooks/bootstrap-todo-issues.sh
+++ b/.claude/hooks/bootstrap-todo-issues.sh
@@ -120,7 +120,7 @@ ensure_project_field() {
 
   # 既存フィールドチェック（Project 操作は PROJECTS_PAT）
   local existing
-  existing=$(gh_project field-list 1 --owner SAS-Sasao --format json 2>/dev/null \
+  existing=$(gh_project field-list 1 --owner "@me" --format json 2>/dev/null \
     | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(' '.join(f['name'] for f in d.get('fields',[])))" 2>/dev/null || echo "")
 
   if echo " $existing " | grep -q " $field_name "; then
@@ -130,11 +130,11 @@ ensure_project_field() {
 
   case "$data_type" in
     TEXT|NUMBER|DATE)
-      gh_project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type "$data_type" 2>&1 \
+      gh_project field-create 1 --owner "@me" --name "$field_name" --data-type "$data_type" 2>&1 \
         || echo "::warning::Failed to create field $field_name"
       ;;
     SINGLE_SELECT)
-      gh_project field-create 1 --owner SAS-Sasao --name "$field_name" --data-type SINGLE_SELECT \
+      gh_project field-create 1 --owner "@me" --name "$field_name" --data-type SINGLE_SELECT \
         --single-select-options "$options" 2>&1 \
         || echo "::warning::Failed to create field $field_name"
       ;;
@@ -150,15 +150,19 @@ ensure_project_field "Today" "SINGLE_SELECT" "Yes,No"
 echo "=== Phase 4: Create Issues and add to Project v2 ==="
 
 # タスク毎に処理
+# 注意: bash の `IFS=$'\t' read` は連続タブを単一デリミタとして扱うため、
+# 空フィールド (issue_num 等) があると column がシフトする既知の問題あり。
+# → 区切り文字に ASCII Unit Separator (\x1f, 非 whitespace) を使用。
+SEP=$'\x1f'
 python3 -c "import json,sys; print(json.dumps(json.loads(sys.stdin.read())))" <<< "$TASKS_JSON" \
   | python3 -c "
 import json,sys
+SEP = '\x1f'
 data = json.loads(sys.stdin.read())
 for t in data:
-    # tab-separated output for bash to read
-    print('\t'.join([
+    fields = [
         t['wbs_id'],
-        (t['task'] or '').replace('\t',' ').replace('\n',' '),
+        (t['task'] or '').replace(SEP,' ').replace('\n',' '),
         t['org'],
         str(t.get('priority') or 3),
         t.get('type') or 'learning',
@@ -166,12 +170,13 @@ for t in data:
         t.get('status') or 'todo',
         str(t.get('issue_number') or ''),
         t.get('wbs_file') or '',
-        t.get('section') or '',
-        t.get('subsection') or '',
-        (t.get('artifact') or '').replace('\t',' '),
-        (t.get('period') or '').replace('\t',' '),
-    ]))
-" | while IFS=$'\t' read -r wbs_id task org priority type iter status issue_num wbs_file section subsection artifact period; do
+        (t.get('section') or '').replace(SEP,' '),
+        (t.get('subsection') or '').replace(SEP,' '),
+        (t.get('artifact') or '').replace(SEP,' '),
+        (t.get('period') or '').replace(SEP,' '),
+    ]
+    print(SEP.join(fields))
+" | while IFS="$SEP" read -r wbs_id task org priority type iter status issue_num wbs_file section subsection artifact period; do
 
   # skip done tasks
   if [ "$status" = "done" ]; then
@@ -246,7 +251,7 @@ EOF
   echo "[created] $org $wbs_id -> #$ISSUE_NUMBER ($ISSUE_URL)"
 
   # Project v2 に追加 (Project 操作は PROJECTS_PAT)
-  gh_project item-add 1 --owner SAS-Sasao --url "$ISSUE_URL" 2>&1 | tail -1 || \
+  gh_project item-add 1 --owner "@me" --url "$ISSUE_URL" 2>&1 | tail -1 || \
     echo "::warning::Failed to add $ISSUE_URL to project"
 
   # 少し待機 (rate limit 対策)


### PR DESCRIPTION
## 問題

初回 bootstrap 実行（workflow run 24280426182）で以下 2 つのバグが発覚:

### バグ 1: 全タスクが \`[skip existing]\` で誤判定

bash の \`IFS=\$'\t' read -r\` は **連続タブを単一デリミタとして扱う** 仕様（IFS whitespace character の特殊処理）。空フィールド（\`issue_num\` = None → 空文字列）があると column が 1 つずつシフトし、\`issue_num\` 変数に本来の \`wbs_file\` の値が入ってしまう。

結果: \`[ -n "\$issue_num" ]\` が常に true → 全 124 タスクが誤 skip、1 件も Issue 作成されず。

### バグ 2: \`gh project field-create\` が "unknown owner type" で失敗

Classic PAT 使用時に \`gh project field-create --owner SAS-Sasao\` が owner type (user/org) を解決できない既知の挙動。Priority/Org/WBS-ID/Type/Today の 5 フィールド全てが作成失敗。

## 修正

| バグ | Before | After |
|---|---|---|
| TSV delimiter | \`\\t\` (タブ) | \`\\x1f\` (ASCII Unit Separator、非 whitespace) |
| Project owner | \`--owner SAS-Sasao\` | \`--owner "@me"\` |

\\x1f は IFS whitespace ではないので、連続しても潰れず、空フィールドが正しく保持される。\`@me\` は認証済みユーザ自身を指す shortcut で、owner type の自動判定が不要。

## 検証

### ローカル再現 → 修正前
\`\`\`
issue_num='.companies/domain-tech-collection/docs/secretary/storcon-preparation-wbs.md'
wbs_file='1. プロジェクト管理'
[ -n \"\$issue_num\" ] = YES   ← 全タスクで YES = 誤判定
\`\`\`

### 修正後
\`\`\`
issue_num=''                                          ← 正しく空
wbs_file='.companies/domain-tech-collection/...'      ← 正しい値
section='1. プロジェクト管理'                          ← 正しい値
[ -n \"\$issue_num\" ] = NO    ← Issue 作成フローへ進む
\`\`\`

### \`@me\` 動作確認
\`\`\`
$ gh project view 1 --owner "@me"
@SAS-Sasao's untitled project  ← 正常取得
\`\`\`

## 関連
- 親 PR: #275 (基盤実装), #276 (Classic PAT 対応)
- Failed workflow run: https://github.com/SAS-Sasao/cc-sier-organization/actions/runs/24280426182

このマージ後に bootstrap を再実行します。