### PR TITLE
chore: aws-diagram-mcp-server のバージョンを 1.0.23 に固定

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "awslabs.aws-diagram-mcp-server": {
       "command": "uvx",
-      "args": ["awslabs.aws-diagram-mcp-server"],
+      "args": ["awslabs.aws-diagram-mcp-server==1.0.23"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }


### PR DESCRIPTION
## 変更サマリー

`.mcp.json` の `awslabs.aws-diagram-mcp-server` の args を `awslabs.aws-diagram-mcp-server` → `awslabs.aws-diagram-mcp-server==1.0.23` にバージョン固定。

uvx での起動時に latest を引かないようピン留めし、構成図生成の再現性を担保する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)