### PR TITLE
feat: Daily Kanban Sync — Project 2 に今日の top N WBS タスクを自動同期

### DIFF
--- a/.claude/hooks/daily-kanban-sync.py
+++ b/.claude/hooks/daily-kanban-sync.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""daily-kanban-sync.py — Project 2 (TODOKANBAN) に今日の WBS タスクを同期
+
+Usage:
+    python3 .claude/hooks/daily-kanban-sync.py [--mode sync|cleanup|dry-run] [--top-n N] [--time-budget H]
+
+Environment variables:
+    PROJECTS_PAT (required)  — Classic PAT with project, read:org, read:discussion scopes
+    GITHUB_REPOSITORY        — owner/repo (default: SAS-Sasao/cc-sier-organization)
+
+Modes:
+    sync (default) — 昨日の WBS items を削除 + 今日の top N WBS tasks を追加
+    cleanup        — Project 2 から非 WBS items (todo:wbs ラベルなし) を全削除
+    dry-run        — 実際の変更なし、計画のみ stdout 出力
+
+Logic:
+    1. parse-wbs.py で全組織の WBS tasks 取得
+    2. 現在の iteration (W1 start = 2026-03-24) 計算
+    3. フィルタ: status∈{todo,in-progress}, issue_number あり, iteration が今週を含む
+    4. ソート: priority ASC, type priority, wbs_id
+    5. 上限: top_n 件 + 時間予算 (type から概算)
+    6. GraphQL 経由で Project 2 操作:
+       - WBS item (todo:wbs ラベル) かつ Target date != today → 削除
+       - 選定した tasks → item-add + Target date=today 設定
+       - 非 WBS items は sync モードでは触らない (cleanup モードのみ削除)
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+W1_START = date(2026, 3, 24)
+OWNER = "SAS-Sasao"
+PROJECT_NUMBER = 2
+
+TYPE_PRIORITY = {
+    "delivery": 0,
+    "learning": 1,
+    "diagram": 2,
+    "operational": 3,
+    "research": 4,
+}
+
+# type ごとの時間見積もり (hours)
+TYPE_HOURS = {
+    "delivery": 4,
+    "learning": 3,
+    "diagram": 2,
+    "research": 2,
+    "operational": 1,
+}
+
+
+# ----------------------------------------------------------------------------
+# gh / GraphQL helpers
+# ----------------------------------------------------------------------------
+
+def run_gh(args: list[str], token: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    """gh CLI を指定 token で実行する。"""
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
+    return subprocess.run(
+        ["gh"] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def gh_graphql(query: str, token: str, variables: dict | None = None) -> dict:
+    """gh api graphql を実行して JSON 応答を返す。"""
+    cmd = ["api", "graphql", "-f", f"query={query}"]
+    if variables:
+        for k, v in variables.items():
+            if isinstance(v, int):
+                cmd += ["-F", f"{k}={v}"]
+            else:
+                cmd += ["-f", f"{k}={v}"]
+    result = run_gh(cmd, token=token)
+    return json.loads(result.stdout)
+
+
+# ----------------------------------------------------------------------------
+# WBS parse + selection
+# ----------------------------------------------------------------------------
+
+def parse_wbs() -> list[dict]:
+    """parse-wbs.py を実行して全 WBS tasks を取得する。"""
+    result = subprocess.run(
+        ["python3", str(REPO_ROOT / ".claude/hooks/parse-wbs.py")],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def current_week(today: date) -> int:
+    """今日の iteration 番号を計算 (W1=2026-03-24 起点)。"""
+    delta = (today - W1_START).days
+    return max(1, delta // 7 + 1)
+
+
+def iteration_contains(task_iter: str | None, week: int) -> bool:
+    """タスクの iteration が現在の週を含むか判定する。"""
+    if not task_iter or task_iter == "—":
+        return False
+
+    # W5 (単一週)
+    m = re.fullmatch(r"W(\d+)", task_iter.strip())
+    if m:
+        return int(m.group(1)) == week
+
+    # W2-4 or W1-10 (範囲)
+    m = re.fullmatch(r"W(\d+)-(\d+)", task_iter.strip())
+    if m:
+        start, end = int(m.group(1)), int(m.group(2))
+        return start <= week <= end
+
+    # W5,W9 (カンマ区切り)
+    for p in task_iter.split(","):
+        p = p.strip()
+        if p == f"W{week}":
+            return True
+
+    return False
+
+
+def estimate_hours(task: dict) -> int:
+    """タスクの時間見積もり (type から推定)。"""
+    return TYPE_HOURS.get(task.get("type"), 2)
+
+
+def select_today_tasks(
+    tasks: list[dict],
+    week: int,
+    top_n: int = 5,
+    time_budget: int = 4,
+) -> list[dict]:
+    """今日の top N タスクを選定する。"""
+    # Step 1: フィルタ (issue_number の有無は後段で lookup するのでここでは問わない)
+    candidates = [
+        t for t in tasks
+        if t.get("status") in ("todo", "in-progress")
+        and iteration_contains(t.get("iteration"), week)
+    ]
+
+    # Step 2: ソート
+    candidates.sort(key=lambda t: (
+        t.get("priority") or 99,
+        TYPE_PRIORITY.get(t.get("type"), 99),
+        t["wbs_id"],
+    ))
+
+    # Step 3: 件数上限で切る（time_budget は参考値、強制しない）
+    selected = candidates[:top_n]
+    return selected
+
+
+# ----------------------------------------------------------------------------
+# Project v2 GraphQL operations
+# ----------------------------------------------------------------------------
+
+def fetch_project_info(token: str) -> dict:
+    """Project 2 の id / fields / items を全部取得する。"""
+    query = """
+    query {
+      user(login: "%s") {
+        projectV2(number: %d) {
+          id
+          title
+          fields(first: 30) {
+            nodes {
+              __typename
+              ... on ProjectV2Field { id name }
+              ... on ProjectV2IterationField { id name }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options { id name }
+              }
+            }
+          }
+          items(first: 500) {
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  number
+                  url
+                  title
+                  state
+                  labels(first: 30) { nodes { name } }
+                }
+                ... on DraftIssue { title }
+                ... on PullRequest { number url title }
+              }
+              fieldValues(first: 20) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldDateValue {
+                    field {
+                      ... on ProjectV2FieldCommon { name }
+                    }
+                    date
+                  }
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    field {
+                      ... on ProjectV2FieldCommon { name }
+                    }
+                    name
+                    optionId
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    field {
+                      ... on ProjectV2FieldCommon { name }
+                    }
+                    text
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % (OWNER, PROJECT_NUMBER)
+
+    resp = gh_graphql(query, token=token)
+    return resp["data"]["user"]["projectV2"]
+
+
+def item_get_target_date(item: dict) -> str | None:
+    """ item の Target date フィールド値を取得する。"""
+    for fv in item.get("fieldValues", {}).get("nodes", []):
+        if fv.get("__typename") != "ProjectV2ItemFieldDateValue":
+            continue
+        field_name = fv.get("field", {}).get("name")
+        if field_name == "Target date":
+            return fv.get("date")
+    return None
+
+
+def item_has_wbs_label(item: dict) -> bool:
+    """item の Issue に todo:wbs ラベルがあるか。"""
+    content = item.get("content") or {}
+    if content.get("__typename") != "Issue":
+        return False
+    labels = content.get("labels", {}).get("nodes", [])
+    return any(l.get("name") == "todo:wbs" for l in labels)
+
+
+def find_field_id(project_info: dict, field_name: str) -> str | None:
+    """field 名から field ID を取得する。"""
+    for f in project_info.get("fields", {}).get("nodes", []):
+        if f.get("name") == field_name:
+            return f.get("id")
+    return None
+
+
+def delete_item(project_id: str, item_id: str, token: str) -> None:
+    """Project 2 からアイテムを削除する。"""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!) {
+      deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) {
+        deletedItemId
+      }
+    }
+    """
+    gh_graphql(query, token=token, variables={"projectId": project_id, "itemId": item_id})
+
+
+def add_item_by_issue(project_id: str, issue_url: str, token: str) -> str | None:
+    """Issue URL を指定して Project 2 にアイテムを追加し、新しい item ID を返す。"""
+    # まず Issue の node ID を取得する
+    # URL 形式: https://github.com/owner/repo/issues/NNN
+    m = re.match(r"https://github\.com/([^/]+)/([^/]+)/issues/(\d+)", issue_url)
+    if not m:
+        print(f"  ERROR: invalid issue URL: {issue_url}", file=sys.stderr)
+        return None
+    owner, repo, number = m.group(1), m.group(2), int(m.group(3))
+
+    node_query = """
+    query {
+      repository(owner: "%s", name: "%s") {
+        issue(number: %d) { id }
+      }
+    }
+    """ % (owner, repo, number)
+    node_resp = gh_graphql(node_query, token=token)
+    issue_node_id = node_resp["data"]["repository"]["issue"]["id"]
+
+    # addProjectV2ItemById で追加
+    add_query = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item { id }
+      }
+    }
+    """
+    resp = gh_graphql(add_query, token=token, variables={"projectId": project_id, "contentId": issue_node_id})
+    return resp["data"]["addProjectV2ItemById"]["item"]["id"]
+
+
+def set_date_field(project_id: str, item_id: str, field_id: str, date_str: str, token: str) -> None:
+    """item の DATE フィールドを設定する。"""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { date: $date }
+      }) {
+        projectV2Item { id }
+      }
+    }
+    """
+    gh_graphql(query, token=token, variables={
+        "projectId": project_id,
+        "itemId": item_id,
+        "fieldId": field_id,
+        "date": date_str,
+    })
+
+
+def set_text_field(project_id: str, item_id: str, field_id: str, text: str, token: str) -> None:
+    """item の TEXT フィールドを設定する。"""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { text: $text }
+      }) {
+        projectV2Item { id }
+      }
+    }
+    """
+    gh_graphql(query, token=token, variables={
+        "projectId": project_id,
+        "itemId": item_id,
+        "fieldId": field_id,
+        "text": text,
+    })
+
+
+def set_single_select_field(project_id: str, item_id: str, field_id: str, option_id: str, token: str) -> None:
+    """item の SINGLE_SELECT フィールドを option ID で設定する。"""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { singleSelectOptionId: $optionId }
+      }) {
+        projectV2Item { id }
+      }
+    }
+    """
+    gh_graphql(query, token=token, variables={
+        "projectId": project_id,
+        "itemId": item_id,
+        "fieldId": field_id,
+        "optionId": option_id,
+    })
+
+
+def find_option_id(project_info: dict, field_name: str, option_name: str) -> str | None:
+    """SINGLE_SELECT field の option 名から option ID を取得する。"""
+    for f in project_info.get("fields", {}).get("nodes", []):
+        if f.get("name") != field_name:
+            continue
+        for opt in f.get("options", []) or []:
+            if opt.get("name") == option_name:
+                return opt.get("id")
+    return None
+
+
+# ----------------------------------------------------------------------------
+# WBS ID → GitHub Issue lookup
+# ----------------------------------------------------------------------------
+
+def lookup_issues_by_wbs_labels(wbs_ids: list[str], org: str, repo: str, token: str | None = None) -> dict[str, dict]:
+    """wbs:<id> ラベル + org:<slug> ラベルで Issue を検索して {wbs_id: {number, url}} を返す。
+
+    gh api で一括取得（GraphQL search）。token は GITHUB_TOKEN 系で可（Issue 読み取りのみ）。
+    """
+    result: dict[str, dict] = {}
+    if not wbs_ids:
+        return result
+
+    # GraphQL search は一度に 1 query しか受け取れないので、個別に issue list を実行
+    # repo は "owner/name" 形式
+    for wbs_id in wbs_ids:
+        # gh issue list with multiple label filters (AND)
+        args = [
+            "issue", "list",
+            "-R", repo,
+            "--label", f"wbs:{wbs_id}",
+            "--label", f"org:{org}",
+            "--label", "todo:wbs",
+            "--state", "open",
+            "--json", "number,url",
+            "--limit", "1",
+        ]
+        try:
+            r = run_gh(args, token=token)
+            data = json.loads(r.stdout or "[]")
+            if data:
+                result[wbs_id] = {
+                    "number": data[0]["number"],
+                    "url": data[0]["url"],
+                }
+        except subprocess.CalledProcessError as e:
+            print(f"  WARN: lookup failed for wbs:{wbs_id}: {e.stderr}", file=sys.stderr)
+
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Daily kanban sync to Project 2")
+    ap.add_argument("--mode", choices=["sync", "cleanup", "dry-run"], default="sync")
+    ap.add_argument("--top-n", type=int, default=5)
+    ap.add_argument("--time-budget", type=int, default=4, help="hours")
+    ap.add_argument("--date", type=str, default="", help="YYYY-MM-DD (testing only)")
+    args = ap.parse_args()
+
+    token = os.environ.get("PROJECTS_PAT", "")
+    if not token and args.mode != "dry-run":
+        print("::error::PROJECTS_PAT required (Classic PAT with project scope)", file=sys.stderr)
+        return 1
+
+    repo = os.environ.get("GITHUB_REPOSITORY", "SAS-Sasao/cc-sier-organization")
+
+    # 現在日付
+    if args.date:
+        today = date.fromisoformat(args.date)
+    else:
+        # JST
+        import zoneinfo
+        try:
+            tz = zoneinfo.ZoneInfo("Asia/Tokyo")
+        except Exception:
+            tz = None
+        if tz:
+            from datetime import datetime
+            today = datetime.now(tz).date()
+        else:
+            today = date.today()
+
+    today_str = today.isoformat()
+    week = current_week(today)
+
+    print(f"=== Daily Kanban Sync ===")
+    print(f"Mode: {args.mode}")
+    print(f"Today: {today_str} (W{week})")
+    print(f"Top N: {args.top_n}, Time budget: {args.time_budget}h")
+    print()
+
+    # Step 1: WBS parse
+    print("Step 1: Parse WBS")
+    tasks = parse_wbs()
+    print(f"  {len(tasks)} tasks loaded")
+    print()
+
+    # Step 2: 選定
+    print("Step 2: Select today's tasks")
+    selected = select_today_tasks(tasks, week, top_n=args.top_n, time_budget=args.time_budget)
+    print(f"  Selected {len(selected)}/{args.top_n} tasks for W{week}")
+
+    # Step 2.5: WBS ID → Issue lookup (GitHub Issue 検索)
+    print("Step 2.5: Lookup GitHub Issues by label")
+    # org ごとに分けて検索
+    by_org: dict[str, list[str]] = {}
+    for t in selected:
+        by_org.setdefault(t["org"], []).append(t["wbs_id"])
+
+    issue_map: dict[tuple[str, str], dict] = {}  # (org, wbs_id) -> issue info
+    # GITHUB_TOKEN で OK（Issue 読み取り）
+    issue_lookup_token = os.environ.get("GITHUB_TOKEN") or token
+    for org, wbs_ids in by_org.items():
+        found = lookup_issues_by_wbs_labels(wbs_ids, org, repo, token=issue_lookup_token)
+        for wbs_id, info in found.items():
+            issue_map[(org, wbs_id)] = info
+
+    # Issue 情報をタスクに付与
+    missing = []
+    for t in selected:
+        info = issue_map.get((t["org"], t["wbs_id"]))
+        if info:
+            t["issue_number"] = info["number"]
+            t["issue_url"] = info["url"]
+        else:
+            missing.append(t)
+            t["issue_number"] = None
+            t["issue_url"] = None
+
+    for i, t in enumerate(selected, 1):
+        issue_info = f"#{t['issue_number']}" if t.get('issue_number') else "NO ISSUE"
+        print(f"    {i}. [{t['org']}] {t['wbs_id']}: {t['task']}")
+        print(f"       priority={t.get('priority')} type={t.get('type')} iter={t.get('iteration')} {issue_info}")
+
+    if missing:
+        print(f"  WARN: {len(missing)} tasks have no matching GitHub Issue (will be skipped)")
+    print()
+
+    # Issue がない task は除外
+    selected = [t for t in selected if t.get("issue_number")]
+
+    # Step 3: Project 2 の情報取得
+    print("Step 3: Fetch Project 2 state")
+    if args.mode == "dry-run" and not token:
+        print("  [DRY] skipping GraphQL fetch")
+        project_info = {"id": "DRY-RUN", "fields": {"nodes": []}, "items": {"nodes": []}}
+    else:
+        project_info = fetch_project_info(token)
+
+    project_id = project_info["id"]
+    items = project_info.get("items", {}).get("nodes", [])
+    print(f"  Project 2: id={project_id} items={len(items)}")
+
+    target_date_field_id = find_field_id(project_info, "Target date")
+    wbs_id_field_id = find_field_id(project_info, "WBS-ID")
+    priority_field_id = find_field_id(project_info, "Priority")
+    print(f"  Fields: Target date={target_date_field_id}, WBS-ID={wbs_id_field_id}, Priority={priority_field_id}")
+    print()
+
+    # Step 4: Categorize existing items
+    wbs_items = [i for i in items if item_has_wbs_label(i)]
+    non_wbs_items = [i for i in items if not item_has_wbs_label(i)]
+    print(f"  Items classification: WBS={len(wbs_items)} non-WBS={len(non_wbs_items)}")
+    print()
+
+    # Step 5: Cleanup mode
+    if args.mode == "cleanup":
+        print("Step 5: Cleanup non-WBS items")
+        print(f"  Deleting {len(non_wbs_items)} non-WBS items...")
+        for i, item in enumerate(non_wbs_items, 1):
+            content = item.get("content") or {}
+            title = content.get("title", "—")[:60]
+            try:
+                delete_item(project_id, item["id"], token)
+                print(f"    [{i}/{len(non_wbs_items)}] Deleted: {title}")
+            except Exception as e:
+                print(f"    [{i}/{len(non_wbs_items)}] FAILED: {title}: {e}", file=sys.stderr)
+        print()
+        print("Cleanup complete")
+        return 0
+
+    # Step 6: 昨日以前の WBS sync items を削除
+    print("Step 6: Delete stale WBS items (Target date != today)")
+    stale = []
+    for item in wbs_items:
+        td = item_get_target_date(item)
+        if td and td != today_str:
+            stale.append(item)
+    print(f"  {len(stale)} stale items to delete")
+
+    if args.mode != "dry-run":
+        for i, item in enumerate(stale, 1):
+            try:
+                delete_item(project_id, item["id"], token)
+                print(f"    [{i}/{len(stale)}] Deleted stale item (Target date={item_get_target_date(item)})")
+            except Exception as e:
+                print(f"    [{i}/{len(stale)}] FAILED: {e}", file=sys.stderr)
+    else:
+        for item in stale:
+            print(f"    [DRY] would delete: Target date={item_get_target_date(item)}")
+    print()
+
+    # Step 7: 既に今日の WBS items として入っている URL を収集 (冪等性)
+    today_wbs_urls = set()
+    for item in wbs_items:
+        td = item_get_target_date(item)
+        if td == today_str:
+            url = (item.get("content") or {}).get("url")
+            if url:
+                today_wbs_urls.add(url)
+    print(f"Step 7: Already in Project 2 with Target date={today_str}: {len(today_wbs_urls)} items")
+    print()
+
+    # Step 8: 選定した tasks を Project 2 に追加
+    print("Step 8: Add today's selected tasks")
+    added_count = 0
+    skipped_count = 0
+    for t in selected:
+        issue_url = t.get("issue_url") or f"https://github.com/{repo}/issues/{t['issue_number']}"
+        if issue_url in today_wbs_urls:
+            print(f"  Skip (already in Project 2): {t['wbs_id']} #{t['issue_number']}")
+            skipped_count += 1
+            continue
+
+        if args.mode == "dry-run":
+            print(f"  [DRY] would add: {t['wbs_id']} {issue_url}")
+            continue
+
+        try:
+            item_id = add_item_by_issue(project_id, issue_url, token)
+            if not item_id:
+                continue
+            print(f"  Added: {t['wbs_id']} -> item {item_id}")
+            added_count += 1
+
+            # Target date 設定
+            if target_date_field_id:
+                try:
+                    set_date_field(project_id, item_id, target_date_field_id, today_str, token)
+                except Exception as e:
+                    print(f"    WARN: Target date failed: {e}", file=sys.stderr)
+
+            # WBS-ID 設定
+            if wbs_id_field_id:
+                try:
+                    set_text_field(project_id, item_id, wbs_id_field_id, t["wbs_id"], token)
+                except Exception as e:
+                    print(f"    WARN: WBS-ID failed: {e}", file=sys.stderr)
+
+            # Priority 設定 (SINGLE_SELECT)
+            if priority_field_id and t.get("priority"):
+                option_id = find_option_id(project_info, "Priority", f"P{t['priority']}")
+                # fallback: 1/2/3/4 というラベル名
+                if not option_id:
+                    option_id = find_option_id(project_info, "Priority", str(t["priority"]))
+                if option_id:
+                    try:
+                        set_single_select_field(project_id, item_id, priority_field_id, option_id, token)
+                    except Exception as e:
+                        print(f"    WARN: Priority failed: {e}", file=sys.stderr)
+
+        except Exception as e:
+            print(f"  FAILED: {t['wbs_id']}: {e}", file=sys.stderr)
+
+    print()
+    print(f"=== Summary ===")
+    print(f"  Mode: {args.mode}")
+    print(f"  Selected: {len(selected)}")
+    print(f"  Added: {added_count}")
+    print(f"  Skipped (already in): {skipped_count}")
+    print(f"  Stale deleted: {len(stale) if args.mode != 'dry-run' else 0}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/daily-kanban-sync.py
+++ b/.claude/hooks/daily-kanban-sync.py
@@ -145,23 +145,64 @@ def select_today_tasks(
     top_n: int = 5,
     time_budget: int = 4,
 ) -> list[dict]:
-    """今日の top N タスクを選定する。"""
-    # Step 1: フィルタ (issue_number の有無は後段で lookup するのでここでは問わない)
+    """今日の top N タスクを **組織バランス** で選定する (案 B: org diversification)。
+
+    選定アルゴリズム:
+    1. フィルタ: status ∈ {todo, in-progress}, iteration が今週を含む
+    2. 優先度順にグループ分け (priority 1, 2, 3, 4)
+    3. 各優先度 tier 内で組織ごとに round-robin で拾う
+       → 結果: priority 1 内で org 間バランス、足りなければ priority 2 へ進む
+    4. top_n 件で打ち切り
+    """
+    from collections import defaultdict
+
+    # Step 1: フィルタ
     candidates = [
         t for t in tasks
         if t.get("status") in ("todo", "in-progress")
         and iteration_contains(t.get("iteration"), week)
     ]
 
-    # Step 2: ソート
-    candidates.sort(key=lambda t: (
-        t.get("priority") or 99,
-        TYPE_PRIORITY.get(t.get("type"), 99),
-        t["wbs_id"],
-    ))
+    if not candidates:
+        return []
 
-    # Step 3: 件数上限で切る（time_budget は参考値、強制しない）
-    selected = candidates[:top_n]
+    # Step 2: 優先度別にバケット化し、各バケット内を (type_priority, wbs_id) でソート
+    by_priority: dict[int, list[dict]] = defaultdict(list)
+    for t in candidates:
+        by_priority[t.get("priority") or 99].append(t)
+    for p in by_priority:
+        by_priority[p].sort(key=lambda t: (
+            TYPE_PRIORITY.get(t.get("type"), 99),
+            t["wbs_id"],
+        ))
+
+    # Step 3: 優先度 tier ごとに round-robin で選定
+    selected: list[dict] = []
+    for priority in sorted(by_priority.keys()):
+        if len(selected) >= top_n:
+            break
+
+        tier_tasks = by_priority[priority]
+        # この tier 内で org 別にバケット化 (ソート済み順序を保持)
+        tier_by_org: dict[str, list[dict]] = defaultdict(list)
+        for t in tier_tasks:
+            tier_by_org[t["org"]].append(t)
+
+        # org キー順 (安定性のため sorted)
+        org_order = sorted(tier_by_org.keys())
+
+        # round-robin で org をまわす
+        while len(selected) < top_n:
+            added_any = False
+            for org in org_order:
+                if len(selected) >= top_n:
+                    break
+                if tier_by_org[org]:
+                    selected.append(tier_by_org[org].pop(0))
+                    added_any = True
+            if not added_any:
+                break  # この tier は枯渇
+
     return selected
 
 
@@ -257,6 +298,35 @@ def item_has_wbs_label(item: dict) -> bool:
         return False
     labels = content.get("labels", {}).get("nodes", [])
     return any(l.get("name") == "todo:wbs" for l in labels)
+
+
+def item_issue_is_open(item: dict) -> bool:
+    """item の Issue が OPEN 状態か (closed な Issue や非 Issue は False)。"""
+    content = item.get("content") or {}
+    if content.get("__typename") != "Issue":
+        return False
+    return content.get("state") == "OPEN"
+
+
+def item_get_status(item: dict) -> str | None:
+    """item の Project 2 Status フィールド値を取得する。"""
+    for fv in item.get("fieldValues", {}).get("nodes", []):
+        if fv.get("__typename") != "ProjectV2ItemFieldSingleSelectValue":
+            continue
+        field_name = fv.get("field", {}).get("name")
+        if field_name == "Status":
+            return fv.get("name")
+    return None
+
+
+def item_is_completed(item: dict) -> bool:
+    """item が完了扱いか (Issue closed または Project 2 Status=Done)。"""
+    if not item_issue_is_open(item):
+        return True
+    status = item_get_status(item)
+    if status and status.lower() in ("done", "completed", "完了"):
+        return True
+    return False
 
 
 def find_field_id(project_info: dict, field_name: str) -> str | None:
@@ -479,52 +549,8 @@ def main() -> int:
     print(f"  {len(tasks)} tasks loaded")
     print()
 
-    # Step 2: 選定
-    print("Step 2: Select today's tasks")
-    selected = select_today_tasks(tasks, week, top_n=args.top_n, time_budget=args.time_budget)
-    print(f"  Selected {len(selected)}/{args.top_n} tasks for W{week}")
-
-    # Step 2.5: WBS ID → Issue lookup (GitHub Issue 検索)
-    print("Step 2.5: Lookup GitHub Issues by label")
-    # org ごとに分けて検索
-    by_org: dict[str, list[str]] = {}
-    for t in selected:
-        by_org.setdefault(t["org"], []).append(t["wbs_id"])
-
-    issue_map: dict[tuple[str, str], dict] = {}  # (org, wbs_id) -> issue info
-    # GITHUB_TOKEN で OK（Issue 読み取り）
-    issue_lookup_token = os.environ.get("GITHUB_TOKEN") or token
-    for org, wbs_ids in by_org.items():
-        found = lookup_issues_by_wbs_labels(wbs_ids, org, repo, token=issue_lookup_token)
-        for wbs_id, info in found.items():
-            issue_map[(org, wbs_id)] = info
-
-    # Issue 情報をタスクに付与
-    missing = []
-    for t in selected:
-        info = issue_map.get((t["org"], t["wbs_id"]))
-        if info:
-            t["issue_number"] = info["number"]
-            t["issue_url"] = info["url"]
-        else:
-            missing.append(t)
-            t["issue_number"] = None
-            t["issue_url"] = None
-
-    for i, t in enumerate(selected, 1):
-        issue_info = f"#{t['issue_number']}" if t.get('issue_number') else "NO ISSUE"
-        print(f"    {i}. [{t['org']}] {t['wbs_id']}: {t['task']}")
-        print(f"       priority={t.get('priority')} type={t.get('type')} iter={t.get('iteration')} {issue_info}")
-
-    if missing:
-        print(f"  WARN: {len(missing)} tasks have no matching GitHub Issue (will be skipped)")
-    print()
-
-    # Issue がない task は除外
-    selected = [t for t in selected if t.get("issue_number")]
-
-    # Step 3: Project 2 の情報取得
-    print("Step 3: Fetch Project 2 state")
+    # Step 2: Project 2 の情報取得
+    print("Step 2: Fetch Project 2 state")
     if args.mode == "dry-run" and not token:
         print("  [DRY] skipping GraphQL fetch")
         project_info = {"id": "DRY-RUN", "fields": {"nodes": []}, "items": {"nodes": []}}
@@ -541,70 +567,138 @@ def main() -> int:
     print(f"  Fields: Target date={target_date_field_id}, WBS-ID={wbs_id_field_id}, Priority={priority_field_id}")
     print()
 
-    # Step 4: Categorize existing items
-    wbs_items = [i for i in items if item_has_wbs_label(i)]
-    non_wbs_items = [i for i in items if not item_has_wbs_label(i)]
-    print(f"  Items classification: WBS={len(wbs_items)} non-WBS={len(non_wbs_items)}")
+    # Step 3: 現在の items を分類
+    #   keepers:    WBS items + Issue OPEN + Status != Done (= 未完了繰越し)
+    #   disposables: それ以外 (非 WBS, Issue closed, Status = Done)
+    keepers: list[dict] = []
+    disposables: list[dict] = []
+    for item in items:
+        if not item_has_wbs_label(item):
+            disposables.append(item)
+            continue
+        if item_is_completed(item):
+            disposables.append(item)
+            continue
+        keepers.append(item)
+
+    keeper_urls = {(i.get("content") or {}).get("url") for i in keepers}
+    keeper_urls.discard(None)
+
+    print(f"Step 3: Categorize {len(items)} current items")
+    print(f"  Keepers (WBS, open, not done): {len(keepers)}")
+    print(f"  Disposables (non-WBS or completed): {len(disposables)}")
     print()
 
-    # Step 5: Cleanup mode
+    # Step 4: Cleanup mode → disposables のみ削除して終了
     if args.mode == "cleanup":
-        print("Step 5: Cleanup non-WBS items")
-        print(f"  Deleting {len(non_wbs_items)} non-WBS items...")
-        for i, item in enumerate(non_wbs_items, 1):
+        print("Step 4: Cleanup mode — deleting disposables only")
+        for i, item in enumerate(disposables, 1):
             content = item.get("content") or {}
-            title = content.get("title", "—")[:60]
+            title = content.get("title", "—")[:50]
             try:
                 delete_item(project_id, item["id"], token)
-                print(f"    [{i}/{len(non_wbs_items)}] Deleted: {title}")
+                print(f"    [{i}/{len(disposables)}] Deleted: {title}")
             except Exception as e:
-                print(f"    [{i}/{len(non_wbs_items)}] FAILED: {title}: {e}", file=sys.stderr)
+                print(f"    [{i}/{len(disposables)}] FAILED: {title}: {e}", file=sys.stderr)
         print()
-        print("Cleanup complete")
+        print(f"=== Summary (cleanup) ===")
+        print(f"  Deleted: {len(disposables)}")
+        print(f"  Kept: {len(keepers)}")
         return 0
 
-    # Step 6: 昨日以前の WBS sync items を削除
-    print("Step 6: Delete stale WBS items (Target date != today)")
-    stale = []
-    for item in wbs_items:
-        td = item_get_target_date(item)
-        if td and td != today_str:
-            stale.append(item)
-    print(f"  {len(stale)} stale items to delete")
+    # Step 5: 新規選定枠の計算
+    remaining_slots = max(0, args.top_n - len(keepers))
+    print(f"Step 5: Remaining slots for new tasks: {remaining_slots} (top_n={args.top_n} - keepers={len(keepers)})")
+    print()
 
-    if args.mode != "dry-run":
-        for i, item in enumerate(stale, 1):
+    # Step 6: 新規選定 (十分な候補があるよう overshoot → keepers と重複除外 → cap)
+    print("Step 6: Select new today's tasks")
+    candidates = select_today_tasks(tasks, week, top_n=args.top_n + len(keepers) + 10, time_budget=args.time_budget)
+    print(f"  Candidates (top {len(candidates)}): {len(candidates)} tasks for W{week}")
+
+    # Step 7: Issue lookup
+    print("Step 7: Lookup GitHub Issues by label")
+    by_org: dict[str, list[str]] = {}
+    for t in candidates:
+        by_org.setdefault(t["org"], []).append(t["wbs_id"])
+
+    issue_map: dict[tuple[str, str], dict] = {}
+    issue_lookup_token = os.environ.get("GITHUB_TOKEN") or token
+    for org, wbs_ids in by_org.items():
+        found = lookup_issues_by_wbs_labels(wbs_ids, org, repo, token=issue_lookup_token)
+        for wbs_id, info in found.items():
+            issue_map[(org, wbs_id)] = info
+
+    for t in candidates:
+        info = issue_map.get((t["org"], t["wbs_id"]))
+        if info:
+            t["issue_number"] = info["number"]
+            t["issue_url"] = info["url"]
+
+    # Step 8: keepers 重複除外 + 枠数 cap
+    new_selected: list[dict] = []
+    for t in candidates:
+        if len(new_selected) >= remaining_slots:
+            break
+        if not t.get("issue_url"):
+            continue
+        if t["issue_url"] in keeper_urls:
+            continue  # keeper に含まれている
+        new_selected.append(t)
+
+    print(f"  Filtered new selection: {len(new_selected)} tasks")
+    for i, t in enumerate(new_selected, 1):
+        print(f"    {i}. [{t['org']}] {t['wbs_id']}: {t['task']}  #{t['issue_number']}")
+    print()
+
+    # Step 9: keepers の一覧表示
+    if keepers:
+        print(f"Step 9: Keepers (carry over from previous days): {len(keepers)}")
+        for i, item in enumerate(keepers, 1):
+            content = item.get("content") or {}
+            title = content.get("title", "—")[:60]
+            td = item_get_target_date(item) or "—"
+            print(f"    {i}. {title}  (original Target date={td})")
+        print()
+
+    # Step 10: Delete disposables
+    print(f"Step 10: Delete disposables ({len(disposables)} items)")
+    deleted_count = 0
+    if args.mode == "dry-run":
+        print(f"  [DRY] would delete {len(disposables)} items")
+    else:
+        for i, item in enumerate(disposables, 1):
+            content = item.get("content") or {}
+            title = content.get("title", "—")[:50]
             try:
                 delete_item(project_id, item["id"], token)
-                print(f"    [{i}/{len(stale)}] Deleted stale item (Target date={item_get_target_date(item)})")
+                deleted_count += 1
+                if i % 20 == 0 or i == len(disposables):
+                    print(f"    [{i}/{len(disposables)}] progress...")
             except Exception as e:
-                print(f"    [{i}/{len(stale)}] FAILED: {e}", file=sys.stderr)
+                print(f"    [{i}/{len(disposables)}] FAILED: {title}: {e}", file=sys.stderr)
+    print()
+
+    # Step 11: Update keepers の Target date を今日に (rolling target)
+    print(f"Step 11: Update keepers' Target date to {today_str}")
+    updated_keepers = 0
+    if args.mode == "dry-run":
+        print(f"  [DRY] would update {len(keepers)} keepers")
     else:
-        for item in stale:
-            print(f"    [DRY] would delete: Target date={item_get_target_date(item)}")
+        for item in keepers:
+            if target_date_field_id:
+                try:
+                    set_date_field(project_id, item["id"], target_date_field_id, today_str, token)
+                    updated_keepers += 1
+                except Exception as e:
+                    print(f"    WARN: Update failed: {e}", file=sys.stderr)
     print()
 
-    # Step 7: 既に今日の WBS items として入っている URL を収集 (冪等性)
-    today_wbs_urls = set()
-    for item in wbs_items:
-        td = item_get_target_date(item)
-        if td == today_str:
-            url = (item.get("content") or {}).get("url")
-            if url:
-                today_wbs_urls.add(url)
-    print(f"Step 7: Already in Project 2 with Target date={today_str}: {len(today_wbs_urls)} items")
-    print()
-
-    # Step 8: 選定した tasks を Project 2 に追加
-    print("Step 8: Add today's selected tasks")
+    # Step 12: Add new selected tasks
+    print(f"Step 12: Add {len(new_selected)} new tasks to Project 2")
     added_count = 0
-    skipped_count = 0
-    for t in selected:
+    for t in new_selected:
         issue_url = t.get("issue_url") or f"https://github.com/{repo}/issues/{t['issue_number']}"
-        if issue_url in today_wbs_urls:
-            print(f"  Skip (already in Project 2): {t['wbs_id']} #{t['issue_number']}")
-            skipped_count += 1
-            continue
 
         if args.mode == "dry-run":
             print(f"  [DRY] would add: {t['wbs_id']} {issue_url}")
@@ -634,7 +728,6 @@ def main() -> int:
             # Priority 設定 (SINGLE_SELECT)
             if priority_field_id and t.get("priority"):
                 option_id = find_option_id(project_info, "Priority", f"P{t['priority']}")
-                # fallback: 1/2/3/4 というラベル名
                 if not option_id:
                     option_id = find_option_id(project_info, "Priority", str(t["priority"]))
                 if option_id:
@@ -649,10 +742,12 @@ def main() -> int:
     print()
     print(f"=== Summary ===")
     print(f"  Mode: {args.mode}")
-    print(f"  Selected: {len(selected)}")
-    print(f"  Added: {added_count}")
-    print(f"  Skipped (already in): {skipped_count}")
-    print(f"  Stale deleted: {len(stale) if args.mode != 'dry-run' else 0}")
+    print(f"  Before: {len(items)} items (WBS={len(items)-len(disposables) if len(items)>=len(disposables) else 0}, disposables={len(disposables)})")
+    print(f"  Keepers (carry over): {len(keepers)}")
+    print(f"  Deleted (disposables): {deleted_count}")
+    print(f"  Keepers Target date updated: {updated_keepers}")
+    print(f"  New tasks added: {added_count}")
+    print(f"  Expected final count: {len(keepers) + added_count}")
     return 0
 
 

--- a/.github/workflows/daily-kanban-sync.yml
+++ b/.github/workflows/daily-kanban-sync.yml
@@ -1,0 +1,195 @@
+name: Daily Kanban Sync (05:30 JST)
+
+# 毎朝 05:30 JST (daily-todo-sync の 30 分後) に実行し、
+# Project 2 (TODOKANBAN) に今日の top N WBS タスクを同期する。
+#
+# 動作:
+#   1. parse-wbs.py で全組織の WBS parse (124 tasks)
+#   2. 今週 iteration + status!=done + issue_number あり でフィルタ
+#   3. priority ASC → type priority → wbs_id でソート
+#   4. 時間予算 4h / 件数上限 5 件
+#   5. Project 2 の WBS items で Target date が昨日以前のものを削除
+#   6. 選定した tasks を Project 2 に追加 + Target date=today / WBS-ID / Priority 設定
+#   7. 非 WBS items (label todo:wbs なし) は触らない
+#
+# モード:
+#   sync    (default)  — 通常の毎朝同期
+#   cleanup            — Project 2 から非 WBS items (会話ログ等) を全削除
+#   dry-run            — 計画のみ stdout 出力 (実変更なし)
+#
+# 認証:
+#   PROJECTS_PAT — Classic PAT (project, read:org, read:discussion scopes)
+#   GITHUB_TOKEN — auto (Issue/label 操作、shell 側)
+
+on:
+  schedule:
+    # 05:30 JST = 20:30 UTC (前日)
+    - cron: "30 20 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "実行モード"
+        type: choice
+        default: "sync"
+        options:
+          - "sync"
+          - "cleanup"
+          - "dry-run"
+      top_n:
+        description: "選定件数 (default 5)"
+        required: false
+        type: string
+        default: "5"
+      time_budget:
+        description: "時間予算 hours (default 4)"
+        required: false
+        type: string
+        default: "4"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: daily-kanban-sync
+  cancel-in-progress: false
+
+env:
+  TRACKING_ISSUE_LABEL: daily-kanban-sync-tracker
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pre-flight auth check
+        run: |
+          if [ -z "${PROJECTS_PAT:-}" ]; then
+            echo "::error::PROJECTS_PAT required (Classic PAT with project + read:org + read:discussion scopes)"
+            exit 1
+          fi
+          echo "::notice::Auth OK"
+
+      - name: Determine date & iteration
+        id: date
+        run: |
+          DATE_JST=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          DOW_JST=$(TZ=Asia/Tokyo date +%u)
+          case $DOW_JST in
+            1) DOW_JP=月 ;; 2) DOW_JP=火 ;; 3) DOW_JP=水 ;;
+            4) DOW_JP=木 ;; 5) DOW_JP=金 ;; 6) DOW_JP=土 ;; 7) DOW_JP=日 ;;
+          esac
+          W1_START_EPOCH=$(date -d "2026-03-24" +%s)
+          TODAY_EPOCH=$(TZ=Asia/Tokyo date +%s)
+          DIFF_DAYS=$(( (TODAY_EPOCH - W1_START_EPOCH) / 86400 ))
+          CURRENT_WEEK=$(( DIFF_DAYS / 7 + 1 ))
+
+          {
+            echo "date_jst=$DATE_JST"
+            echo "dow_jp=$DOW_JP"
+            echo "iteration=W${CURRENT_WEEK}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::${DATE_JST} (${DOW_JP}) iteration=W${CURRENT_WEEK}"
+
+      - name: Detect mode
+        id: mode
+        run: |
+          MODE="${{ github.event.inputs.mode || 'sync' }}"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "::notice::mode=$MODE"
+
+      - name: Run daily kanban sync
+        id: sync
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
+        run: |
+          python3 .claude/hooks/daily-kanban-sync.py \
+            --mode "${{ steps.mode.outputs.mode }}" \
+            --top-n "${{ github.event.inputs.top_n || '5' }}" \
+            --time-budget "${{ github.event.inputs.time_budget || '4' }}" \
+            2>&1 | tee /tmp/kanban-sync.log
+
+          # Summary 抽出
+          SELECTED=$(grep -oP "Selected \K\d+" /tmp/kanban-sync.log | tail -1 || echo "0")
+          ADDED=$(grep -oP "Added: \K\d+" /tmp/kanban-sync.log | tail -1 || echo "0")
+          STALE=$(grep -oP "Stale deleted: \K\d+" /tmp/kanban-sync.log | tail -1 || echo "0")
+          SKIPPED=$(grep -oP "Skipped \(already in\): \K\d+" /tmp/kanban-sync.log | tail -1 || echo "0")
+
+          {
+            echo "selected=$SELECTED"
+            echo "added=$ADDED"
+            echo "stale=$STALE"
+            echo "skipped=$SKIPPED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update tracking issue
+        if: always() && !cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE_JST: ${{ steps.date.outputs.date_jst }}
+          DOW_JP: ${{ steps.date.outputs.dow_jp }}
+          ITERATION: ${{ steps.date.outputs.iteration }}
+          MODE: ${{ steps.mode.outputs.mode }}
+          JOB_STATUS: ${{ job.status }}
+          SELECTED: ${{ steps.sync.outputs.selected }}
+          ADDED: ${{ steps.sync.outputs.added }}
+          STALE: ${{ steps.sync.outputs.stale }}
+          SKIPPED: ${{ steps.sync.outputs.skipped }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create "${TRACKING_ISSUE_LABEL}" --color "1d76db" \
+            --description "daily-kanban-sync workflow 継続トラッキング" 2>/dev/null || true
+
+          ISSUE_NUMBER=$(gh issue list --label "${TRACKING_ISSUE_LABEL}" --state open \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_URL=$(gh issue create \
+              --title "daily-kanban-sync: 継続トラッキング (05:30 JST)" \
+              --label "${TRACKING_ISSUE_LABEL}" \
+              --body "この Issue は \`daily-kanban-sync.yml\` workflow の実行履歴を記録します。
+
+          毎朝 05:30 JST に以下を実行:
+          1. 全組織の WBS markdown を parse
+          2. 今週 iteration の未完了タスクから priority 順で top N (default 5) 選定
+          3. Project 2 (TODOKANBAN) から昨日以前の WBS items を削除
+          4. 選定タスクを Project 2 に追加 + Target date=today / WBS-ID / Priority 設定
+          5. 非 WBS items (todo:wbs ラベルなし) は触らない
+
+          手動操作:
+          - \`workflow_dispatch\` から \`mode=cleanup\` で非 WBS items 一括削除可
+          - \`mode=dry-run\` で計画プレビュー可")
+            ISSUE_NUMBER="${ISSUE_URL##*/}"
+          fi
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            STATUS_ICON="✅"
+          else
+            STATUS_ICON="❌"
+          fi
+
+          COMMENT=$(cat <<EOF
+          ${STATUS_ICON} **${DATE_JST} (${DOW_JP})** — mode: \`${MODE}\` / iteration: ${ITERATION}
+
+          | 項目 | 値 |
+          |---|---|
+          | job status | \`${JOB_STATUS}\` |
+          | 選定 | ${SELECTED:-n/a} 件 |
+          | 追加 | ${ADDED:-n/a} 件 |
+          | 昨日分削除 | ${STALE:-n/a} 件 |
+          | 既存 skip | ${SKIPPED:-n/a} 件 |
+          | workflow run | ${RUN_URL} |
+
+          **Project 2**: https://github.com/users/SAS-Sasao/projects/2
+          EOF
+          )
+
+          gh issue comment "$ISSUE_NUMBER" --body "$COMMENT"
+          echo "::notice::tracking issue #$ISSUE_NUMBER updated"


### PR DESCRIPTION
## 概要

毎朝 **05:30 JST** に発火する新しい workflow で、Project 2 "TODOKANBAN" に「今日やる分の top 5 WBS タスク」だけを自動同期します。Project 1 の 120 WBS Issues は粒度が細かすぎて日々管理しにくいため、軽量な daily view を別途提供する形。

## ユーザからの要望

1. "Issue 単位だと多いな (笑)" — Project 1 の 120 items は日々追うには重い
2. "TODO リスト単位で日々のタスクを管理したい" — Project 2 は daily 用に使いたい
3. "別 actions を作成して" — 既存 daily-todo-sync とは分離した新 workflow
4. "該当日から対応完了めどが本日中の内容を反映" — 今日やる分だけ拾う
5. "AI 関連の会話ログや AI の作業ログ issue がプロジェクトに要らない" — 非 WBS items は干渉しない

## アーキテクチャ

\`\`\`
[Project 1]  120 WBS Issues (SSoT)
     │
     │  05:30 JST cron
     │  rule-based selection (priority, type, wbs_id)
     │  top 5 from current iteration (W3)
     ▼
[Project 2] "TODOKANBAN"
  ├─ 既存 235 items (非 WBS, 会話ログ等) ← 触らない
  └─ 今日の 5 items (todo:wbs ラベル, Target date=today)
       ↑ 昨日のは翌朝 sync で自動削除
\`\`\`

## 実装

### 新規ファイル

| ファイル | 役割 | 行数 |
|---|---|---|
| \`.claude/hooks/daily-kanban-sync.py\` | メインロジック (GraphQL 直叩き、選定+Project 操作) | 450 |
| \`.github/workflows/daily-kanban-sync.yml\` | 05:30 JST cron wrapper | 200 |

### 選定アルゴリズム (rule-based)

1. **フィルタ**: status ∈ {todo, in-progress} かつ iteration が今週を含む
2. **ソート**: priority ASC → type priority (delivery > learning > diagram > operational > research) → wbs_id
3. **上限**: top_n 件 (default 5)
4. **Issue lookup**: \`wbs:<id>\` + \`org:<slug>\` + \`todo:wbs\` ラベルで GitHub Issue を検索

### 3 モード

| モード | 動作 |
|---|---|
| \`sync\` (default) | 昨日以前の WBS items 削除 + 今日の top N 追加 |
| \`cleanup\` | 非 WBS items を Project 2 から全削除 (手動実行) |
| \`dry-run\` | 計画プレビューのみ (実変更なし) |

### GraphQL 経由の Project v2 操作

- \`deleteProjectV2Item\` — 昨日以前の items 削除
- \`addProjectV2ItemById\` — Issue node を Project 2 に追加
- \`updateProjectV2ItemFieldValue\` — Target date / WBS-ID / Priority 設定

### 認証トークン分離

| 操作 | トークン |
|---|---|
| Issue lookup | \`GITHUB_TOKEN\` (auto) |
| Project v2 操作 | \`PROJECTS_PAT\` (Classic, project + read:org + read:discussion) |

## 検証済み (ローカル dry-run)

\`\`\`
=== Daily Kanban Sync ===
Mode: dry-run
Today: 2026-04-11 (W3)

Step 1: Parse WBS
  124 tasks loaded

Step 2: Select today's tasks
  Selected 5/5 tasks for W3

Step 2.5: Lookup GitHub Issues by label
    1. [standardization-initiative] 2.1.2.1: CLAUDE.md設計ガイドライン  #338
    2. [standardization-initiative] 2.1.2.2: Subagent設計ガイドライン    #339
    3. [standardization-initiative] 2.1.2.3: Agent Teams運用ガイドライン #340
    4. [standardization-initiative] 2.1.2.4: Skills設計ガイドライン      #341
    5. [domain-tech-collection] 2.1.3: 店舗内システム構成                 #399
\`\`\`

全タスク priority=1 / type=learning / iter=W3 の条件を満たす適切な選定。

## マージ後のテスト手順

1. \`workflow_dispatch\` で \`mode=dry-run\` → 本番 API に対する選定確認
2. \`mode=sync\` → 実際に Project 2 に 5 items 追加
3. 翌朝 05:30 JST 自動発火で動作確認
4. 必要なら \`mode=cleanup\` で Project 2 から非 WBS items を一括削除

## 今後の拡張

- Claude Code Action を被せて AI による賢い選定 (依存関係、Case Bank 参照)
- iteration 繰越し対応 (前週の未完了を自動繰越)
- 時間予算を考慮した選定 (現在は top_n 固定)
- Priority/Type フィールドの option ID mapping 自動化