### PR TITLE
feat: TodoInsights — 毎晩 23:50 JST にクローズ items 収集 + Chart.js dashboard

### DIFF
--- a/.claude/hooks/daily-insights-sync.py
+++ b/.claude/hooks/daily-insights-sync.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""daily-insights-sync.py — TodoInsights (Project 4) にクローズ済み Issues/PRs を同期
+
+Usage:
+    python3 .claude/hooks/daily-insights-sync.py --mode sync
+    python3 .claude/hooks/daily-insights-sync.py --mode backfill --since 2026-03-21
+    python3 .claude/hooks/daily-insights-sync.py --mode dry-run
+
+Environment:
+    PROJECTS_PAT  (required)   — Classic PAT with project + read:org + read:discussion
+    GITHUB_TOKEN  (optional)   — Issue/PR 読取 (無ければ PROJECTS_PAT 流用)
+
+Modes:
+    sync (default)  — 過去 24h の closed items を追加 (rolling window)
+    backfill        — --since 以降の全 closed items を一括インポート
+    dry-run         — 計画のみ出力、実変更なし
+
+動作:
+    1. GitHub Search API で cc-sier-organization の closed Issues/PRs を取得
+    2. Project 4 の既存 items と突合 (Issue URL で dedup)
+    3. 新規 items を Project v2 に追加
+    4. カスタムフィールド (Closed date / Type / Org / Category) を設定
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OWNER = "SAS-Sasao"
+PROJECT_NUMBER = 4  # TodoInsights
+REPO_FULL = "SAS-Sasao/cc-sier-organization"
+
+# Category 判定テーブル (label 優先)
+CATEGORY_LABEL_MAP: dict[str, str] = {
+    "todo:wbs": "wbs",
+    "type:daily-digest": "digest",
+    "daily-kanban-sync": "automation",
+    "daily-todo-sync-tracker": "automation",
+    "daily-todo-sync": "automation",
+    "daily-kanban-sync-tracker": "automation",
+    "nightly-claude-md-update": "automation",
+    "nightly-claude-md-tracker": "automation",
+    "daily-cycle-supplement-tracker": "automation",
+    "daily-digest-automation-tracker": "automation",
+    "daily-digest-automation": "automation",
+    "daily-insights-sync-tracker": "automation",
+    "daily-insights-sync": "automation",
+    "cycle-tracker": "automation",
+    "cycle-supplement-tracker": "automation",
+    "needs-human-review": "automation",
+}
+
+# タイトル prefix による category 判定 (fallback)
+CATEGORY_TITLE_PATTERNS = [
+    (re.compile(r"^feat[:\(]"), "feat"),
+    (re.compile(r"^fix[:\(]"), "fix"),
+    (re.compile(r"^docs[:\(]"), "docs"),
+    (re.compile(r"^chore[:\(]"), "chore"),
+    (re.compile(r"^ci[:\(]"), "chore"),
+    (re.compile(r"^refactor[:\(]"), "other"),
+    (re.compile(r"^test[:\(]"), "other"),
+    (re.compile(r"^perf[:\(]"), "other"),
+    (re.compile(r"^admin[:\(]"), "chore"),
+]
+
+
+# ----------------------------------------------------------------------------
+# gh / GraphQL helpers
+# ----------------------------------------------------------------------------
+
+def run_gh(args: list[str], token: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
+    return subprocess.run(
+        ["gh"] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def gh_graphql(query: str, token: str, variables: dict | None = None) -> dict:
+    cmd = ["api", "graphql", "-f", f"query={query}"]
+    if variables:
+        for k, v in variables.items():
+            if v is None:
+                continue
+            if isinstance(v, int):
+                cmd += ["-F", f"{k}={v}"]
+            else:
+                cmd += ["-f", f"{k}={v}"]
+    try:
+        result = run_gh(cmd, token=token)
+    except subprocess.CalledProcessError as e:
+        print(f"::error::gh graphql failed:", file=sys.stderr)
+        print(f"::error::  stderr: {e.stderr}", file=sys.stderr)
+        raise
+    data = json.loads(result.stdout)
+    if data.get("errors"):
+        print(f"::warning::GraphQL errors: {data['errors']}", file=sys.stderr)
+    return data
+
+
+# ----------------------------------------------------------------------------
+# Closed items search (GitHub Search API)
+# ----------------------------------------------------------------------------
+
+def fetch_closed_items(search_query: str, token: str) -> list[dict]:
+    """GitHub Search API でクローズ済み Issues/PRs を取得 (cursor pagination)。
+
+    注意: search API は 1000 件上限。backfill で超える場合は呼び出し側で分割する。
+    """
+    all_items: list[dict] = []
+    cursor: str | None = None
+    page = 0
+    query = """
+    query($q: String!, $cursor: String) {
+      search(query: $q, type: ISSUE, first: 100, after: $cursor) {
+        issueCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          __typename
+          ... on Issue {
+            id
+            number
+            url
+            title
+            state
+            closedAt
+            labels(first: 30) { nodes { name } }
+          }
+          ... on PullRequest {
+            id
+            number
+            url
+            title
+            state
+            closedAt
+            mergedAt
+            labels(first: 30) { nodes { name } }
+          }
+        }
+      }
+    }
+    """
+    while True:
+        page += 1
+        resp = gh_graphql(query, token=token, variables={"q": search_query, "cursor": cursor})
+        search = resp["data"]["search"]
+        total = search.get("issueCount", 0)
+        nodes = [n for n in (search.get("nodes") or []) if n]
+        all_items.extend(nodes)
+        print(
+            f"  Fetched page {page}: {len(nodes)} items (cumulative: {len(all_items)} / totalCount: {total})",
+            file=sys.stderr,
+        )
+        page_info = search.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return all_items
+
+
+# ----------------------------------------------------------------------------
+# Project v2 ops
+# ----------------------------------------------------------------------------
+
+def fetch_project_info(token: str) -> dict:
+    """Project 4 の id / fields / items を取得する (items は pagination)。"""
+    query = """
+    query($cursor: String) {
+      user(login: "%s") {
+        projectV2(number: %d) {
+          id
+          title
+          fields(first: 30) {
+            nodes {
+              __typename
+              ... on ProjectV2Field { id name }
+              ... on ProjectV2IterationField { id name }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options { id name }
+              }
+            }
+          }
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue { number url }
+                ... on PullRequest { number url }
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % (OWNER, PROJECT_NUMBER)
+
+    all_items: list[dict] = []
+    project_id = None
+    title = None
+    fields_nodes = None
+    cursor: str | None = None
+    page = 0
+
+    while True:
+        page += 1
+        resp = gh_graphql(query, token=token, variables={"cursor": cursor})
+        pv2 = resp["data"]["user"]["projectV2"]
+        if pv2 is None:
+            print("::error::Project 4 not found or not accessible", file=sys.stderr)
+            break
+
+        if project_id is None:
+            project_id = pv2["id"]
+            title = pv2["title"]
+            fields_nodes = pv2["fields"]
+
+        items_conn = pv2.get("items", {})
+        page_nodes = items_conn.get("nodes") or []
+        all_items.extend(page_nodes)
+
+        page_info = items_conn.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+
+    print(f"  Project {title}: {len(all_items)} existing items", file=sys.stderr)
+
+    return {
+        "id": project_id,
+        "title": title,
+        "fields": fields_nodes or {"nodes": []},
+        "items": {"nodes": all_items},
+    }
+
+
+def find_field_id(project_info: dict, field_name: str) -> str | None:
+    for f in project_info.get("fields", {}).get("nodes", []):
+        if f.get("name") == field_name:
+            return f.get("id")
+    return None
+
+
+def find_option_id(project_info: dict, field_name: str, option_name: str) -> str | None:
+    for f in project_info.get("fields", {}).get("nodes", []):
+        if f.get("name") != field_name:
+            continue
+        for opt in f.get("options", []) or []:
+            if opt.get("name") == option_name:
+                return opt.get("id")
+    return None
+
+
+def add_item(project_id: str, content_node_id: str, token: str) -> str | None:
+    query = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item { id }
+      }
+    }
+    """
+    resp = gh_graphql(query, token=token, variables={"projectId": project_id, "contentId": content_node_id})
+    try:
+        return resp["data"]["addProjectV2ItemById"]["item"]["id"]
+    except (KeyError, TypeError):
+        return None
+
+
+def set_date_field(project_id: str, item_id: str, field_id: str, date_str: str, token: str) -> None:
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { date: $date }
+      }) { projectV2Item { id } }
+    }
+    """
+    gh_graphql(query, token=token, variables={
+        "projectId": project_id,
+        "itemId": item_id,
+        "fieldId": field_id,
+        "date": date_str,
+    })
+
+
+def set_single_select_field(project_id: str, item_id: str, field_id: str, option_id: str, token: str) -> None:
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { singleSelectOptionId: $optionId }
+      }) { projectV2Item { id } }
+    }
+    """
+    gh_graphql(query, token=token, variables={
+        "projectId": project_id,
+        "itemId": item_id,
+        "fieldId": field_id,
+        "optionId": option_id,
+    })
+
+
+# ----------------------------------------------------------------------------
+# Classification helpers
+# ----------------------------------------------------------------------------
+
+def detect_type(item: dict) -> str:
+    return "PR" if item.get("__typename") == "PullRequest" else "Issue"
+
+
+def detect_org(labels: list[str]) -> str:
+    for lbl in labels:
+        if lbl.startswith("org:"):
+            candidate = lbl[len("org:"):]
+            if candidate in ("domain-tech-collection", "standardization-initiative", "jutaku-dev-team"):
+                return candidate
+    return "none"
+
+
+def detect_category(labels: list[str], title: str) -> str:
+    # Label 優先
+    for lbl in labels:
+        if lbl in CATEGORY_LABEL_MAP:
+            return CATEGORY_LABEL_MAP[lbl]
+    # Title prefix fallback
+    for pattern, cat in CATEGORY_TITLE_PATTERNS:
+        if pattern.match(title):
+            return cat
+    return "other"
+
+
+def jst_date_from_utc(utc_iso: str | None) -> str | None:
+    if not utc_iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(utc_iso.replace("Z", "+00:00"))
+        jst_dt = dt.astimezone(timezone(timedelta(hours=9)))
+        return jst_dt.date().isoformat()
+    except Exception:
+        return None
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="TodoInsights daily sync")
+    ap.add_argument("--mode", choices=["sync", "backfill", "dry-run"], default="sync")
+    ap.add_argument("--since", type=str, default="", help="backfill start date YYYY-MM-DD (default: 2026-03-21)")
+    ap.add_argument("--until", type=str, default="", help="backfill end date YYYY-MM-DD (default: today)")
+    ap.add_argument("--window-hours", type=int, default=24, help="sync mode rolling window (default: 24)")
+    args = ap.parse_args()
+
+    token = os.environ.get("PROJECTS_PAT", "")
+    if not token and args.mode != "dry-run":
+        print("::error::PROJECTS_PAT required (Classic PAT with project + read:org + read:discussion)", file=sys.stderr)
+        return 1
+
+    issue_token = os.environ.get("GITHUB_TOKEN") or token
+
+    # JST 時刻計算
+    try:
+        import zoneinfo
+        tz_jst = zoneinfo.ZoneInfo("Asia/Tokyo")
+    except Exception:
+        tz_jst = timezone(timedelta(hours=9))
+
+    now_jst = datetime.now(tz_jst)
+    now_utc = now_jst.astimezone(timezone.utc)
+
+    # Search query 構築
+    if args.mode == "backfill":
+        since = args.since or "2026-03-21"
+        if args.until:
+            search_query = f"repo:{REPO_FULL} is:closed closed:{since}..{args.until}"
+        else:
+            search_query = f"repo:{REPO_FULL} is:closed closed:>={since}"
+    else:
+        # sync / dry-run: rolling window
+        since_utc = now_utc - timedelta(hours=args.window_hours)
+        since_iso = since_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        now_iso = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        search_query = f"repo:{REPO_FULL} is:closed closed:{since_iso}..{now_iso}"
+
+    print(f"=== TodoInsights Sync ===")
+    print(f"Mode: {args.mode}")
+    print(f"JST now: {now_jst.isoformat()}")
+    print(f"Search query: {search_query}")
+    print()
+
+    # Step 1: Fetch closed items
+    print("Step 1: Fetch closed Issues/PRs from GitHub Search API")
+    closed_items = fetch_closed_items(search_query, token=issue_token)
+    print(f"  {len(closed_items)} items matched")
+    print()
+
+    if not closed_items:
+        print("No closed items in this window. Nothing to do.")
+        return 0
+
+    # Step 2: Fetch project state
+    print("Step 2: Fetch Project 4 (TodoInsights) state")
+    if args.mode == "dry-run" and not token:
+        print("  [DRY] skipping GraphQL fetch")
+        project_info = {"id": "DRY-RUN", "fields": {"nodes": []}, "items": {"nodes": []}}
+    else:
+        project_info = fetch_project_info(token)
+
+    project_id = project_info["id"]
+    existing_items = project_info.get("items", {}).get("nodes", [])
+    existing_urls: set[str] = set()
+    for item in existing_items:
+        url = (item.get("content") or {}).get("url")
+        if url:
+            existing_urls.add(url)
+    print(f"  existing: {len(existing_items)} items, {len(existing_urls)} unique URLs")
+    print()
+
+    # Step 3: Field lookup
+    closed_date_field_id = find_field_id(project_info, "Closed date")
+    type_field_id = find_field_id(project_info, "Type")
+    org_field_id = find_field_id(project_info, "Org")
+    category_field_id = find_field_id(project_info, "Category")
+
+    if args.mode != "dry-run":
+        missing_fields = [name for name, fid in [
+            ("Closed date", closed_date_field_id),
+            ("Type", type_field_id),
+            ("Org", org_field_id),
+            ("Category", category_field_id),
+        ] if fid is None]
+        if missing_fields:
+            print(f"::warning::Missing custom fields: {missing_fields}")
+            print(f"::warning::Run 'gh project field-create' to add them before sync")
+
+    # Step 4: Categorize and add
+    print("Step 4: Classify and add items")
+    added = 0
+    skipped = 0
+    failed = 0
+    by_date: dict[str, int] = {}
+    by_type: dict[str, int] = {}
+    by_org: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+
+    for item in closed_items:
+        url = item.get("url")
+        if not url:
+            continue
+
+        labels = [l["name"] for l in (item.get("labels") or {}).get("nodes", [])]
+        title = item.get("title", "")
+        node_id = item.get("id")
+        itype = detect_type(item)
+        org = detect_org(labels)
+        category = detect_category(labels, title)
+        closed_iso = item.get("closedAt") or ""
+        closed_date = jst_date_from_utc(closed_iso)
+
+        # 統計集計
+        if closed_date:
+            by_date[closed_date] = by_date.get(closed_date, 0) + 1
+        by_type[itype] = by_type.get(itype, 0) + 1
+        by_org[org] = by_org.get(org, 0) + 1
+        by_category[category] = by_category.get(category, 0) + 1
+
+        if url in existing_urls:
+            skipped += 1
+            continue
+
+        if args.mode == "dry-run":
+            print(f"  [DRY] +#{item.get('number')} {title[:50]}")
+            print(f"         type={itype} org={org} category={category} closed={closed_date}")
+            continue
+
+        if not node_id:
+            print(f"  WARN: no node id for {url}", file=sys.stderr)
+            failed += 1
+            continue
+
+        try:
+            new_item_id = add_item(project_id, node_id, token)
+            if not new_item_id:
+                failed += 1
+                continue
+            added += 1
+
+            # Set custom fields
+            if closed_date_field_id and closed_date:
+                try:
+                    set_date_field(project_id, new_item_id, closed_date_field_id, closed_date, token)
+                except Exception as e:
+                    print(f"    WARN Closed date: {e}", file=sys.stderr)
+
+            if type_field_id:
+                opt_id = find_option_id(project_info, "Type", itype)
+                if opt_id:
+                    try:
+                        set_single_select_field(project_id, new_item_id, type_field_id, opt_id, token)
+                    except Exception as e:
+                        print(f"    WARN Type: {e}", file=sys.stderr)
+
+            if org_field_id:
+                opt_id = find_option_id(project_info, "Org", org)
+                if opt_id:
+                    try:
+                        set_single_select_field(project_id, new_item_id, org_field_id, opt_id, token)
+                    except Exception as e:
+                        print(f"    WARN Org: {e}", file=sys.stderr)
+
+            if category_field_id:
+                opt_id = find_option_id(project_info, "Category", category)
+                if opt_id:
+                    try:
+                        set_single_select_field(project_id, new_item_id, category_field_id, opt_id, token)
+                    except Exception as e:
+                        print(f"    WARN Category: {e}", file=sys.stderr)
+
+            if added % 25 == 0:
+                print(f"  progress: {added} added...")
+
+        except Exception as e:
+            print(f"  FAILED #{item.get('number')}: {e}", file=sys.stderr)
+            failed += 1
+
+    # Summary
+    print()
+    print(f"=== Summary ===")
+    print(f"  Mode: {args.mode}")
+    print(f"  Fetched (matching search): {len(closed_items)}")
+    print(f"  Added: {added}")
+    print(f"  Skipped (already in project): {skipped}")
+    print(f"  Failed: {failed}")
+    print()
+    print(f"  By type: {dict(sorted(by_type.items()))}")
+    print(f"  By org: {dict(sorted(by_org.items()))}")
+    print(f"  By category: {dict(sorted(by_category.items()))}")
+    print(f"  By date (top 10):")
+    for d in sorted(by_date.keys(), reverse=True)[:10]:
+        print(f"    {d}: {by_date[d]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/generate-dashboard.sh
+++ b/.claude/hooks/generate-dashboard.sh
@@ -1571,6 +1571,14 @@ if Path("docs/handover/index.html").exists():
       <div class="org-label">全活動履歴・判断履歴・Tips →</div>
     </a>'''
 
+# TodoInsights ダッシュボードが存在すれば追加
+if Path("docs/insights/index.html").exists():
+    cards += '''
+    <a href="./insights/index.html" class="card" style="border:2px solid #4361ee;">
+      <div class="org-name">TodoInsights</div>
+      <div class="org-label">活動インサイト・完了グラフ →</div>
+    </a>'''
+
 html = f"""<!DOCTYPE html>
 <html lang="ja">
 <head>

--- a/.claude/hooks/generate-insights-html.py
+++ b/.claude/hooks/generate-insights-html.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""generate-insights-html.py — TodoInsights (Project 4) の HTML dashboard を生成する
+
+Reads:
+    Project v2 TodoInsights (number=4) の全 items + field values
+
+Writes:
+    docs/insights/index.html         — メイン dashboard
+    docs/index.html                   — トップページに TodoInsights カード追記
+
+Environment:
+    PROJECTS_PAT (required)           — Classic PAT with project scope
+
+Features:
+    - 累計 / 今週 / 今日 / 直近30日平均の サマリーカード
+    - 日別完了件数 棒グラフ (直近 30 日, Issue/PR stack)
+    - 週次トレンド 折れ線 (直近 12 週)
+    - カテゴリ分布 doughnut chart
+    - 組織分布 horizontal bar
+    - 累計完了 area line
+    - 最新クローズ 20 件 テーブル
+    - Dark / Light mode 自動切替
+    - Chart.js CDN (オフライン時はグレースフル劣化)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OWNER = "SAS-Sasao"
+PROJECT_NUMBER = 4  # TodoInsights
+REPO_URL_BASE = "https://github.com/SAS-Sasao/cc-sier-organization"
+
+
+# ----------------------------------------------------------------------------
+# gh / GraphQL helpers
+# ----------------------------------------------------------------------------
+
+def run_gh(args: list[str], token: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
+    return subprocess.run(
+        ["gh"] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def gh_graphql(query: str, token: str, variables: dict | None = None) -> dict:
+    cmd = ["api", "graphql", "-f", f"query={query}"]
+    if variables:
+        for k, v in variables.items():
+            if v is None:
+                continue
+            if isinstance(v, int):
+                cmd += ["-F", f"{k}={v}"]
+            else:
+                cmd += ["-f", f"{k}={v}"]
+    try:
+        result = run_gh(cmd, token=token)
+    except subprocess.CalledProcessError as e:
+        print(f"::error::gh graphql failed: {e.stderr}", file=sys.stderr)
+        raise
+    data = json.loads(result.stdout)
+    if data.get("errors"):
+        print(f"::warning::GraphQL errors: {data['errors']}", file=sys.stderr)
+    return data
+
+
+# ----------------------------------------------------------------------------
+# Fetch Project 4 items with field values
+# ----------------------------------------------------------------------------
+
+def fetch_all_items(token: str) -> tuple[list[dict], str]:
+    """Project 4 の items を全ページ取得してフラット dict のリストに変換する。
+
+    各 dict には以下のキーが入る:
+        url, number, title, state, type (Issue|PR), closed_date, org, category, labels
+    """
+    query = """
+    query($cursor: String) {
+      user(login: "%s") {
+        projectV2(number: %d) {
+          id
+          title
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  number url title state
+                  labels(first: 30) { nodes { name } }
+                }
+                ... on PullRequest {
+                  number url title state
+                  labels(first: 30) { nodes { name } }
+                }
+              }
+              fieldValues(first: 20) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldDateValue {
+                    field { ... on ProjectV2FieldCommon { name } }
+                    date
+                  }
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    field { ... on ProjectV2FieldCommon { name } }
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % (OWNER, PROJECT_NUMBER)
+
+    all_nodes: list[dict] = []
+    project_title = ""
+    cursor: str | None = None
+    page = 0
+    while True:
+        page += 1
+        resp = gh_graphql(query, token=token, variables={"cursor": cursor})
+        pv2 = resp["data"]["user"]["projectV2"]
+        if pv2 is None:
+            print("::error::Project 4 not found", file=sys.stderr)
+            break
+        if not project_title:
+            project_title = pv2.get("title", "TodoInsights")
+        items_conn = pv2.get("items", {}) or {}
+        nodes = items_conn.get("nodes") or []
+        all_nodes.extend(nodes)
+        page_info = items_conn.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+
+    print(f"  Fetched {len(all_nodes)} items from {project_title}", file=sys.stderr)
+
+    # フラット化
+    items: list[dict] = []
+    for node in all_nodes:
+        content = node.get("content") or {}
+        if not content:
+            continue
+        tname = content.get("__typename", "")
+        if tname not in ("Issue", "PullRequest"):
+            continue
+
+        # Field values の抽出
+        fv_nodes = (node.get("fieldValues") or {}).get("nodes") or []
+        fv_map: dict[str, str] = {}
+        for fv in fv_nodes:
+            if not fv:
+                continue
+            field_name = ((fv.get("field") or {}) or {}).get("name")
+            if not field_name:
+                continue
+            if fv.get("__typename") == "ProjectV2ItemFieldDateValue":
+                fv_map[field_name] = fv.get("date") or ""
+            elif fv.get("__typename") == "ProjectV2ItemFieldSingleSelectValue":
+                fv_map[field_name] = fv.get("name") or ""
+
+        labels = [l.get("name", "") for l in ((content.get("labels") or {}).get("nodes") or [])]
+
+        items.append({
+            "number": content.get("number"),
+            "url": content.get("url"),
+            "title": content.get("title", ""),
+            "state": content.get("state", ""),
+            "type": "PR" if tname == "PullRequest" else "Issue",
+            "closed_date": fv_map.get("Closed date") or "",
+            "org": fv_map.get("Org") or "none",
+            "category": fv_map.get("Category") or "other",
+            "labels": labels,
+        })
+
+    return items, project_title
+
+
+# ----------------------------------------------------------------------------
+# Aggregation
+# ----------------------------------------------------------------------------
+
+def compute_aggregates(items: list[dict], now_jst: date) -> dict:
+    """HTML 描画に使う集計結果を dict で返す。"""
+    # 有効 item のみ (Closed date セット済)
+    valid = [i for i in items if i.get("closed_date")]
+    total = len(valid)
+
+    # 日付範囲
+    all_dates = sorted({i["closed_date"] for i in valid})
+    first_date = all_dates[0] if all_dates else now_jst.isoformat()
+    last_date = all_dates[-1] if all_dates else now_jst.isoformat()
+
+    # Daily counts (全期間)
+    by_date: dict[str, int] = Counter(i["closed_date"] for i in valid)
+    # Daily by type (直近 30 日)
+    last30_start = now_jst - timedelta(days=29)
+    daily30_labels: list[str] = []
+    daily30_issue: list[int] = []
+    daily30_pr: list[int] = []
+    for i in range(30):
+        d = (last30_start + timedelta(days=i)).isoformat()
+        daily30_labels.append(d)
+        daily30_issue.append(sum(1 for x in valid if x["closed_date"] == d and x["type"] == "Issue"))
+        daily30_pr.append(sum(1 for x in valid if x["closed_date"] == d and x["type"] == "PR"))
+
+    # Weekly counts (直近 12 週)
+    # 週の起点は月曜 (ISO week start)
+    weekly_labels: list[str] = []
+    weekly_values: list[int] = []
+    # 今週の月曜を起点にする
+    today_weekday = now_jst.weekday()  # Mon=0
+    this_monday = now_jst - timedelta(days=today_weekday)
+    for wk in range(11, -1, -1):
+        week_start = this_monday - timedelta(days=wk * 7)
+        week_end = week_start + timedelta(days=7)
+        count = sum(
+            1 for x in valid
+            if week_start.isoformat() <= x["closed_date"] < week_end.isoformat()
+        )
+        weekly_labels.append(week_start.isoformat())
+        weekly_values.append(count)
+
+    # Category breakdown
+    by_category = Counter(i["category"] for i in valid)
+    # Org breakdown
+    by_org = Counter(i["org"] for i in valid)
+    # Type breakdown
+    by_type = Counter(i["type"] for i in valid)
+
+    # Cumulative (全期間)
+    cumulative_labels: list[str] = []
+    cumulative_values: list[int] = []
+    running = 0
+    if all_dates:
+        start = date.fromisoformat(all_dates[0])
+        end = now_jst
+        # 日付を連続生成
+        d = start
+        while d <= end:
+            running += by_date.get(d.isoformat(), 0)
+            cumulative_labels.append(d.isoformat())
+            cumulative_values.append(running)
+            d += timedelta(days=1)
+
+    # 週次 / 今日 / 今週 / 先週 の比較
+    today_iso = now_jst.isoformat()
+    today_count = by_date.get(today_iso, 0)
+
+    this_week_count = 0
+    last_week_count = 0
+    for x in valid:
+        try:
+            xd = date.fromisoformat(x["closed_date"])
+        except ValueError:
+            continue
+        if this_monday <= xd < this_monday + timedelta(days=7):
+            this_week_count += 1
+        elif this_monday - timedelta(days=7) <= xd < this_monday:
+            last_week_count += 1
+
+    # 直近 30 日平均
+    last30_total = sum(daily30_issue) + sum(daily30_pr)
+    avg_30d = round(last30_total / 30, 1)
+
+    # 前週比
+    if last_week_count > 0:
+        week_delta_pct = round((this_week_count - last_week_count) / last_week_count * 100, 1)
+    elif this_week_count > 0:
+        week_delta_pct = 100.0
+    else:
+        week_delta_pct = 0.0
+
+    # 最新クローズ 20 件
+    recent = sorted(valid, key=lambda i: i.get("closed_date", ""), reverse=True)[:20]
+
+    return {
+        "total": total,
+        "today": today_count,
+        "this_week": this_week_count,
+        "last_week": last_week_count,
+        "week_delta_pct": week_delta_pct,
+        "avg_30d": avg_30d,
+        "first_date": first_date,
+        "last_date": last_date,
+        "daily30": {
+            "labels": daily30_labels,
+            "issue": daily30_issue,
+            "pr": daily30_pr,
+        },
+        "weekly": {
+            "labels": weekly_labels,
+            "values": weekly_values,
+        },
+        "category": dict(by_category.most_common()),
+        "org": dict(by_org.most_common()),
+        "type": dict(by_type),
+        "cumulative": {
+            "labels": cumulative_labels,
+            "values": cumulative_values,
+        },
+        "recent": [
+            {
+                "number": r["number"],
+                "title": r["title"],
+                "url": r["url"],
+                "type": r["type"],
+                "org": r["org"],
+                "category": r["category"],
+                "closed_date": r["closed_date"],
+            }
+            for r in recent
+        ],
+    }
+
+
+# ----------------------------------------------------------------------------
+# HTML rendering
+# ----------------------------------------------------------------------------
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TodoInsights — 活動インサイト</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+:root {
+  --bg: #f8f9fa; --card-bg: #fff; --text: #212529; --muted: #6c757d;
+  --border: #dee2e6; --shadow: rgba(0,0,0,0.08);
+  --blue: #0d6efd; --yellow: #ffc107; --red: #dc3545; --green: #198754;
+  --purple: #6f42c1; --teal: #20c997; --orange: #fd7e14; --pink: #d63384;
+  --accent: #4361ee; --chart-grid: rgba(0,0,0,0.06);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a2e; --card-bg: #16213e; --text: #e0e0e0; --muted: #9e9e9e;
+    --border: #2a2a4a; --shadow: rgba(0,0,0,0.3);
+    --blue: #4dabf7; --yellow: #ffd43b; --red: #ff6b6b; --green: #51cf66;
+    --purple: #9775fa; --teal: #4ecdc4; --orange: #ff922b; --pink: #f783ac;
+    --accent: #748ffc; --chart-grid: rgba(255,255,255,0.08);
+  }
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Yu Gothic UI', sans-serif;
+  background: var(--bg); color: var(--text);
+  padding: 24px; max-width: 1400px; margin: 0 auto;
+  line-height: 1.5;
+}
+
+.nav {
+  display: flex; gap: 16px; margin-bottom: 16px;
+  font-size: 0.85rem;
+}
+.nav a {
+  color: var(--blue); text-decoration: none;
+  padding: 4px 0; border-bottom: 1px solid transparent;
+}
+.nav a:hover { border-bottom-color: var(--blue); }
+
+.hero {
+  margin-bottom: 28px;
+}
+h1 {
+  font-size: 1.8rem; margin-bottom: 4px;
+  background: linear-gradient(135deg, var(--accent), var(--teal));
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.subtitle { color: var(--muted); font-size: 0.9rem; }
+
+/* Summary cards */
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px; margin-bottom: 28px;
+}
+.summary-card {
+  background: var(--card-bg); border: 1px solid var(--border);
+  border-radius: 14px; padding: 20px;
+  box-shadow: 0 2px 12px var(--shadow);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.summary-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px var(--shadow);
+}
+.summary-label {
+  font-size: 0.75rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.8px;
+  margin-bottom: 6px;
+}
+.summary-value {
+  font-size: 2rem; font-weight: 700;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.summary-value.blue { color: var(--blue); }
+.summary-value.green { color: var(--green); }
+.summary-value.orange { color: var(--orange); }
+.summary-value.purple { color: var(--purple); }
+.summary-delta {
+  font-size: 0.8rem; font-weight: 600;
+  padding: 2px 8px; border-radius: 999px;
+}
+.summary-delta.up { background: rgba(25,135,84,0.12); color: var(--green); }
+.summary-delta.down { background: rgba(220,53,69,0.12); color: var(--red); }
+.summary-delta.flat { background: rgba(108,117,125,0.12); color: var(--muted); }
+
+/* Charts */
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 20px; margin-bottom: 28px;
+}
+.chart-card {
+  background: var(--card-bg); border: 1px solid var(--border);
+  border-radius: 14px; padding: 20px;
+  box-shadow: 0 2px 12px var(--shadow);
+}
+.chart-card.full { grid-column: 1 / -1; }
+.chart-card h2 {
+  font-size: 1rem; margin-bottom: 14px;
+  display: flex; align-items: center; gap: 8px;
+  color: var(--text);
+}
+.chart-card .accent-bar {
+  width: 4px; height: 18px; border-radius: 2px;
+  background: var(--accent);
+}
+.chart-container {
+  position: relative;
+  height: 280px;
+}
+.chart-card.full .chart-container { height: 320px; }
+
+/* Recent table */
+.recent-card {
+  background: var(--card-bg); border: 1px solid var(--border);
+  border-radius: 14px; padding: 20px; margin-bottom: 28px;
+  box-shadow: 0 2px 12px var(--shadow);
+}
+.recent-card h2 {
+  font-size: 1rem; margin-bottom: 14px;
+  display: flex; align-items: center; gap: 8px;
+}
+.table-wrap { overflow-x: auto; }
+.recent-table {
+  width: 100%; border-collapse: collapse; font-size: 0.85rem;
+}
+.recent-table th {
+  text-align: left; padding: 10px 12px;
+  background: var(--border); font-weight: 600;
+  position: sticky; top: 0;
+}
+.recent-table td {
+  padding: 10px 12px; border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.recent-table tr:hover td { background: rgba(67, 97, 238, 0.04); }
+.recent-table a { color: var(--blue); text-decoration: none; }
+.recent-table a:hover { text-decoration: underline; }
+
+.badge {
+  display: inline-block; font-size: 0.7rem; font-weight: 600;
+  padding: 2px 8px; border-radius: 999px;
+  text-transform: uppercase; letter-spacing: 0.4px;
+}
+.badge-issue { background: rgba(13,110,253,0.12); color: var(--blue); }
+.badge-pr { background: rgba(111,66,193,0.12); color: var(--purple); }
+.badge-wbs { background: rgba(25,135,84,0.12); color: var(--green); }
+.badge-digest { background: rgba(253,126,20,0.12); color: var(--orange); }
+.badge-automation { background: rgba(32,201,151,0.12); color: var(--teal); }
+.badge-feat { background: rgba(13,110,253,0.12); color: var(--blue); }
+.badge-fix { background: rgba(220,53,69,0.12); color: var(--red); }
+.badge-docs { background: rgba(255,193,7,0.18); color: #a06800; }
+.badge-chore { background: rgba(108,117,125,0.12); color: var(--muted); }
+.badge-other { background: rgba(108,117,125,0.08); color: var(--muted); }
+.badge-org { background: rgba(67,97,238,0.08); color: var(--accent); }
+
+.footer {
+  margin-top: 40px; text-align: center;
+  font-size: 0.78rem; color: var(--muted);
+}
+
+/* Responsive */
+@media (max-width: 720px) {
+  body { padding: 16px; }
+  h1 { font-size: 1.4rem; }
+  .summary-value { font-size: 1.6rem; }
+  .chart-grid { grid-template-columns: 1fr; }
+  .summary-grid { grid-template-columns: repeat(2, 1fr); }
+}
+</style>
+</head>
+<body>
+
+<div class="nav">
+  <a href="../">← トップに戻る</a>
+  <a href="https://github.com/users/SAS-Sasao/projects/4" target="_blank">Project 4 (TodoInsights) →</a>
+</div>
+
+<div class="hero">
+  <h1>TodoInsights</h1>
+  <p class="subtitle">cc-sier-organization の活動インサイト｜最終更新: __LAST_UPDATED__｜収集期間: __FIRST_DATE__ 〜 __LAST_DATE__</p>
+</div>
+
+<div class="summary-grid">
+  <div class="summary-card">
+    <div class="summary-label">累計クローズ</div>
+    <div class="summary-value blue">__TOTAL__</div>
+  </div>
+  <div class="summary-card">
+    <div class="summary-label">今週の完了</div>
+    <div class="summary-value green">
+      __THIS_WEEK__
+      <span class="summary-delta __DELTA_CLASS__">__DELTA_LABEL__</span>
+    </div>
+  </div>
+  <div class="summary-card">
+    <div class="summary-label">本日の完了</div>
+    <div class="summary-value orange">__TODAY__</div>
+  </div>
+  <div class="summary-card">
+    <div class="summary-label">直近30日平均/日</div>
+    <div class="summary-value purple">__AVG_30D__</div>
+  </div>
+</div>
+
+<div class="chart-grid">
+  <div class="chart-card full">
+    <h2><span class="accent-bar"></span>直近 30 日の完了件数 (Issue / PR)</h2>
+    <div class="chart-container"><canvas id="dailyChart"></canvas></div>
+  </div>
+
+  <div class="chart-card">
+    <h2><span class="accent-bar"></span>週次トレンド (直近 12 週)</h2>
+    <div class="chart-container"><canvas id="weeklyChart"></canvas></div>
+  </div>
+
+  <div class="chart-card">
+    <h2><span class="accent-bar"></span>累計完了</h2>
+    <div class="chart-container"><canvas id="cumulativeChart"></canvas></div>
+  </div>
+
+  <div class="chart-card">
+    <h2><span class="accent-bar"></span>カテゴリ分布</h2>
+    <div class="chart-container"><canvas id="categoryChart"></canvas></div>
+  </div>
+
+  <div class="chart-card">
+    <h2><span class="accent-bar"></span>組織分布</h2>
+    <div class="chart-container"><canvas id="orgChart"></canvas></div>
+  </div>
+</div>
+
+<div class="recent-card">
+  <h2><span class="accent-bar"></span>最新クローズ 20 件</h2>
+  <div class="table-wrap">
+    <table class="recent-table">
+      <thead>
+        <tr>
+          <th>クローズ日</th>
+          <th>Type</th>
+          <th>タイトル</th>
+          <th>組織</th>
+          <th>カテゴリ</th>
+        </tr>
+      </thead>
+      <tbody>
+__RECENT_ROWS__
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="footer">
+  Generated by <code>generate-insights-html.py</code> ｜ Data source: GitHub Projects v2 #4 TodoInsights
+</div>
+
+<script>
+const DATA = __DATA_JSON__;
+
+// Chart.js 共通設定
+const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const textColor = darkMode ? '#e0e0e0' : '#212529';
+const gridColor = darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+const mutedColor = darkMode ? '#9e9e9e' : '#6c757d';
+Chart.defaults.color = mutedColor;
+Chart.defaults.borderColor = gridColor;
+Chart.defaults.font.family = "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Yu Gothic UI', sans-serif";
+
+// Color palette
+const C = {
+  blue: darkMode ? '#4dabf7' : '#0d6efd',
+  green: darkMode ? '#51cf66' : '#198754',
+  red: darkMode ? '#ff6b6b' : '#dc3545',
+  yellow: darkMode ? '#ffd43b' : '#ffc107',
+  purple: darkMode ? '#9775fa' : '#6f42c1',
+  teal: darkMode ? '#4ecdc4' : '#20c997',
+  orange: darkMode ? '#ff922b' : '#fd7e14',
+  pink: darkMode ? '#f783ac' : '#d63384',
+  gray: mutedColor,
+};
+
+// 1. Daily chart (Issue + PR stack)
+new Chart(document.getElementById('dailyChart'), {
+  type: 'bar',
+  data: {
+    labels: DATA.daily30.labels.map(d => d.slice(5)),
+    datasets: [
+      {
+        label: 'Issue',
+        data: DATA.daily30.issue,
+        backgroundColor: C.blue,
+        borderRadius: 4,
+      },
+      {
+        label: 'PR',
+        data: DATA.daily30.pr,
+        backgroundColor: C.purple,
+        borderRadius: 4,
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    scales: {
+      x: { stacked: true, grid: { display: false } },
+      y: { stacked: true, beginAtZero: true, ticks: { precision: 0 }, grid: { color: gridColor } }
+    },
+    plugins: {
+      legend: { position: 'top', labels: { usePointStyle: true, boxWidth: 10 } },
+      tooltip: { mode: 'index', intersect: false }
+    }
+  }
+});
+
+// 2. Weekly trend (line)
+new Chart(document.getElementById('weeklyChart'), {
+  type: 'line',
+  data: {
+    labels: DATA.weekly.labels.map(d => d.slice(5)),
+    datasets: [{
+      label: '週次完了数',
+      data: DATA.weekly.values,
+      borderColor: C.teal,
+      backgroundColor: 'transparent',
+      tension: 0.35,
+      pointRadius: 4,
+      pointBackgroundColor: C.teal,
+      pointBorderColor: darkMode ? '#16213e' : '#fff',
+      pointBorderWidth: 2,
+      fill: false,
+    }]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { grid: { display: false } },
+      y: { beginAtZero: true, ticks: { precision: 0 }, grid: { color: gridColor } }
+    },
+    plugins: { legend: { display: false } }
+  }
+});
+
+// 3. Cumulative (area)
+new Chart(document.getElementById('cumulativeChart'), {
+  type: 'line',
+  data: {
+    labels: DATA.cumulative.labels.map(d => d.slice(5)),
+    datasets: [{
+      label: '累計',
+      data: DATA.cumulative.values,
+      borderColor: C.blue,
+      backgroundColor: darkMode ? 'rgba(77,171,247,0.15)' : 'rgba(13,110,253,0.12)',
+      tension: 0.2,
+      pointRadius: 0,
+      fill: true,
+    }]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { grid: { display: false }, ticks: { maxTicksLimit: 10 } },
+      y: { beginAtZero: true, grid: { color: gridColor } }
+    },
+    plugins: { legend: { display: false } }
+  }
+});
+
+// 4. Category (doughnut)
+const categoryColors = {
+  'wbs': C.green,
+  'digest': C.orange,
+  'automation': C.teal,
+  'feat': C.blue,
+  'fix': C.red,
+  'docs': C.yellow,
+  'chore': C.gray,
+  'other': C.pink,
+};
+const catLabels = Object.keys(DATA.category);
+const catValues = Object.values(DATA.category);
+const catBgs = catLabels.map(l => categoryColors[l] || C.gray);
+new Chart(document.getElementById('categoryChart'), {
+  type: 'doughnut',
+  data: {
+    labels: catLabels,
+    datasets: [{
+      data: catValues,
+      backgroundColor: catBgs,
+      borderColor: darkMode ? '#16213e' : '#fff',
+      borderWidth: 2,
+    }]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: 'right', labels: { usePointStyle: true, boxWidth: 10 } }
+    }
+  }
+});
+
+// 5. Org (horizontal bar)
+const orgLabels = Object.keys(DATA.org);
+const orgValues = Object.values(DATA.org);
+const orgColors = [C.blue, C.purple, C.teal, C.gray];
+new Chart(document.getElementById('orgChart'), {
+  type: 'bar',
+  data: {
+    labels: orgLabels,
+    datasets: [{
+      label: '件数',
+      data: orgValues,
+      backgroundColor: orgLabels.map((_, i) => orgColors[i % orgColors.length]),
+      borderRadius: 4,
+    }]
+  },
+  options: {
+    indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { beginAtZero: true, grid: { color: gridColor } },
+      y: { grid: { display: false } }
+    },
+    plugins: { legend: { display: false } }
+  }
+});
+</script>
+
+</body>
+</html>
+"""
+
+
+def render_html(items: list[dict], aggregates: dict, now_jst: datetime) -> str:
+    """HTML を組み立てる。"""
+    delta_pct = aggregates["week_delta_pct"]
+    if delta_pct > 0:
+        delta_class = "up"
+        delta_label = f"▲ {delta_pct}%"
+    elif delta_pct < 0:
+        delta_class = "down"
+        delta_label = f"▼ {abs(delta_pct)}%"
+    else:
+        delta_class = "flat"
+        delta_label = "→ 0%"
+
+    # Recent rows
+    recent_rows_html: list[str] = []
+    for r in aggregates["recent"]:
+        type_badge = f'<span class="badge badge-{r["type"].lower()}">{r["type"]}</span>'
+        cat_badge = f'<span class="badge badge-{r["category"]}">{r["category"]}</span>'
+        org_badge = f'<span class="badge badge-org">{r["org"]}</span>'
+        title_html = f'<a href="{r["url"]}" target="_blank" rel="noopener">#{r["number"]} {escape_html(r["title"])}</a>'
+        recent_rows_html.append(
+            f'        <tr>'
+            f'<td>{r["closed_date"]}</td>'
+            f'<td>{type_badge}</td>'
+            f'<td>{title_html}</td>'
+            f'<td>{org_badge}</td>'
+            f'<td>{cat_badge}</td>'
+            f'</tr>'
+        )
+
+    # Data JSON for charts
+    data_for_js = {
+        "daily30": aggregates["daily30"],
+        "weekly": aggregates["weekly"],
+        "cumulative": aggregates["cumulative"],
+        "category": aggregates["category"],
+        "org": aggregates["org"],
+        "type": aggregates["type"],
+    }
+    data_json = json.dumps(data_for_js, ensure_ascii=False)
+
+    html = HTML_TEMPLATE
+    html = html.replace("__LAST_UPDATED__", now_jst.strftime("%Y-%m-%d %H:%M JST"))
+    html = html.replace("__FIRST_DATE__", aggregates["first_date"])
+    html = html.replace("__LAST_DATE__", aggregates["last_date"])
+    html = html.replace("__TOTAL__", f"{aggregates['total']:,}")
+    html = html.replace("__THIS_WEEK__", str(aggregates["this_week"]))
+    html = html.replace("__TODAY__", str(aggregates["today"]))
+    html = html.replace("__AVG_30D__", str(aggregates["avg_30d"]))
+    html = html.replace("__DELTA_CLASS__", delta_class)
+    html = html.replace("__DELTA_LABEL__", delta_label)
+    html = html.replace("__RECENT_ROWS__", "\n".join(recent_rows_html))
+    html = html.replace("__DATA_JSON__", data_json)
+    return html
+
+
+def escape_html(s: str) -> str:
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# ----------------------------------------------------------------------------
+# Top page card update
+# ----------------------------------------------------------------------------
+
+def update_top_index(repo_root: Path) -> None:
+    """docs/index.html に TodoInsights カードを追加 (既存なら置換)。"""
+    index_path = repo_root / "docs" / "index.html"
+    if not index_path.exists():
+        print(f"  docs/index.html not found, skipping top page update", file=sys.stderr)
+        return
+
+    html = index_path.read_text(encoding="utf-8")
+
+    # 既存の insights カードを削除
+    html = re.sub(
+        r'\s*<a href="\./insights/[^"]*"[^>]*class="card"[^>]*>.*?</a>',
+        "",
+        html,
+        flags=re.DOTALL,
+    )
+
+    insights_card = '''
+    <a href="./insights/index.html" class="card" style="border:2px solid #4361ee;">
+      <div class="org-name">TodoInsights</div>
+      <div class="org-label">活動インサイト・完了グラフ →</div>
+    </a>'''
+
+    html = re.sub(
+        r'(</div>\s*<p class="updated")',
+        f"{insights_card}\n\\1",
+        html,
+        count=1,
+    )
+
+    index_path.write_text(html, encoding="utf-8")
+    print(f"  Updated: {index_path}", file=sys.stderr)
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+def main() -> int:
+    token = os.environ.get("PROJECTS_PAT", "")
+    if not token:
+        print("::error::PROJECTS_PAT required", file=sys.stderr)
+        return 1
+
+    try:
+        import zoneinfo
+        tz_jst = zoneinfo.ZoneInfo("Asia/Tokyo")
+    except Exception:
+        tz_jst = timezone(timedelta(hours=9))
+
+    now_jst = datetime.now(tz_jst)
+
+    print("=== Generate TodoInsights HTML ===")
+    print(f"JST: {now_jst.isoformat()}")
+    print()
+
+    # Step 1: Fetch project items
+    print("Step 1: Fetch Project 4 items")
+    items, project_title = fetch_all_items(token)
+    print(f"  {len(items)} items")
+    print()
+
+    # Step 2: Aggregate
+    print("Step 2: Compute aggregates")
+    aggregates = compute_aggregates(items, now_jst.date())
+    print(f"  total: {aggregates['total']}")
+    print(f"  today: {aggregates['today']}")
+    print(f"  this_week: {aggregates['this_week']} (last week: {aggregates['last_week']}, delta: {aggregates['week_delta_pct']}%)")
+    print(f"  avg_30d: {aggregates['avg_30d']}")
+    print(f"  category breakdown: {aggregates['category']}")
+    print(f"  org breakdown: {aggregates['org']}")
+    print()
+
+    # Step 3: Render HTML
+    print("Step 3: Render HTML")
+    html = render_html(items, aggregates, now_jst)
+
+    output_dir = REPO_ROOT / "docs" / "insights"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "index.html"
+    output_path.write_text(html, encoding="utf-8")
+    size_kb = round(output_path.stat().st_size / 1024, 1)
+    print(f"  Written: {output_path} ({size_kb} KB)")
+
+    # Step 4: Update top page
+    print("Step 4: Update docs/index.html")
+    update_top_index(REPO_ROOT)
+    print()
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/daily-insights-sync.yml
+++ b/.github/workflows/daily-insights-sync.yml
@@ -1,0 +1,251 @@
+name: Daily Insights Sync (23:50 JST)
+
+# 毎晩 23:50 JST に実行し、過去 24h にクローズされた Issues/PRs を
+# TodoInsights (Project 4) に同期 + HTML dashboard を再生成する。
+#
+# モード (workflow_dispatch input):
+#   sync      (default)  — 過去 24h の closed items を追加
+#   backfill              — --since 以降の全 closed items を一括インポート
+#   dry-run               — 実変更なし、計画のみ出力
+#   html-only             — Project への同期スキップ、HTML のみ再生成
+#
+# 認証:
+#   PROJECTS_PAT — Classic PAT (project + read:org + read:discussion)
+#   GITHUB_TOKEN — auto (Issue 読み取り、PR 作成)
+
+on:
+  schedule:
+    # 23:50 JST = 14:50 UTC
+    - cron: "50 14 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "実行モード"
+        type: choice
+        default: "sync"
+        options:
+          - "sync"
+          - "backfill"
+          - "dry-run"
+          - "html-only"
+      since:
+        description: "backfill 開始日 YYYY-MM-DD (backfill モード時のみ)"
+        required: false
+        type: string
+        default: "2026-03-21"
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: daily-insights-sync
+  cancel-in-progress: false
+
+env:
+  TRACKING_ISSUE_LABEL: daily-insights-sync-tracker
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pre-flight auth check
+        run: |
+          if [ -z "${PROJECTS_PAT:-}" ]; then
+            echo "::error::PROJECTS_PAT required"
+            exit 1
+          fi
+          echo "::notice::Auth OK"
+
+      - name: Determine date
+        id: date
+        run: |
+          DATE_JST=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          DOW_JST=$(TZ=Asia/Tokyo date +%u)
+          case $DOW_JST in
+            1) DOW_JP=月 ;; 2) DOW_JP=火 ;; 3) DOW_JP=水 ;;
+            4) DOW_JP=木 ;; 5) DOW_JP=金 ;; 6) DOW_JP=土 ;; 7) DOW_JP=日 ;;
+          esac
+          {
+            echo "date_jst=$DATE_JST"
+            echo "dow_jp=$DOW_JP"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::${DATE_JST} (${DOW_JP})"
+
+      - name: Detect mode
+        id: mode
+        run: |
+          MODE="${{ github.event.inputs.mode || 'sync' }}"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "::notice::mode=$MODE"
+
+      # ---------------------------------------------------------------
+      # Step A: Sync (project に items 追加)
+      # ---------------------------------------------------------------
+      - name: Run daily insights sync
+        id: sync
+        if: steps.mode.outputs.mode != 'html-only'
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MODE="${{ steps.mode.outputs.mode }}"
+          SINCE="${{ github.event.inputs.since || '2026-03-21' }}"
+
+          ARGS=(--mode "$MODE")
+          if [ "$MODE" = "backfill" ]; then
+            ARGS+=(--since "$SINCE")
+          fi
+
+          python3 .claude/hooks/daily-insights-sync.py "${ARGS[@]}" \
+            > /tmp/insights-sync.log 2>&1 &
+          PY_PID=$!
+          tail -f /tmp/insights-sync.log --pid=$PY_PID 2>/dev/null &
+          TAIL_PID=$!
+          wait $PY_PID
+          PY_EXIT=$?
+          kill $TAIL_PID 2>/dev/null || true
+          cat /tmp/insights-sync.log
+
+          if [ $PY_EXIT -ne 0 ]; then
+            echo "::error::daily-insights-sync.py exited $PY_EXIT"
+            exit $PY_EXIT
+          fi
+
+          ADDED=$(grep -oP "Added: \K\d+" /tmp/insights-sync.log | tail -1 || echo "0")
+          SKIPPED=$(grep -oP "Skipped \(already in project\): \K\d+" /tmp/insights-sync.log | tail -1 || echo "0")
+          FETCHED=$(grep -oP "Fetched \(matching search\): \K\d+" /tmp/insights-sync.log | tail -1 || echo "0")
+
+          {
+            echo "added=$ADDED"
+            echo "skipped=$SKIPPED"
+            echo "fetched=$FETCHED"
+          } >> "$GITHUB_OUTPUT"
+
+      # ---------------------------------------------------------------
+      # Step B: HTML dashboard 再生成
+      # ---------------------------------------------------------------
+      - name: Generate HTML dashboard
+        id: html
+        if: steps.mode.outputs.mode != 'dry-run'
+        env:
+          PROJECTS_PAT: ${{ secrets.PROJECTS_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .claude/hooks/generate-insights-html.py 2>&1 | tee /tmp/insights-html.log
+
+          if [ -f docs/insights/index.html ]; then
+            SIZE=$(wc -c < docs/insights/index.html)
+            echo "html_size=$SIZE" >> "$GITHUB_OUTPUT"
+            echo "::notice::HTML generated: docs/insights/index.html ($SIZE bytes)"
+          else
+            echo "::warning::HTML file not created"
+            echo "html_size=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------
+      # Step C: HTML 変更を main に直 commit
+      # ---------------------------------------------------------------
+      - name: Commit HTML to main
+        if: steps.mode.outputs.mode != 'dry-run'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE_JST: ${{ steps.date.outputs.date_jst }}
+        run: |
+          git config user.email "daily-insights-sync-bot@users.noreply.github.com"
+          git config user.name "Daily Insights Sync Bot"
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add docs/insights/ docs/index.html 2>/dev/null || true
+
+          if git diff --cached --quiet; then
+            echo "::notice::HTML 変更なし"
+          else
+            git commit -m "chore: TodoInsights HTML 更新 [daily-insights-sync] (${DATE_JST})"
+            git push origin main
+            echo "::notice::HTML committed and pushed"
+          fi
+
+      # ---------------------------------------------------------------
+      # Step D: tracking issue 更新
+      # ---------------------------------------------------------------
+      - name: Update tracking issue
+        if: always() && !cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE_JST: ${{ steps.date.outputs.date_jst }}
+          DOW_JP: ${{ steps.date.outputs.dow_jp }}
+          MODE: ${{ steps.mode.outputs.mode }}
+          JOB_STATUS: ${{ job.status }}
+          ADDED: ${{ steps.sync.outputs.added }}
+          SKIPPED: ${{ steps.sync.outputs.skipped }}
+          FETCHED: ${{ steps.sync.outputs.fetched }}
+          HTML_SIZE: ${{ steps.html.outputs.html_size }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create "${TRACKING_ISSUE_LABEL}" --color "4361ee" \
+            --description "daily-insights-sync workflow 継続トラッキング" 2>/dev/null || true
+
+          ISSUE_NUMBER=$(gh issue list --label "${TRACKING_ISSUE_LABEL}" --state open \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_URL=$(gh issue create \
+              --title "daily-insights-sync: 継続トラッキング (23:50 JST)" \
+              --label "${TRACKING_ISSUE_LABEL}" \
+              --body "この Issue は \`daily-insights-sync.yml\` workflow の実行履歴を記録します。
+
+          毎晩 23:50 JST に以下を実行:
+          1. 過去 24h にクローズされた Issues/PRs を GitHub Search API で取得
+          2. TodoInsights (Project 4) に追加 + Closed date/Type/Org/Category 設定
+          3. HTML dashboard (\`docs/insights/index.html\`) を Chart.js で再生成
+          4. main 直コミット → GitHub Pages に即反映
+
+          Dashboard: https://sas-sasao.github.io/cc-sier-organization/insights/
+          Project: https://github.com/users/SAS-Sasao/projects/4")
+            ISSUE_NUMBER="${ISSUE_URL##*/}"
+          fi
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            STATUS_ICON="✅"
+          else
+            STATUS_ICON="❌"
+          fi
+
+          HTML_KB="—"
+          if [ -n "${HTML_SIZE:-}" ] && [ "$HTML_SIZE" != "0" ]; then
+            HTML_KB=$(awk "BEGIN {printf \"%.1f KB\", $HTML_SIZE / 1024}")
+          fi
+
+          COMMENT=$(cat <<EOF
+          ${STATUS_ICON} **${DATE_JST} (${DOW_JP})** — mode: \`${MODE}\`
+
+          | 項目 | 値 |
+          |---|---|
+          | job status | \`${JOB_STATUS}\` |
+          | 検索ヒット | ${FETCHED:-n/a} 件 |
+          | 新規追加 | ${ADDED:-n/a} 件 |
+          | 既存 skip | ${SKIPPED:-n/a} 件 |
+          | HTML サイズ | ${HTML_KB} |
+          | workflow run | ${RUN_URL} |
+
+          **Dashboard**: https://sas-sasao.github.io/cc-sier-organization/insights/
+          **Project**: https://github.com/users/SAS-Sasao/projects/4
+          EOF
+          )
+
+          gh issue comment "$ISSUE_NUMBER" --body "$COMMENT"
+          echo "::notice::tracking issue #$ISSUE_NUMBER updated"


### PR DESCRIPTION
## 概要

毎晩 **23:50 JST** に cc-sier-organization でクローズされた Issues/PRs を収集し、
**Project 4 (TodoInsights)** に同期 + **リッチな HTML dashboard** を自動生成する新 workflow。

## 設計の選定理由

### 案検討（ultrathink）
Project v2 built-in Insights は機能限定（カラムで group by するだけ）なので、
「個別 item 蓄積 (Project 4)」 + 「Chart.js リッチ dashboard (HTML)」の **二段構え** で実装。

- **Layer 1 (生データ)**: Project 4 に個別 item 蓄積 → 将来の built-in Insights チャート対応
- **Layer 2 (集計)**: Python で日次/週次/カテゴリ別 aggregation
- **Layer 3 (可視化)**: Chart.js v4 で 5 チャート + サマリーカード + 最新 20 件テーブル

## 新規ファイル 3 つ

### \`.claude/hooks/daily-insights-sync.py\` (568 行)
- GitHub Search API で cc-sier-organization の closed Issues/PRs を取得（pagination）
- Project 4 既存 items と突合 → 新規のみ \`addProjectV2ItemById\` で追加
- カスタムフィールド設定: Closed date (DATE) / Type / Org / Category
- **Category 判定**: label 優先 (\`todo:wbs\`→wbs, \`type:daily-digest\`→digest, etc.) + title prefix fallback (\`feat:\`/\`fix:\`/\`docs:\`/\`chore:\`)
- **モード**: sync (rolling 24h) / backfill (\`--since\` 指定日以降) / dry-run

### \`.claude/hooks/generate-insights-html.py\` (944 行)
- Project 4 の全 items を GraphQL で取得 (field values 含む)
- 集計: daily30 / weekly12 / category / org / cumulative
- **Chart.js で 5 チャート描画**:
  1. 直近 30 日 日別完了 (Issue/PR stacked bar, \`dailyChart\`)
  2. 週次トレンド 折れ線 (直近 12 週, \`weeklyChart\`)
  3. カテゴリ分布 doughnut (\`categoryChart\`)
  4. 組織分布 horizontal bar (\`orgChart\`)
  5. 累計完了 area line (\`cumulativeChart\`)
- **サマリーカード 4 枚**: 累計 / 今週 (前週比%) / 今日 / 30日平均
- **最新クローズ 20 件テーブル** (type/org/category バッジ付き)
- **Dark/Light mode 自動切替** (prefers-color-scheme)
- **レスポンシブ grid layout**
- \`docs/index.html\` に TodoInsights カード追加 (\`./insights/\` regex で他カードと分離)

### \`.github/workflows/daily-insights-sync.yml\` (251 行)
- cron: \`50 14 * * *\` (23:50 JST)
- 4 モード: \`sync\` (default cron) / \`backfill\` / \`dry-run\` / \`html-only\`
- Step A: Python sync
- Step B: HTML dashboard 生成
- Step C: \`docs/insights/\` + \`docs/index.html\` を main 直コミット
- Step D: tracking issue コメント投稿

## 既存ロジックとの衝突回避

**docs/index.html を更新する 3 スクリプトを全て調査**:

| スクリプト | 動作 | TodoInsights 影響 |
|---|---|---|
| \`generate-insights-html.py\` (新規) | \`./insights/\` href のみ regex 削除 + 挿入 | ✅ 自己更新のみ |
| \`generate-daily-digest-html.sh\` | \`./daily-digest/\` href のみ regex 削除 + 挿入 | ✅ 触らない |
| \`generate-dashboard.sh\` | **docs/index.html 完全再生成** | ⚠️ TodoInsights カードが消える危険 → **このPRで修正** |

\`generate-dashboard.sh\` に \`if Path("docs/insights/index.html").exists()\` 分岐を追加し、
他の動的カード (daily-digest/diagrams/drawio/handover) と同じパターンで TodoInsights
カードも生成するようにした。

## Project 4 設定 (事前作成済)

- Name: \`TodoInsights\`
- Number: 4
- Node ID: \`PVT_kwHODAtE_84BUVPV\`
- Custom fields:
  - \`Closed date\` (DATE)
  - \`Type\` (SINGLE_SELECT: Issue, PR)
  - \`Org\` (SINGLE_SELECT: domain-tech-collection, standardization-initiative, jutaku-dev-team, none)
  - \`Category\` (SINGLE_SELECT: wbs, digest, automation, feat, fix, docs, chore, other)

## マージ後の計画

1. 初回 backfill (\`workflow_dispatch --mode=backfill --since=2026-03-21\`)
2. 明晩 23:50 JST から cron 自動発火
3. Dashboard: https://sas-sasao.github.io/cc-sier-organization/insights/
4. Project: https://github.com/users/SAS-Sasao/projects/4

## 既知の制約

- Search API 1000 件上限 → backfill で超える場合は月単位分割が将来必要
- Project v2 item limit ~2000 → 半年以上は問題なし
- 23:50 JST cron は 10 分ブラインドあり → rolling 24h window で翌日カバー

🤖 Generated with ultrathink planning