### PR TITLE
fix: bootstrap の [found] 分岐でも Project v2 に追加（冪等化）

### DIFF
--- a/.claude/hooks/bootstrap-todo-issues.sh
+++ b/.claude/hooks/bootstrap-todo-issues.sh
@@ -198,7 +198,12 @@ for t in data:
   fi
 
   if [ -n "$existing_issue" ]; then
-    echo "[found] $org $wbs_id -> Issue #$existing_issue"
+    # 既存 Issue あり → Project v2 への追加のみ試みる（冪等）
+    EXISTING_URL="https://github.com/${GITHUB_REPOSITORY:-SAS-Sasao/cc-sier-organization}/issues/$existing_issue"
+    echo "[found] $org $wbs_id -> Issue #$existing_issue (re-adding to project)"
+    gh_project item-add 1 --owner "@me" --url "$EXISTING_URL" 2>&1 | tail -1 || \
+      echo "::warning::Failed to add existing $EXISTING_URL to project"
+    sleep 0.5
     continue
   fi
 


### PR DESCRIPTION
## 問題

前回の bootstrap 実行で 119 Issue が作成されたが、`gh project item-add` が
`missing required scopes [read:org read:discussion]` で全件失敗。

PAT scope 修正後に bootstrap を再実行する際、`[found]   -> Issue #N`
で continue されていたため、**既存 Issue を Project v2 に追加できない** 状態だった。

## 修正

`[found]` 分岐で continue する前に `gh_project item-add` を呼び出す。
`gh project item-add` は冪等（同じ Issue を複数回 add しても重複しない）なので
安全。

## 次のステップ
1. 本 PR マージ
2. PAT に `read:org` + `read:discussion` scope 追加
3. bootstrap 再実行 → 既存 119 Issue を Project v2 に一括追加 + Project v2 field 作成
