### PR TITLE
feat: AWS構成図v2(drawio) EDI受発注 オンプレ→AWS移行 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260613-201116-diagram-v2-edi-onprem-to-aws-migration.md
+++ b/.companies/domain-tech-collection/.task-log/20260613-201116-diagram-v2-edi-onprem-to-aws-migration.md
@@ -7,8 +7,8 @@ mode: "subagent"
 started: "2026-06-13T20:11:16"
 completed: "2026-06-14T07:25:20"
 request: "EDI受発注システムをオンプレミス環境からAWSへ移行する際の構成図を作成して（/company-diagram-v2 初の本番実行）"
-issue_number: null
-pr_number: null
+issue_number: 576
+pr_number: 575
 subagents: [cloud-engineer, general-purpose-reviewer]
 l0_gate: pass
 l0_retries: 0

--- a/.companies/domain-tech-collection/.task-log/20260613-201116-diagram-v2-edi-onprem-to-aws-migration.md
+++ b/.companies/domain-tech-collection/.task-log/20260613-201116-diagram-v2-edi-onprem-to-aws-migration.md
@@ -1,0 +1,61 @@
+---
+task_id: "20260613-201116-diagram-v2-edi-onprem-to-aws-migration"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "subagent"
+started: "2026-06-13T20:11:16"
+completed: "2026-06-14T07:25:20"
+request: "EDI受発注システムをオンプレミス環境からAWSへ移行する際の構成図を作成して（/company-diagram-v2 初の本番実行）"
+issue_number: null
+pr_number: null
+subagents: [cloud-engineer, general-purpose-reviewer]
+l0_gate: pass
+l0_retries: 0
+l1_gate: pass
+l1_retries: 0
+l2_composite: 1.00
+l2_retries: 0
+l2_scores:
+  s1_structure: 1.00
+  s2_iac: 1.00
+  s3_xml_html_consistency: 1.00
+  s4_legend: 1.00
+  s5_index_update: 1.00
+  s6_drawio_quality: 1.00
+---
+
+## 実行計画
+- **実行モード**: subagent（Phase2-4 生成+L0 を cloud-engineer に委譲、Phase6 L2 を fresh general-purpose に委譲）
+- **Skill**: /company-diagram-v2（draw.io XML 方式・初の本番実行）
+- **図名**: edi-onprem-to-aws-migration
+- **想定構成**: 取引先→(AS2/SFTP)→Transfer Family→S3→B2B Data Interchange(EDI変換)→Lambda/Step Functions→Aurora。オンプレ既存系は Direct Connect + Transit Gateway でハイブリッド接続（段階移行）。CloudWatch/SNS 監視、IAM/KMS/Secrets Manager。
+- **参照**: company-diagram-v2/references/drawio/*, aws-cost-estimation.md, review-prompt.md
+
+## エージェント作業ログ
+### [2026-06-13 20:11:16] secretary
+受付: /company-diagram-v2 で EDI受発注 オンプレ→AWS 移行構成図。Phase0(前提自動設定)→Phase1(branch/task-log)完了。Phase2-4 を cloud-engineer に委譲。
+
+### [2026-06-13 20:24-20:28] cloud-engineer
+完了(Phase2-3): edi-onprem-to-aws-migration.{drawio,html,yaml,-iac.html} 生成 + index.html カード追記。Transfer Family/B2B Data Interchange/EventBridge/SQS/Lambda/Step Functions/Aurora + Direct Connect/VPN/Transit Gateway ハイブリッド（ストラングラー型）。※ セッション切断で最終報告ロスト。
+
+### [2026-06-14 07:20] secretary（セッション復帰・Phase4-5 再検証）
+L0① validate_drawio.py exit0/PASSED（無効シェイプなし）、L0② review-drawio.js exit0/貫通0。L1: 7セクション順序OK・コスト表(Dev/Prod/合計/円)・learning-points 5・index カード追記(PNG無しvariant)・件数JS再計算。L0/L1 全PASS（retry 0）。
+
+### [2026-06-14 07:24] general-purpose-reviewer（Phase6 L2）
+L2独立採点: composite 1.00 / verdict pass / critical_triggered false（s1-s6 全1.00）。EDI移行アーキテクチャの技術的妥当性も確認。
+
+## judge
+
+```yaml
+completeness: 1.00
+accuracy: 1.00
+clarity: 1.00
+total: 1.00
+failure_reason: ""
+judge_comment: "/company-diagram-v2 l2_scores から自動マッピング: completeness=avg(s1_structure,s5_index_update), accuracy=avg(s2_iac,s3_xml_html_consistency), clarity=avg(s4_legend,s6_drawio_quality)"
+judged_at: "2026-06-14T07:25:20+09:00"
+```
+
+## reward
+（post-merge hook が自動追記）

--- a/docs/diagrams/edi-onprem-to-aws-migration-iac.html
+++ b/docs/diagrams/edi-onprem-to-aws-migration-iac.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EDI受発注 オンプレ→AWS移行 - IaC Source Code</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08); --muted:#6c757d; --shadow:rgba(0,0,0,.06);
+        --code-bg:#1e1e2e; --code-text:#cdd6f4; --line-num:#6c7086; --kw:#cba6f7; --str:#a6e3a1; --comment:#6c7086; --key:#89b4fa; --val:#fab387; --bool:#f38ba8; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08); --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1200px; margin:0 auto; }
+.top-bar { display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; margin-bottom:20px; gap:12px; }
+.back-btn { color:var(--blue); text-decoration:none; font-size:.88rem; }
+.back-btn:hover { text-decoration:underline; }
+.dl-btn { display:inline-block; padding:8px 16px; background:var(--blue); color:#fff; border-radius:8px; text-decoration:none; font-size:.84rem; font-weight:500; transition:opacity .2s; }
+.dl-btn:hover { opacity:.85; }
+.copy-btn { display:inline-flex; align-items:center; gap:6px; padding:6px 14px; background:rgba(255,255,255,.08); color:var(--code-text); border:1px solid rgba(255,255,255,.15); border-radius:6px; font-size:.78rem; font-family:inherit; cursor:pointer; transition:all .2s; }
+.copy-btn:hover { background:rgba(255,255,255,.15); }
+.copy-btn.copied { background:#16a34a; color:#fff; border-color:#16a34a; }
+.copy-btn svg { width:14px; height:14px; fill:currentColor; }
+h1 { font-size:1.3rem; margin-bottom:8px; }
+.meta { color:var(--muted); font-size:.85rem; margin-bottom:20px; display:flex; flex-wrap:wrap; gap:16px; align-items:center; }
+.badge { display:inline-block; padding:3px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.badge-pass { background:#d1fae5; color:#065f46; }
+.badge-fail { background:#fee2e2; color:#991b1b; }
+@media (prefers-color-scheme: dark) {
+  .badge-pass { background:#064e3b; color:#6ee7b7; }
+  .badge-fail { background:#7f1d1d; color:#fca5a5; }
+}
+.code-container { background:var(--code-bg); border-radius:12px; overflow:hidden; box-shadow:0 4px 16px var(--shadow); margin-bottom:24px; }
+.code-header { background:rgba(255,255,255,.05); padding:12px 20px; display:flex; justify-content:space-between; align-items:center; border-bottom:1px solid rgba(255,255,255,.08); }
+.code-header .filename { color:var(--code-text); font-size:.85rem; font-family:'SF Mono',Consolas,monospace; }
+.code-header .lines { color:var(--line-num); font-size:.78rem; }
+.code-scroll { overflow-x:auto; padding:16px 0; }
+.code-table { border-collapse:collapse; width:100%; }
+.code-table td { padding:0; vertical-align:top; font-family:'SF Mono',Consolas,'Courier New',monospace; font-size:.82rem; line-height:1.65; }
+.code-table .ln { width:1%; white-space:nowrap; padding:0 16px 0 20px; color:var(--line-num); text-align:right; user-select:none; border-right:1px solid rgba(255,255,255,.06); }
+.code-table .code { padding:0 20px; color:var(--code-text); white-space:pre; }
+.hl-comment { color:var(--comment); font-style:italic; }
+.hl-key { color:var(--key); }
+.hl-str { color:var(--str); }
+.hl-kw { color:var(--kw); }
+.hl-bool { color:var(--bool); }
+.hl-ref { color:#f9e2af; }
+.info { background:var(--bg2); border:1px solid var(--border); border-radius:12px; padding:20px; box-shadow:0 2px 8px var(--shadow); }
+.info h2 { font-size:1rem; margin-bottom:8px; }
+.info p { font-size:.88rem; color:var(--muted); line-height:1.6; }
+.updated { margin-top:24px; font-size:.78rem; color:var(--muted); }
+</style>
+</head>
+<body>
+<div class="top-bar">
+  <a href="./edi-onprem-to-aws-migration.html" class="back-btn">&larr; 構成図に戻る</a>
+  <div><a href="./edi-onprem-to-aws-migration.yaml" class="dl-btn" download>YAMLをダウンロード</a></div>
+</div>
+<h1>EDI受発注 オンプレ→AWS移行 - CloudFormation Template</h1>
+<div class="meta">
+  <span>生成日: 2026-06-13</span>
+  <span class="badge badge-pass">検証: Pass</span>
+  <span>437 行</span>
+</div>
+<div class="code-container">
+  <div class="code-header">
+    <span class="filename">edi-onprem-to-aws-migration.yaml</span>
+    <div style="display:flex;align-items:center;gap:12px">
+      <span class="lines">437 lines</span>
+      <button class="copy-btn" onclick="copyYaml(this)">
+        <svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+        <span>Copy</span>
+      </button>
+    </div>
+  </div>
+  <div class="code-scroll"><table class="code-table"><tbody id="code-body"></tbody></table></div>
+</div>
+<div class="info">
+  <h2>CloudFormation テンプレートについて</h2>
+  <p>このテンプレートは構成図のアーキテクチャを CloudFormation で実装した参照コードです。
+  サンプル値（<code># TODO</code> コメント付き）は実運用時に変更してください。
+  暗号化・最小権限・パブリックアクセスブロックはデフォルトで有効化されています。</p>
+</div>
+<p class="updated">Generated by /company-diagram-v2 (LLM 直接生成 CFn / cfn-lint 検証)</p>
+<script>
+const raw = "AWSTemplateFormatVersion: \"2010-09-09\"\nDescription: >\n  EDI \u53d7\u767a\u6ce8\u30b7\u30b9\u30c6\u30e0 \u30aa\u30f3\u30d7\u30ec\u30df\u30b9 \u2192 AWS \u79fb\u884c\u69cb\u6210\u3002\n  Transfer Family (AS2/SFTP) \u3067\u53d6\u5f15\u5148\u304b\u3089 EDI \u3092\u53d7\u4fe1\u3057\u3001S3 \u306b landing\u3002\n  B2B Data Interchange \u3067 X12/EDIFACT \u3092 JSON \u3078\u5909\u63db\u3057\u3001EventBridge \u7d4c\u7531\u3067\n  Step Functions / Lambda / SQS \u306b\u3088\u308b\u53d7\u767a\u6ce8\u51e6\u7406\u30ef\u30fc\u30af\u30d5\u30ed\u30fc\u3092\u99c6\u52d5\u3001\n  Aurora (Multi-AZ) \u3068 DynamoDB \u306b\u66f8\u304d\u8fbc\u3080\u3002Direct Connect / Site-to-Site VPN +\n  Transit Gateway \u306b\u3088\u308a\u30aa\u30f3\u30d7\u30ec\u306e\u30ec\u30ac\u30b7\u30fc\u53d7\u767a\u6ce8\u30b7\u30b9\u30c6\u30e0\u3068\u79fb\u884c\u671f\u306b\u4e26\u884c\u7a3c\u50cd\u3059\u308b\u3002\n  \u5b9f\u5024\u306f # TODO \u30b3\u30e1\u30f3\u30c8\u3067\u660e\u793a\uff08\u672c\u30c6\u30f3\u30d7\u30ec\u30fc\u30c8\u306f\u69cb\u6210\u56f3\u3068\u6574\u5408\u3057\u305f\u9aa8\u5b50\uff09\u3002\n\nParameters:\n  EnvName:\n    Type: String\n    Default: dev\n    AllowedValues: [dev, prod]\n    Description: \u74b0\u5883\u540d\uff08dev / prod\uff09\u3002Aurora \u306e\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u6570\u30fb\u5bb9\u91cf\u306e\u51fa\u3057\u5206\u3051\u306b\u4f7f\u7528\u3002\n  VpcCidr:\n    Type: String\n    Default: 10.0.0.0/16 # TODO: \u5b9f CIDR \u306b\u5408\u308f\u305b\u308b\n  OnPremCidr:\n    Type: String\n    Default: 192.168.0.0/16 # TODO: \u30aa\u30f3\u30d7\u30ec DC \u306e CIDR\n  CustomerGatewayIp:\n    Type: String\n    Default: 203.0.113.10 # TODO: \u30aa\u30f3\u30d7\u30ec\u5074 VPN \u7d42\u7aef\u306e\u30b0\u30ed\u30fc\u30d0\u30eb IP\n\nMappings:\n  EnvMap:\n    dev:\n      AuroraInstanceClass: db.serverless\n      AuroraMinAcu: 0.5\n      AuroraMaxAcu: 2\n    prod:\n      AuroraInstanceClass: db.serverless\n      AuroraMinAcu: 2\n      AuroraMaxAcu: 8\n\nResources:\n  # ===== \u30cd\u30c3\u30c8\u30ef\u30fc\u30af\uff08VPC / Multi-AZ\uff09 =====\n  Vpc:\n    Type: AWS::EC2::VPC\n    Properties:\n      CidrBlock: !Ref VpcCidr\n      EnableDnsSupport: true\n      EnableDnsHostnames: true\n      Tags:\n        - Key: Name\n          Value: !Sub \"edi-${EnvName}-vpc\"\n\n  PrivateSubnetA:\n    Type: AWS::EC2::Subnet\n    Properties:\n      VpcId: !Ref Vpc\n      CidrBlock: 10.0.1.0/24 # TODO\n      AvailabilityZone: !Select [0, !GetAZs \"\"]\n\n  PrivateSubnetB:\n    Type: AWS::EC2::Subnet\n    Properties:\n      VpcId: !Ref Vpc\n      CidrBlock: 10.0.2.0/24 # TODO\n      AvailabilityZone: !Select [1, !GetAZs \"\"]\n\n  # ===== \u30cf\u30a4\u30d6\u30ea\u30c3\u30c9\u63a5\u7d9a\uff08Transit Gateway + Site-to-Site VPN\uff09 =====\n  # Direct Connect \u672c\u4f53\uff08DX Gateway / VIF\uff09\u306f\u30a2\u30ab\u30a6\u30f3\u30c8\u6a2a\u65ad\u30fb\u7269\u7406\u56de\u7dda\u624b\u914d\u306e\u305f\u3081\n  # \u5225\u30b9\u30bf\u30c3\u30af\u7ba1\u7406\u3092\u60f3\u5b9a\u3002\u3053\u3053\u3067\u306f TGW \u3068 VPN \u306b\u3088\u308b\u63a5\u7d9a\u5b9a\u7fa9\u306e\u307f\u8a18\u8ff0\u3002\n  TransitGateway:\n    Type: AWS::EC2::TransitGateway\n    Properties:\n      Description: !Sub \"edi-${EnvName}-tgw (DX/VPN \u96c6\u7d04)\"\n      AmazonSideAsn: 64512 # TODO\n\n  TgwVpcAttachment:\n    Type: AWS::EC2::TransitGatewayVpcAttachment\n    Properties:\n      TransitGatewayId: !Ref TransitGateway\n      VpcId: !Ref Vpc\n      SubnetIds:\n        - !Ref PrivateSubnetA\n        - !Ref PrivateSubnetB\n\n  CustomerGateway:\n    Type: AWS::EC2::CustomerGateway\n    Properties:\n      Type: ipsec.1\n      BgpAsn: 65000 # TODO: \u30aa\u30f3\u30d7\u30ec\u5074 ASN\n      IpAddress: !Ref CustomerGatewayIp\n\n  SiteToSiteVpn:\n    Type: AWS::EC2::VPNConnection\n    Properties:\n      Type: ipsec.1\n      CustomerGatewayId: !Ref CustomerGateway\n      TransitGatewayId: !Ref TransitGateway\n      StaticRoutesOnly: false\n\n  # ===== \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff08KMS / Secrets Manager / IAM\uff09 =====\n  EdiKmsKey:\n    Type: AWS::KMS::Key\n    Properties:\n      Description: EDI \u30c7\u30fc\u30bf\u4fdd\u7ba1\u6642\u6697\u53f7\u5316\uff08S3 / Aurora / DynamoDB / SQS\uff09\n      EnableKeyRotation: true\n      KeyPolicy:\n        Version: \"2012-10-17\"\n        Statement:\n          - Sid: EnableRoot\n            Effect: Allow\n            Principal:\n              AWS: !Sub \"arn:aws:iam::${AWS::AccountId}:root\"\n            Action: \"kms:*\"\n            Resource: \"*\"\n\n  PartnerCredentialsSecret:\n    Type: AWS::SecretsManager::Secret\n    Properties:\n      Name: !Sub \"edi-${EnvName}-partner-credentials\"\n      Description: \u53d6\u5f15\u5148\u306e AS2/SFTP \u8a8d\u8a3c\u60c5\u5831\n      KmsKeyId: !Ref EdiKmsKey\n\n  # ===== \u30d5\u30a1\u30a4\u30eb\u57fa\u76e4\uff08S3\uff09 =====\n  EdiLandingBucket:\n    Type: AWS::S3::Bucket\n    Properties:\n      BucketName: !Sub \"edi-${EnvName}-landing-${AWS::AccountId}\"\n      VersioningConfiguration:\n        Status: Enabled\n      BucketEncryption:\n        ServerSideEncryptionConfiguration:\n          - ServerSideEncryptionByDefault:\n              SSEAlgorithm: aws:kms\n              KMSMasterKeyID: !Ref EdiKmsKey\n      PublicAccessBlockConfiguration:\n        BlockPublicAcls: true\n        BlockPublicPolicy: true\n        IgnorePublicAcls: true\n        RestrictPublicBuckets: true\n      LifecycleConfiguration:\n        Rules:\n          - Id: ArchiveRawEdi\n            Status: Enabled\n            Transitions:\n              - StorageClass: GLACIER\n                TransitionInDays: 90 # TODO: \u30a2\u30fc\u30ab\u30a4\u30d6\u8981\u4ef6\u306b\u5408\u308f\u305b\u308b\n\n  # ===== EDI \u53d7\u4fe1\uff08Transfer Family AS2/SFTP\uff09 =====\n  TransferServer:\n    Type: AWS::Transfer::Server\n    Properties:\n      Protocols:\n        - SFTP\n        - AS2\n      Domain: S3\n      EndpointType: VPC\n      EndpointDetails:\n        VpcId: !Ref Vpc\n        SubnetIds:\n          - !Ref PrivateSubnetA\n          - !Ref PrivateSubnetB\n      IdentityProviderType: SERVICE_MANAGED\n      Tags:\n        - Key: Name\n          Value: !Sub \"edi-${EnvName}-transfer\"\n\n  # ===== EDI \u5909\u63db\uff08B2B Data Interchange\uff09 =====\n  # B2Bi \u306e Profile / Capability / Transformer / Partnership \u306f\n  # AWS::B2BI::* \u30ea\u30bd\u30fc\u30b9\u3067\u5b9a\u7fa9\u3059\u308b\u3002X12/EDIFACT \u2192 JSON \u5909\u63db\u3092\u62c5\u3046\u3002\n  B2biProfile:\n    Type: AWS::B2BI::Profile\n    Properties:\n      Name: !Sub \"edi-${EnvName}-profile\"\n      Phone: \"000-0000-0000\" # TODO\n      BusinessName: \"EDI Migration Org\" # TODO\n      Logging: ENABLED\n\n  B2biTransformer:\n    Type: AWS::B2BI::Transformer\n    Properties:\n      Name: !Sub \"edi-${EnvName}-x12-to-json\"\n      Status: active\n      # TODO: EdiType (X12 / EDIFACT) \u3068 OutputConversion (JSON) \u3092\u6307\u5b9a\n\n  # ===== \u9023\u643a\u30fb\u30aa\u30fc\u30b1\u30b9\u30c8\u30ec\u30fc\u30b7\u30e7\u30f3\uff08EventBridge / SQS / Lambda / Step Functions\uff09 =====\n  OrderEventBus:\n    Type: AWS::Events::EventBus\n    Properties:\n      Name: !Sub \"edi-${EnvName}-order-bus\"\n\n  OrderProcessingDlq:\n    Type: AWS::SQS::Queue\n    Properties:\n      QueueName: !Sub \"edi-${EnvName}-order-dlq\"\n      KmsMasterKeyId: !Ref EdiKmsKey\n\n  OrderProcessingQueue:\n    Type: AWS::SQS::Queue\n    Properties:\n      QueueName: !Sub \"edi-${EnvName}-order-queue\"\n      KmsMasterKeyId: !Ref EdiKmsKey\n      RedrivePolicy:\n        deadLetterTargetArn: !GetAtt OrderProcessingDlq.Arn\n        maxReceiveCount: 5\n\n  OrderProcessingFunction:\n    Type: AWS::Lambda::Function\n    Properties:\n      FunctionName: !Sub \"edi-${EnvName}-order-processor\"\n      Runtime: python3.12\n      Architectures: [arm64]\n      Handler: index.handler\n      Timeout: 60\n      MemorySize: 512\n      Role: !GetAtt OrderProcessingRole.Arn\n      Code:\n        ZipFile: |\n          def handler(event, context):\n              # TODO: B2Bi \u5909\u63db\u6e08\u307f\u53d7\u767a\u6ce8 JSON \u3092 Aurora / DynamoDB \u306b\u53cd\u6620\n              return {\"status\": \"ok\"}\n\n  OrderApiFunction:\n    Type: AWS::Lambda::Function\n    Properties:\n      FunctionName: !Sub \"edi-${EnvName}-order-api\"\n      Runtime: python3.12\n      Architectures: [arm64]\n      Handler: index.handler\n      Timeout: 30\n      MemorySize: 512\n      Role: !GetAtt OrderProcessingRole.Arn\n      Code:\n        ZipFile: |\n          def handler(event, context):\n              # TODO: \u79fb\u884c\u5148 \u53d7\u767a\u6ce8 API \u30d0\u30c3\u30af\u30a8\u30f3\u30c9\uff08Aurora \u7167\u4f1a\uff09\n              return {\"statusCode\": 200, \"body\": \"{}\"}\n\n  OrderWorkflow:\n    Type: AWS::StepFunctions::StateMachine\n    Properties:\n      StateMachineName: !Sub \"edi-${EnvName}-order-workflow\"\n      RoleArn: !GetAtt StepFunctionsRole.Arn\n      DefinitionString: !Sub |\n        {\n          \"Comment\": \"\u53d7\u767a\u6ce8\u51e6\u7406\u30ef\u30fc\u30af\u30d5\u30ed\u30fc\",\n          \"StartAt\": \"Validate\",\n          \"States\": {\n            \"Validate\": { \"Type\": \"Task\", \"Resource\": \"${OrderProcessingFunction.Arn}\", \"Next\": \"Persist\" },\n            \"Persist\":  { \"Type\": \"Task\", \"Resource\": \"${OrderProcessingFunction.Arn}\", \"End\": true }\n          }\n        }\n\n  # EventBridge \u30eb\u30fc\u30eb: B2Bi \u5909\u63db\u5b8c\u4e86\u30a4\u30d9\u30f3\u30c8 \u2192 Step Functions / SQS\n  B2biCompletedToWorkflowRule:\n    Type: AWS::Events::Rule\n    Properties:\n      EventBusName: !Ref OrderEventBus\n      EventPattern:\n        source: [\"aws.b2bi\"] # TODO: \u5b9f\u30a4\u30d9\u30f3\u30c8\u30bd\u30fc\u30b9\u306b\u5408\u308f\u305b\u308b\n        detail-type: [\"EDI Transformation Completed\"]\n      Targets:\n        - Id: ToWorkflow\n          Arn: !Ref OrderWorkflow\n          RoleArn: !GetAtt EventBridgeInvokeRole.Arn\n        - Id: ToQueue\n          Arn: !GetAtt OrderProcessingQueue.Arn\n\n  OrderQueueEventSourceMapping:\n    Type: AWS::Lambda::EventSourceMapping\n    Properties:\n      EventSourceArn: !GetAtt OrderProcessingQueue.Arn\n      FunctionName: !Ref OrderProcessingFunction\n      BatchSize: 10\n\n  # ===== \u30c7\u30fc\u30bf\uff08Aurora Multi-AZ / DynamoDB\uff09 =====\n  AuroraCluster:\n    Type: AWS::RDS::DBCluster\n    Properties:\n      Engine: aurora-postgresql\n      EngineMode: provisioned\n      DatabaseName: orders\n      MasterUsername: !Sub \"{{resolve:secretsmanager:${PartnerCredentialsSecret}:SecretString:dbuser}}\" # TODO\n      StorageEncrypted: true\n      KmsKeyId: !Ref EdiKmsKey\n      ServerlessV2ScalingConfiguration:\n        MinCapacity: !FindInMap [EnvMap, !Ref EnvName, AuroraMinAcu]\n        MaxCapacity: !FindInMap [EnvMap, !Ref EnvName, AuroraMaxAcu]\n\n  AuroraInstanceA:\n    Type: AWS::RDS::DBInstance\n    Properties:\n      DBClusterIdentifier: !Ref AuroraCluster\n      DBInstanceClass: db.serverless\n      Engine: aurora-postgresql\n\n  AuroraInstanceB:\n    Type: AWS::RDS::DBInstance\n    Condition: IsProd\n    Properties:\n      DBClusterIdentifier: !Ref AuroraCluster\n      DBInstanceClass: db.serverless\n      Engine: aurora-postgresql\n\n  ProcessingStateTable:\n    Type: AWS::DynamoDB::Table\n    Properties:\n      TableName: !Sub \"edi-${EnvName}-processing-state\"\n      BillingMode: PAY_PER_REQUEST\n      AttributeDefinitions:\n        - AttributeName: orderId\n          AttributeType: S\n      KeySchema:\n        - AttributeName: orderId\n          KeyType: HASH\n      SSESpecification:\n        SSEEnabled: true\n        KMSMasterKeyId: !Ref EdiKmsKey\n        SSEType: KMS\n      PointInTimeRecoverySpecification:\n        PointInTimeRecoveryEnabled: true\n\n  # ===== \u793e\u5185 API\uff08API Gateway\uff09 =====\n  OrderApi:\n    Type: AWS::ApiGatewayV2::Api\n    Properties:\n      Name: !Sub \"edi-${EnvName}-order-api\"\n      ProtocolType: HTTP\n\n  # ===== \u76e3\u8996\u30fb\u901a\u77e5\uff08CloudWatch / SNS\uff09 =====\n  OpsAlertTopic:\n    Type: AWS::SNS::Topic\n    Properties:\n      TopicName: !Sub \"edi-${EnvName}-ops-alerts\"\n      KmsMasterKeyId: !Ref EdiKmsKey\n\n  DlqDepthAlarm:\n    Type: AWS::CloudWatch::Alarm\n    Properties:\n      AlarmName: !Sub \"edi-${EnvName}-order-dlq-depth\"\n      Namespace: AWS/SQS\n      MetricName: ApproximateNumberOfMessagesVisible\n      Dimensions:\n        - Name: QueueName\n          Value: !GetAtt OrderProcessingDlq.QueueName\n      Statistic: Maximum\n      Period: 300\n      EvaluationPeriods: 1\n      Threshold: 1\n      ComparisonOperator: GreaterThanOrEqualToThreshold\n      AlarmActions:\n        - !Ref OpsAlertTopic\n\n  # ===== IAM\uff08\u6700\u5c0f\u6a29\u9650\u30ed\u30fc\u30eb\uff09 =====\n  OrderProcessingRole:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Principal:\n              Service: lambda.amazonaws.com\n            Action: sts:AssumeRole\n      ManagedPolicyArns:\n        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\n      Policies:\n        - PolicyName: order-processing-least-privilege\n          PolicyDocument:\n            Version: \"2012-10-17\"\n            Statement:\n              - Effect: Allow\n                Action: [sqs:ReceiveMessage, sqs:DeleteMessage, sqs:GetQueueAttributes]\n                Resource: !GetAtt OrderProcessingQueue.Arn\n              - Effect: Allow\n                Action: [dynamodb:PutItem, dynamodb:UpdateItem, dynamodb:GetItem]\n                Resource: !GetAtt ProcessingStateTable.Arn\n              - Effect: Allow\n                Action: [kms:Decrypt, kms:GenerateDataKey]\n                Resource: !GetAtt EdiKmsKey.Arn\n              - Effect: Allow\n                Action: [secretsmanager:GetSecretValue]\n                Resource: !Ref PartnerCredentialsSecret\n\n  StepFunctionsRole:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Principal:\n              Service: states.amazonaws.com\n            Action: sts:AssumeRole\n      Policies:\n        - PolicyName: invoke-order-lambda\n          PolicyDocument:\n            Version: \"2012-10-17\"\n            Statement:\n              - Effect: Allow\n                Action: lambda:InvokeFunction\n                Resource: !GetAtt OrderProcessingFunction.Arn\n\n  EventBridgeInvokeRole:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Principal:\n              Service: events.amazonaws.com\n            Action: sts:AssumeRole\n      Policies:\n        - PolicyName: start-order-workflow\n          PolicyDocument:\n            Version: \"2012-10-17\"\n            Statement:\n              - Effect: Allow\n                Action: states:StartExecution\n                Resource: !Ref OrderWorkflow\n\nConditions:\n  IsProd: !Equals [!Ref EnvName, prod]\n\nOutputs:\n  TransferServerId:\n    Description: Transfer Family \u30b5\u30fc\u30d0\u30fc ID\uff08\u53d6\u5f15\u5148 AS2/SFTP \u63a5\u7d9a\u5148\uff09\n    Value: !Ref TransferServer\n  LandingBucketName:\n    Description: EDI raw landing / \u30a2\u30fc\u30ab\u30a4\u30d6\u7528 S3 \u30d0\u30b1\u30c3\u30c8\n    Value: !Ref EdiLandingBucket\n  OrderApiEndpoint:\n    Description: \u79fb\u884c\u5148 \u53d7\u767a\u6ce8 API \u30a8\u30f3\u30c9\u30dd\u30a4\u30f3\u30c8\n    Value: !Sub \"https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com\"\n  AuroraClusterEndpoint:\n    Description: \u53d7\u767a\u6ce8 DB\uff08Aurora Multi-AZ\uff09\u66f8\u304d\u8fbc\u307f\u30a8\u30f3\u30c9\u30dd\u30a4\u30f3\u30c8\n    Value: !GetAtt AuroraCluster.Endpoint.Address\n  TransitGatewayId:\n    Description: \u30aa\u30f3\u30d7\u30ec DC \u3068\u306e\u30cf\u30a4\u30d6\u30ea\u30c3\u30c9\u63a5\u7d9a\u3092\u96c6\u7d04\u3059\u308b Transit Gateway\n    Value: !Ref TransitGateway\n";
+const lines = raw.split("\n");
+const tbody = document.getElementById("code-body");
+lines.forEach((line, i) => {
+  const tr = document.createElement("tr");
+  const lnTd = document.createElement("td");
+  lnTd.className = "ln"; lnTd.textContent = i + 1;
+  const codeTd = document.createElement("td");
+  codeTd.className = "code"; codeTd.innerHTML = highlight(line);
+  tr.appendChild(lnTd); tr.appendChild(codeTd); tbody.appendChild(tr);
+});
+function copyYaml(btn) {
+  navigator.clipboard.writeText(raw).then(() => {
+    btn.classList.add("copied");
+    btn.querySelector("span").textContent = "Copied!";
+    btn.querySelector("svg").innerHTML = '<path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>';
+    setTimeout(() => {
+      btn.classList.remove("copied");
+      btn.querySelector("span").textContent = "Copy";
+      btn.querySelector("svg").innerHTML = '<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>';
+    }, 2000);
+  });
+}
+function highlight(line) {
+  let h = line.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+  if (/^\s*#/.test(h)) return '<span class="hl-comment">' + h + '</span>';
+  h = h.replace(/(#.*)$/, '<span class="hl-comment">$1</span>');
+  h = h.replace(/(!(?:Ref|Sub|GetAtt|Select|Join|If|Equals|FindInMap|Split|ImportValue|GetAZs|Condition|Not|And|Or))/g, '<span class="hl-ref">$1</span>');
+  h = h.replace(/^(\s*)(AWSTemplateFormatVersion|Description|Parameters|Mappings|Conditions|Resources|Outputs|Rules|Metadata|Transform)(:)/, '$1<span class="hl-kw">$2</span>$3');
+  h = h.replace(/(AWS::[A-Za-z0-9]+::[A-Za-z0-9]+)/g, '<span class="hl-kw">$1</span>');
+  h = h.replace(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)(:)/gm, '$1<span class="hl-key">$2</span>$3');
+  return h;
+}
+</script>
+</body>
+</html>

--- a/docs/diagrams/edi-onprem-to-aws-migration.drawio
+++ b/docs/diagrams/edi-onprem-to-aws-migration.drawio
@@ -1,0 +1,356 @@
+<mxfile host="cc-sier-diagram-v2" agent="company-diagram-v2 LLM direct generation" version="29.6.1">
+  <diagram name="EDI-Onprem-to-AWS-Migration" id="edi-onprem-to-aws-migration">
+    <mxGraphModel dx="1700" dy="1300" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1900" pageHeight="1300" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <!-- ===== Title block ===== -->
+        <mxCell id="title-group" connectable="0" parent="1" style="group;fontFamily=Helvetica;" value="" vertex="1">
+          <mxGeometry height="83" width="1800" x="50" y="30" as="geometry" />
+        </mxCell>
+        <mxCell id="title-text" parent="title-group" style="text;html=1;resizable=1;points=[];autosize=1;align=left;verticalAlign=top;spacingTop=-4;fontSize=30;fontStyle=1;fontFamily=Helvetica;" value="EDI 受発注システム オンプレミス → AWS 移行構成" vertex="1">
+          <mxGeometry height="42" width="1100" as="geometry" />
+        </mxCell>
+        <mxCell id="subtitle-text" parent="title-group" style="text;html=1;resizable=0;points=[];autosize=1;align=left;verticalAlign=top;spacingTop=-4;fontSize=16;fontFamily=Helvetica;" value="既存 EDI/VAN を Transfer Family + B2B Data Interchange + サーバーレス受発注処理へ。Direct Connect/VPN によるハイブリッド並行稼働" vertex="1">
+          <mxGeometry height="25" width="1400" x="5" y="40" as="geometry" />
+        </mxCell>
+        <mxCell id="title-separator" parent="title-group" style="line;strokeWidth=2;html=1;fontSize=14;strokeColor=#FF9900;fontFamily=Helvetica;" value="" vertex="1">
+          <mxGeometry height="10" width="1790" x="5" y="70" as="geometry" />
+        </mxCell>
+        <!-- ===== On-premises label (text only, NOT a container, to avoid edge-penetration false positives) ===== -->
+        <mxCell id="onprem-label" parent="1" value="&lt;b&gt;オンプレミス データセンター&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#666666;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="50" y="160" width="230" height="24" as="geometry" />
+        </mxCell>
+        <!-- Trading Partners (external actor, outside both clouds) -->
+        <mxCell id="partners-container" parent="1" style="fillColor=#f5f5f5;strokeColor=light-dark(#666666,#D4D4D4);rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#333333;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1;perimeterSpacing=0;" value="取引先（発注元/受注先）" vertex="1">
+          <mxGeometry x="80" y="250" width="170" height="98" as="geometry" />
+        </mxCell>
+        <mxCell id="partners-icon" parent="partners-container" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#232F3D;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.users;fontFamily=Helvetica;" value="" vertex="1">
+          <mxGeometry height="48" width="48" x="61" y="30" as="geometry" />
+        </mxCell>
+        <!-- Legacy EDI/VAN system -->
+        <mxCell id="svc-group-legacy-edi" parent="1" style="fillColor=#F5F5F5;strokeColor=#666666;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#666666;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="レガシー EDI/VAN" vertex="1">
+          <mxGeometry x="80" y="420" width="170" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-legacy-edi" parent="svc-group-legacy-edi" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#666666;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.traditional_server;fontFamily=Helvetica;shadow=1;" value="既存 EDI/VAN&lt;div&gt;&lt;i&gt;X12/EDIFACT 交換&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="61" y="30" as="geometry" />
+        </mxCell>
+        <!-- Legacy order system -->
+        <mxCell id="svc-group-legacy-order" parent="1" style="fillColor=#F5F5F5;strokeColor=#666666;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#666666;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="既存 受発注システム" vertex="1">
+          <mxGeometry x="80" y="640" width="170" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-legacy-order" parent="svc-group-legacy-order" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#666666;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.corporate_data_center;fontFamily=Helvetica;shadow=1;" value="レガシー受発注&lt;div&gt;&lt;i&gt;移行期に並行稼働&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="61" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== AWS Cloud boundary (decoration container=1) ===== -->
+        <mxCell id="aws-cloud" parent="1" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud;strokeColor=light-dark(#232F3E,#E4F0FF);fillColor=light-dark(#232F3E0D,#232F3E0D);fillStyle=auto;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;fontFamily=Helvetica;" value="&lt;font style=&quot;color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;AWS Cloud（VPC / Multi-AZ）&lt;/font&gt;" vertex="1">
+          <mxGeometry height="1010" width="1470" x="360" y="150" as="geometry" />
+        </mxCell>
+        <!-- ===== Column labels (children of aws-cloud, relative coords) ===== -->
+        <mxCell id="col-hybrid" parent="aws-cloud" value="&lt;b&gt;ハイブリッド接続&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#8C4FFF;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="40" y="50" width="160" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="col-ingest" parent="aws-cloud" value="&lt;b&gt;EDI 受信層&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#3F8624;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="270" y="50" width="160" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="col-convert" parent="aws-cloud" value="&lt;b&gt;EDI 変換 / 連携&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#E7157B;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="500" y="50" width="180" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="col-process" parent="aws-cloud" value="&lt;b&gt;受発注処理 / データ&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#ED7100;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="960" y="50" width="200" height="20" as="geometry" />
+        </mxCell>
+        <!-- ===== Direct Connect ===== -->
+        <mxCell id="svc-group-dx" parent="aws-cloud" style="fillColor=#EDE7F6;strokeColor=#8C4FFF;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#8C4FFF;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="専用線" vertex="1">
+          <mxGeometry x="50" y="100" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-dx" parent="svc-group-dx" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.direct_connect;fontFamily=Helvetica;shadow=1;" value="Direct Connect&lt;div&gt;&lt;i&gt;専用線接続&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Site-to-Site VPN (redundant) ===== -->
+        <mxCell id="svc-group-vpn" parent="aws-cloud" style="fillColor=#EDE7F6;strokeColor=#8C4FFF;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#8C4FFF;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="冗長 VPN" vertex="1">
+          <mxGeometry x="50" y="290" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-vpn" parent="svc-group-vpn" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.site_to_site_vpn;fontFamily=Helvetica;shadow=1;" value="Site-to-Site VPN&lt;div&gt;&lt;i&gt;DX 障害時の冗長&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Transit Gateway ===== -->
+        <mxCell id="svc-group-tgw" parent="aws-cloud" style="fillColor=#EDE7F6;strokeColor=#8C4FFF;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#8C4FFF;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="ルーティング" vertex="1">
+          <mxGeometry x="50" y="490" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-tgw" parent="svc-group-tgw" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.transit_gateway;fontFamily=Helvetica;shadow=1;" value="Transit Gateway&lt;div&gt;&lt;i&gt;VPC へ集約&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Transfer Family (ingest) ===== -->
+        <mxCell id="svc-group-transfer" parent="aws-cloud" style="fillColor=#EDE7F6;strokeColor=#8C4FFF;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#8C4FFF;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="EDI 受信" vertex="1">
+          <mxGeometry x="270" y="290" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-transfer" parent="svc-group-transfer" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.transfer_family;fontFamily=Helvetica;shadow=1;" value="Transfer Family&lt;div&gt;&lt;i&gt;AS2/SFTP 受信&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== S3 raw landing ===== -->
+        <mxCell id="svc-group-s3" parent="aws-cloud" style="fillColor=#E8F5E9;strokeColor=#3F8624;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#3F8624;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="ファイル基盤" vertex="1">
+          <mxGeometry x="270" y="490" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-s3" parent="svc-group-s3" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#3F8624;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;fontFamily=Helvetica;shadow=1;" value="S3&lt;div&gt;&lt;i&gt;raw / アーカイブ&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== B2B Data Interchange (convert) ===== -->
+        <mxCell id="svc-group-b2bi" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="EDI 変換" vertex="1">
+          <mxGeometry x="520" y="290" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-b2bi" parent="svc-group-b2bi" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.b2b_data_interchange;fontFamily=Helvetica;shadow=1;" value="B2B Data Interchange&lt;div&gt;&lt;i&gt;X12/EDIFACT→JSON&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="46" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== EventBridge ===== -->
+        <mxCell id="svc-group-eventbridge" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="イベント連携" vertex="1">
+          <mxGeometry x="520" y="490" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-eventbridge" parent="svc-group-eventbridge" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.eventbridge;fontFamily=Helvetica;shadow=1;" value="EventBridge&lt;div&gt;&lt;i&gt;受発注イベント&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="46" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== SQS ===== -->
+        <mxCell id="svc-group-sqs" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="キュー" vertex="1">
+          <mxGeometry x="520" y="690" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-sqs" parent="svc-group-sqs" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sqs;fontFamily=Helvetica;shadow=1;" value="SQS&lt;div&gt;&lt;i&gt;処理キュー + DLQ&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="46" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Step Functions (orchestration) ===== -->
+        <mxCell id="svc-group-sfn" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="オーケストレーション" vertex="1">
+          <mxGeometry x="760" y="490" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-sfn" parent="svc-group-sfn" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.step_functions;fontFamily=Helvetica;shadow=1;" value="Step Functions&lt;div&gt;&lt;i&gt;受発注ワークフロー&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="46" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Lambda (processing) ===== -->
+        <mxCell id="svc-group-lambda" parent="aws-cloud" style="fillColor=#FFF2E8;strokeColor=#ED7100;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#ED7100;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="Compute" vertex="1">
+          <mxGeometry x="990" y="490" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-lambda" parent="svc-group-lambda" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;fontFamily=Helvetica;shadow=1;" value="Lambda&lt;div&gt;&lt;i&gt;受発注処理&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Aurora (order DB, Multi-AZ) ===== -->
+        <mxCell id="svc-group-aurora" parent="aws-cloud" style="fillColor=#F5E6F7;strokeColor=#C925D1;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#C925D1;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="受発注 DB" vertex="1">
+          <mxGeometry x="990" y="290" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-aurora" parent="svc-group-aurora" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.aurora;fontFamily=Helvetica;shadow=1;" value="Aurora&lt;div&gt;&lt;i&gt;受発注DB Multi-AZ&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== DynamoDB (processing state) ===== -->
+        <mxCell id="svc-group-dynamodb" parent="aws-cloud" style="fillColor=#F5E6F7;strokeColor=#C925D1;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#C925D1;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="処理状態" vertex="1">
+          <mxGeometry x="990" y="690" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-dynamodb" parent="svc-group-dynamodb" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;fontFamily=Helvetica;shadow=1;" value="DynamoDB&lt;div&gt;&lt;i&gt;処理ステータス&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== API Gateway (internal order API) ===== -->
+        <mxCell id="svc-group-apigw" parent="aws-cloud" style="fillColor=#EDE7F6;strokeColor=#8C4FFF;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#8C4FFF;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="社内 API" vertex="1">
+          <mxGeometry x="1230" y="290" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-apigw" parent="svc-group-apigw" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.api_gateway;fontFamily=Helvetica;shadow=1;" value="API Gateway&lt;div&gt;&lt;i&gt;移行先 受発注API&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== API Lambda ===== -->
+        <mxCell id="svc-group-apilambda" parent="aws-cloud" style="fillColor=#FFF2E8;strokeColor=#ED7100;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#ED7100;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="API Compute" vertex="1">
+          <mxGeometry x="1230" y="490" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-apilambda" parent="svc-group-apilambda" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;fontFamily=Helvetica;shadow=1;" value="Lambda&lt;div&gt;&lt;i&gt;API バックエンド&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- ===== Auxiliary / Security label (text only, placed clear of edge lanes) ===== -->
+        <mxCell id="aux-label" parent="aws-cloud" value="&lt;b&gt;監視・通知 / セキュリティ（横断レイヤー）&lt;/b&gt;" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#666666;fontFamily=Helvetica;" vertex="1">
+          <mxGeometry x="770" y="900" width="400" height="20" as="geometry" />
+        </mxCell>
+        <!-- CloudWatch -->
+        <mxCell id="svc-group-cloudwatch" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="監視" vertex="1">
+          <mxGeometry x="50" y="860" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-cloudwatch" parent="svc-group-cloudwatch" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;fontFamily=Helvetica;shadow=1;" value="CloudWatch&lt;div&gt;&lt;i&gt;メトリクス/ログ&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- SNS -->
+        <mxCell id="svc-group-sns" parent="aws-cloud" style="fillColor=#FCE4EC;strokeColor=#E7157B;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#E7157B;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="通知" vertex="1">
+          <mxGeometry x="230" y="860" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-sns" parent="svc-group-sns" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sns;fontFamily=Helvetica;shadow=1;" value="SNS&lt;div&gt;&lt;i&gt;運用アラート通知&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- IAM -->
+        <mxCell id="svc-group-iam" parent="aws-cloud" style="fillColor=#FFEBEE;strokeColor=#DD344C;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#DD344C;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="権限" vertex="1">
+          <mxGeometry x="410" y="860" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-iam" parent="svc-group-iam" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.identity_and_access_management;fontFamily=Helvetica;shadow=1;" value="IAM&lt;div&gt;&lt;i&gt;最小権限ロール&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- KMS -->
+        <mxCell id="svc-group-kms" parent="aws-cloud" style="fillColor=#FFEBEE;strokeColor=#DD344C;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#DD344C;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="暗号化" vertex="1">
+          <mxGeometry x="590" y="860" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-kms" parent="svc-group-kms" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.key_management_service;fontFamily=Helvetica;shadow=1;" value="KMS&lt;div&gt;&lt;i&gt;保管時暗号化&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+        <!-- Secrets Manager -->
+        <mxCell id="svc-group-secrets" parent="aws-cloud" style="fillColor=#FFEBEE;strokeColor=#DD344C;rounded=1;whiteSpace=wrap;html=1;verticalAlign=top;fontStyle=1;fontSize=12;fontColor=#DD344C;fontFamily=Helvetica;container=1;collapsible=0;shadow=1;strokeWidth=1.5;" value="認証情報" vertex="1">
+          <mxGeometry x="1230" y="690" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="svc-secrets" parent="svc-group-secrets" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.secrets_manager;fontFamily=Helvetica;shadow=1;" value="Secrets Manager&lt;div&gt;&lt;i&gt;取引先認証情報&lt;/i&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="48" width="48" x="36" y="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===================== EDGES (icon-to-icon; waypoints route around intervening icons) ===================== -->
+        <!-- ===== Flow 1 (色A #2E7DD7): EDI受信フロー 取引先 → Transfer Family → S3 ===== -->
+        <mxCell id="e-partners-transfer" edge="1" parent="1" source="partners-icon" target="svc-transfer" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#2E7DD7;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="305" y="304" />
+              <mxPoint x="305" y="600" />
+              <mxPoint x="690" y="600" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-partners-transfer-label" value="AS2/SFTP 送受信" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-partners-transfer">
+          <mxGeometry relative="1" x="-0.4" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-transfer-s3" edge="1" parent="1" source="svc-transfer" target="svc-s3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#2E7DD7;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-transfer-s3-label" value="EDI ファイル landing" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-transfer-s3">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+
+        <!-- ===== Flow 2 (色B #ED7100): EDI変換・受発注処理フロー S3 → B2BDI → EventBridge → Lambda/SFn → Aurora ===== -->
+        <mxCell id="e-s3-b2bi" edge="1" parent="1" source="svc-s3" target="svc-b2bi" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-s3-b2bi-label" value="raw 取り込み" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-s3-b2bi">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-b2bi-eventbridge" edge="1" parent="1" source="svc-b2bi" target="svc-eventbridge" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-b2bi-eventbridge-label" value="JSON 変換完了イベント" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-b2bi-eventbridge">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-eventbridge-sfn" edge="1" parent="1" source="svc-eventbridge" target="svc-sfn" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-eventbridge-sfn-label" value="ワークフロー起動" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-eventbridge-sfn">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-eventbridge-sqs" edge="1" parent="1" source="svc-eventbridge" target="svc-sqs" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-eventbridge-sqs-label" value="非同期エンキュー" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-eventbridge-sqs">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-sfn-lambda" edge="1" parent="1" source="svc-sfn" target="svc-lambda" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-sfn-lambda-label" value="ステップ実行" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-sfn-lambda">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-sqs-lambda" edge="1" parent="1" source="svc-sqs" target="svc-lambda" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="940" y="790" />
+              <mxPoint x="1410" y="790" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-sqs-lambda-label" value="デキュー処理" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-sqs-lambda">
+          <mxGeometry relative="1" x="0.4" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-lambda-aurora" edge="1" parent="1" source="svc-lambda" target="svc-aurora" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-lambda-aurora-label" value="受発注書き込み" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-lambda-aurora">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-lambda-dynamodb" edge="1" parent="1" source="svc-lambda" target="svc-dynamodb" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-lambda-dynamodb-label" value="処理状態更新" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-lambda-dynamodb">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-apigw-apilambda" edge="1" parent="1" source="svc-apigw" target="svc-apilambda" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-apigw-apilambda-label" value="社内API 呼び出し" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-apigw-apilambda">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-apilambda-aurora" edge="1" parent="1" source="svc-apilambda" target="svc-aurora" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#ED7100;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1180" y="550" />
+              <mxPoint x="1180" y="350" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-apilambda-aurora-label" value="受発注照会" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-apilambda-aurora">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+
+        <!-- ===== Flow 3 (色C #8C4FFF, 破線): オンプレ⇔AWS ハイブリッド並行稼働 ===== -->
+        <mxCell id="e-legacyedi-dx" edge="1" parent="1" source="svc-legacy-edi" target="svc-dx" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#8C4FFF;strokeWidth=2;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="345" y="474" />
+              <mxPoint x="345" y="304" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-legacyedi-dx-label" value="専用線接続" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;fontStyle=2;" connectable="0" vertex="1" parent="e-legacyedi-dx">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-legacyorder-vpn" edge="1" parent="1" source="svc-legacy-order" target="svc-vpn" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#8C4FFF;strokeWidth=2;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="325" y="694" />
+              <mxPoint x="325" y="494" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-legacyorder-vpn-label" value="VPN 冗長経路" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;fontStyle=2;" connectable="0" vertex="1" parent="e-legacyorder-vpn">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-dx-tgw" edge="1" parent="1" source="svc-dx" target="svc-tgw" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#8C4FFF;strokeWidth=2;dashed=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="390" y="304" />
+              <mxPoint x="390" y="700" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-dx-tgw-label" value="集約" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;fontStyle=2;" connectable="0" vertex="1" parent="e-dx-tgw">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-vpn-tgw" edge="1" parent="1" source="svc-vpn" target="svc-tgw" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#8C4FFF;strokeWidth=2;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-vpn-tgw-label" value="冗長集約" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;fontStyle=2;" connectable="0" vertex="1" parent="e-vpn-tgw">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+        <mxCell id="e-tgw-apilambda" edge="1" parent="1" source="svc-tgw" target="svc-apilambda" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#8C4FFF;strokeWidth=2;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="470" y="990" />
+              <mxPoint x="1300" y="990" />
+              <mxPoint x="1300" y="544" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-tgw-apilambda-label" value="移行期: レガシー↔新基盤 連携" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;fontStyle=2;" connectable="0" vertex="1" parent="e-tgw-apilambda">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+
+        <!-- ===== Flow 4 (色D #607D8B, 破線): 監視・通知フロー CloudWatch → SNS ===== -->
+        <mxCell id="e-cloudwatch-sns" edge="1" parent="1" source="svc-cloudwatch" target="svc-sns" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#607D8B;strokeWidth=2;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-cloudwatch-sns-label" value="アラーム発火" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=none;fontSize=11;fontFamily=Helvetica;" connectable="0" vertex="1" parent="e-cloudwatch-sns">
+          <mxGeometry relative="1" x="0" y="0" as="geometry"><mxPoint as="offset" /></mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/edi-onprem-to-aws-migration.html
+++ b/docs/diagrams/edi-onprem-to-aws-migration.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EDI 受発注システム オンプレミス → AWS 移行構成 - AWS構成図</title>
+<style>
+:root { --bg:#f8f9fa; --bg2:#fff; --text:#1a1a2e; --blue:#4361ee; --border:rgba(0,0,0,.08);
+        --muted:#6c757d; --shadow:rgba(0,0,0,.06); }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --bg2:#161b22; --text:#e6edf3; --border:rgba(255,255,255,.08);
+          --muted:#8b949e; --shadow:rgba(0,0,0,.3); }
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+body { background:var(--bg); color:var(--text); font-family:system-ui,sans-serif; padding:32px; max-width:1100px; margin:0 auto; }
+.back-btn { display:inline-block; color:var(--blue); text-decoration:none; font-size:.88rem; margin-bottom:20px; }
+.back-btn:hover { text-decoration:underline; }
+h1 { font-size:1.4rem; margin-bottom:8px; }
+.meta { color:var(--muted); font-size:.85rem; margin-bottom:24px; display:flex; flex-wrap:wrap; gap:16px; }
+.tag { display:inline-block; padding:2px 10px; border-radius:4px; font-size:.75rem; font-weight:600; }
+.tag-area { background:#e0e7ff; color:#3730a3; }
+.tag-project { background:#fef3c7; color:#92400e; }
+@media (prefers-color-scheme: dark) {
+  .tag-area { background:#312e81; color:#c7d2fe; }
+  .tag-project { background:#78350f; color:#fde68a; }
+}
+.diagram-container { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+                     padding:24px; margin-bottom:32px; text-align:center; box-shadow:0 2px 8px var(--shadow); }
+.diagram-container iframe { width:100%; height:680px; border:0; border-radius:8px; background:#fff; }
+.hint { font-size:.78rem; color:var(--muted); margin-top:8px; }
+.legend-grid { display:flex; flex-wrap:wrap; gap:12px 24px; }
+.legend-item { display:flex; align-items:center; gap:8px; font-size:.85rem; }
+.legend-line { width:28px; height:3px; border-radius:2px; flex-shrink:0; }
+.legend-dashed { height:0; border-top:3px dashed; background:none !important; }
+.iac-btn { display:inline-block; margin-top:12px; padding:10px 20px; background:linear-gradient(135deg,#4361ee,#7c3aed);
+           color:#fff; text-decoration:none; border-radius:8px; font-size:.88rem; font-weight:600;
+           transition:opacity .2s, transform .15s; }
+.iac-btn:hover { opacity:.9; transform:translateY(-1px); }
+.dl-link { display:inline-block; margin-top:12px; margin-left:8px; padding:10px 20px; background:var(--bg);
+           color:var(--blue); text-decoration:none; border:1px solid var(--border); border-radius:8px; font-size:.88rem; font-weight:600; }
+.section { background:var(--bg2); border:1px solid var(--border); border-radius:12px;
+           padding:24px; margin-bottom:24px; box-shadow:0 2px 8px var(--shadow); }
+.section h2 { font-size:1.1rem; margin-bottom:12px; }
+.section h3 { font-size:.95rem; margin:20px 0 12px; }
+.section p { font-size:.9rem; line-height:1.7; margin-bottom:12px; }
+table { width:100%; border-collapse:collapse; font-size:.85rem; }
+th { text-align:left; background:var(--bg); padding:10px 12px; border:1px solid var(--border); white-space:nowrap; font-weight:600; }
+td { padding:10px 12px; border:1px solid var(--border); }
+.flow { display:flex; flex-wrap:wrap; align-items:center; gap:8px; margin:16px 0; font-size:.88rem; }
+.flow-step { background:var(--bg); border:1px solid var(--border); border-radius:8px; padding:8px 14px; font-weight:500; }
+.flow-arrow { color:var(--muted); font-size:1.2rem; }
+.badge { display:inline-block; padding:2px 8px; border-radius:4px; font-size:.72rem; font-weight:600; margin-right:6px; }
+.badge-recv { background:#dbeafe; color:#1e40af; }
+.badge-proc { background:#ffedd5; color:#9a3412; }
+.badge-hybrid { background:#ede9fe; color:#5b21b6; }
+.badge-ops { background:#e2e8f0; color:#334155; }
+ul.learning-points { list-style:none; padding-left:0; }
+ul.learning-points li { border-left:4px solid var(--blue); padding:8px 14px; margin-bottom:10px; background:var(--bg); border-radius:4px; font-size:.88rem; line-height:1.65; }
+ul.learning-points strong { color:var(--blue); }
+.cost-total td, .cost-total th { background:var(--bg); font-weight:600; }
+.updated { margin-top:32px; font-size:.78rem; color:var(--muted); }
+</style>
+</head>
+<body>
+<a href="./index.html" class="back-btn">&larr; 構成図一覧に戻る</a>
+
+<h1>EDI 受発注システム オンプレミス &rarr; AWS 移行構成</h1>
+<div class="meta">
+  <span class="tag tag-project">EDI 受発注移行</span>
+  <span class="tag tag-area">ハイブリッド / サーバーレス</span>
+  <span>生成日: 2026-06-13</span>
+</div>
+
+<div class="diagram-container">
+  <iframe src="./edi-onprem-to-aws-migration.drawio" title="EDI 受発注システム オンプレミス→AWS 移行構成図"></iframe>
+  <div class="hint">draw.io XML を直接埋め込み表示（v2 方式）。ブラウザによっては <a href="./edi-onprem-to-aws-migration.drawio" download>.drawio をダウンロード</a>して diagrams.net で開いてください。</div>
+  <div>
+    <a href="./edi-onprem-to-aws-migration-iac.html" class="iac-btn">IaCソースコードを見る</a>
+    <a href="./edi-onprem-to-aws-migration.drawio" class="dl-link" download>.drawio をダウンロード</a>
+  </div>
+</div>
+
+<div class="section">
+  <h2>凡例</h2>
+  <div class="legend-grid">
+    <div class="legend-item"><span class="legend-line" style="background:#2E7DD7"></span> EDI 受信フロー &#8212; 取引先が AS2/SFTP で送信 &rarr; Transfer Family が受信 &rarr; S3 へ EDI ファイルを landing</div>
+    <div class="legend-item"><span class="legend-line" style="background:#ED7100"></span> EDI 変換・受発注処理フロー &#8212; S3 &rarr; B2B Data Interchange (X12/EDIFACT→JSON) &rarr; EventBridge &rarr; Step Functions / SQS / Lambda &rarr; Aurora・DynamoDB。社内 API (API Gateway+Lambda) からの受発注照会も含む</div>
+    <div class="legend-item"><span class="legend-line legend-dashed" style="border-color:#8C4FFF"></span> オンプレ⇔AWS ハイブリッド連携（破線・移行期の並行稼働）&#8212; レガシー受発注/EDI ↔ Direct Connect・Site-to-Site VPN ↔ Transit Gateway ↔ VPC 内サービス</div>
+    <div class="legend-item"><span class="legend-line legend-dashed" style="border-color:#607D8B"></span> 監視・通知フロー（破線）&#8212; CloudWatch アラームが発火 &rarr; SNS で運用担当へ通知</div>
+  </div>
+</div>
+
+<div class="section">
+  <h2>概要</h2>
+  <p>既存の <strong>オンプレミス EDI/VAN・レガシー受発注システム</strong> を AWS のマネージドサービス群へ段階的に移行する構成。取引先（発注元・受注先）からの EDI ファイルは <strong>AWS Transfer Family</strong> が AS2/SFTP で受信し、<strong>S3</strong> に raw landing する。<strong>AWS B2B Data Interchange</strong> が X12/EDIFACT を JSON へ変換し、その完了イベントを起点に <strong>EventBridge → Step Functions / SQS / Lambda</strong> の受発注処理ワークフローが駆動され、<strong>Aurora（Multi-AZ）</strong>に受発注データ、<strong>DynamoDB</strong> に処理ステータスを記録する。移行先の受発注機能は <strong>API Gateway + Lambda</strong> の社内 API として提供する。</p>
+  <p>移行はビッグバンではなく<strong>並行稼働（ストラングラーパターン）</strong>を前提とする。オンプレのレガシー受発注/EDI システムは <strong>Direct Connect</strong>（冗長として <strong>Site-to-Site VPN</strong>）と <strong>Transit Gateway</strong> 経由で VPC 内の新基盤と接続し、移行期間中はデータをやり取りしながら段階的に処理を AWS 側へ切り替える。セキュリティは <strong>IAM 最小権限ロール・KMS 保管時暗号化・Secrets Manager（取引先認証情報）</strong>を最初から各層に織り込み、<strong>CloudWatch + SNS</strong> で監視・通知を行う。本ファイルは company-diagram-v2（draw.io XML 直接生成方式 / MCP 不使用）の成果物。</p>
+</div>
+
+<div class="section">
+  <h2>データフロー</h2>
+  <div class="flow">
+    <span class="badge badge-recv">受信</span>
+    <span class="flow-step">取引先（発注元/受注先）</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Transfer Family (AS2/SFTP)</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">S3 (raw landing / アーカイブ)</span>
+  </div>
+  <div class="flow">
+    <span class="badge badge-proc">変換・処理</span>
+    <span class="flow-step">S3</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">B2B Data Interchange</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">EventBridge</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Step Functions / SQS</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Lambda</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Aurora / DynamoDB</span>
+  </div>
+  <div class="flow">
+    <span class="badge badge-proc">社内API</span>
+    <span class="flow-step">社内システム</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">API Gateway</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Lambda (API)</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">Aurora</span>
+  </div>
+  <div class="flow">
+    <span class="badge badge-hybrid">ハイブリッド</span>
+    <span class="flow-step">レガシー受発注/EDI（オンプレ）</span><span class="flow-arrow">&harr;</span>
+    <span class="flow-step">Direct Connect / VPN</span><span class="flow-arrow">&harr;</span>
+    <span class="flow-step">Transit Gateway</span><span class="flow-arrow">&harr;</span>
+    <span class="flow-step">VPC 内サービス</span>
+  </div>
+  <div class="flow">
+    <span class="badge badge-ops">監視・通知</span>
+    <span class="flow-step">CloudWatch (メトリクス/アラーム)</span><span class="flow-arrow">&rarr;</span>
+    <span class="flow-step">SNS (運用通知)</span>
+  </div>
+  <p><strong>EDI 変換・受発注処理フロー</strong>: S3 に着地した EDI ファイルを B2B Data Interchange が X12/EDIFACT から JSON へ変換し、変換完了イベントを EventBridge に発行する。EventBridge は同期的なステップ実行が必要な受発注は Step Functions ワークフローへ、スパイクを吸収すべき非同期処理は SQS（+ DLQ, maxReceiveCount=5）へ振り分ける。Lambda が処理結果を Aurora（受発注 DB, Multi-AZ）へ書き込み、処理ステータスを DynamoDB に記録する。</p>
+  <p><strong>オンプレ⇔AWS ハイブリッド連携フロー（移行期）</strong>: レガシー EDI/VAN・受発注システムは Direct Connect（主）と Site-to-Site VPN（冗長）で AWS へ接続し、両回線を Transit Gateway が集約して VPC へルーティングする。移行期間中はレガシー側と新基盤（API Gateway+Lambda）の間で受発注データを連携させ、機能単位で段階的に切り替える。</p>
+</div>
+
+<div class="section">
+  <h2>レイヤー構成</h2>
+  <table>
+    <tr><th>レイヤー</th><th>AWSサービス</th><th>用途</th></tr>
+    <tr><td>外部アクター</td><td>取引先（発注元/受注先）</td><td>複数の取引先が AS2/SFTP で EDI ファイルを送受信</td></tr>
+    <tr><td>オンプレミス</td><td>既存 EDI/VAN（レガシー）</td><td>X12/EDIFACT の既存交換基盤。移行期は並行稼働</td></tr>
+    <tr><td>オンプレミス</td><td>レガシー受発注システム</td><td>既存の受発注処理。Direct Connect/VPN 経由で AWS と連携</td></tr>
+    <tr><td>ハイブリッド接続</td><td>Direct Connect</td><td>オンプレ DC と AWS をつなぐ専用線（主回線）</td></tr>
+    <tr><td>ハイブリッド接続</td><td>Site-to-Site VPN</td><td>Direct Connect 障害時の冗長 IPsec 経路</td></tr>
+    <tr><td>ハイブリッド接続</td><td>Transit Gateway</td><td>DX/VPN を集約し VPC へルーティング</td></tr>
+    <tr><td>EDI 受信</td><td>AWS Transfer Family</td><td>AS2/SFTP エンドポイント。取引先から EDI を受信し S3 へ</td></tr>
+    <tr><td>ファイル基盤</td><td>S3</td><td>EDI raw landing バケット + アーカイブ（Glacier 移行）。KMS 暗号化</td></tr>
+    <tr><td>EDI 変換</td><td>AWS B2B Data Interchange</td><td>X12/EDIFACT &rarr; JSON 変換。Transformer/Partnership で取引先別に処理</td></tr>
+    <tr><td>イベント連携</td><td>EventBridge</td><td>変換完了イベントを Step Functions / SQS へルーティング</td></tr>
+    <tr><td>キュー</td><td>SQS (+ DLQ)</td><td>非同期受発注処理キュー。スパイク吸収・失敗は DLQ へ退避</td></tr>
+    <tr><td>オーケストレーション</td><td>Step Functions</td><td>受発注処理ワークフロー（検証→永続化）のステップ管理</td></tr>
+    <tr><td>Compute</td><td>Lambda（受発注処理）</td><td>SQS/Step Functions から起動。Aurora/DynamoDB へ反映</td></tr>
+    <tr><td>受発注 DB</td><td>Aurora（Multi-AZ）</td><td>受発注データの永続化。Serverless v2、KMS 暗号化、Multi-AZ</td></tr>
+    <tr><td>処理状態</td><td>DynamoDB</td><td>受発注処理ステータス。PITR 有効、KMS 暗号化</td></tr>
+    <tr><td>社内 API</td><td>API Gateway</td><td>移行先 受発注 API のエンドポイント（HTTP API）</td></tr>
+    <tr><td>API Compute</td><td>Lambda（API）</td><td>社内 API バックエンド。Aurora を照会</td></tr>
+    <tr><td>監視</td><td>CloudWatch</td><td>メトリクス・ログ集約、DLQ 滞留などのアラーム</td></tr>
+    <tr><td>通知</td><td>SNS</td><td>運用アラートの通知トピック</td></tr>
+    <tr><td>権限</td><td>IAM</td><td>Lambda/Step Functions/EventBridge の最小権限ロール</td></tr>
+    <tr><td>暗号化</td><td>KMS</td><td>S3/Aurora/DynamoDB/SQS/SNS の保管時暗号化 CMK</td></tr>
+    <tr><td>認証情報</td><td>Secrets Manager</td><td>取引先の AS2/SFTP 認証情報・DB 認証情報</td></tr>
+  </table>
+</div>
+
+<div class="section">
+  <h2>設計のポイント</h2>
+  <ul>
+    <li><strong>ビッグバンではなくストラングラーパターンで段階移行する</strong> &#8212; レガシー受発注/EDI を一度に止めるのではなく、Direct Connect/VPN + Transit Gateway でオンプレと AWS を接続し、受発注の機能単位で新基盤へ少しずつ切り替える。並行稼働期間を設けることで、変換ロジックの差異や取引先ごとの方言を本番データで検証しながら、切り戻し可能な状態を保てる。EDI は取引先との取り決めが絡むため一斉切替のリスクが極めて高い。</li>
+    <li><strong>EDI 変換はマネージドの B2B Data Interchange に寄せる</strong> &#8212; X12/EDIFACT のパースとマッピングは自前実装すると保守負担が大きく、取引先追加のたびに改修が必要になる。B2B Data Interchange の Transformer/Partnership に変換定義を持たせることで、業務ロジック（Lambda）と EDI 方言の吸収（B2Bi）を分離し、取引先の増減に変換定義の追加だけで対応できる。</li>
+    <li><strong>同期ワークフローと非同期キューを EventBridge で振り分ける</strong> &#8212; 順序保証や複数ステップが要る受発注は Step Functions に、繁忙期のスパイクを吸収すべき大量処理は SQS（+ DLQ）に流す。EventBridge をハブにすることで、後から購読者（分析・監査・別システム連携）を追加してもプロデューサー側を変えずに済む疎結合を保てる。</li>
+    <li><strong>受発注データは Aurora、処理ステータスは DynamoDB と役割で分ける</strong> &#8212; トランザクション整合性と既存 SQL 資産の移行性が要る受発注本体は Aurora（Multi-AZ）、高頻度に更新され参照キーが固定の処理ステータスは DynamoDB に置く。データ特性に合わせてストアを使い分けることで、それぞれのスケーリング特性とコスト効率を最大化する。</li>
+    <li><strong>取引先認証情報・暗号化・最小権限を最初から多層で設計する</strong> &#8212; 取引先の AS2/SFTP 認証情報は Secrets Manager に隔離し、S3/Aurora/DynamoDB/SQS は KMS CMK で保管時暗号化、Lambda 等は IAM 最小権限ロールで動かす。EDI は企業間取引データそのものを扱うため、移行を機に「点」の対策ではなく層ごとの防御を組み込む。</li>
+  </ul>
+</div>
+
+<div class="section">
+  <h2>コスト概算</h2>
+  <p class="cost-note">ap-northeast-1 (東京) リージョン基準の月額概算。実際の費用は利用量により変動します。<br>
+  為替レート: $1 = 150円（参考値）</p>
+  <table>
+    <thead>
+      <tr><th>サービス</th><th>構成</th><th>Dev (月額)</th><th>Prod (月額)</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Transfer Family</td><td>AS2/SFTP エンドポイント（時間課金 + 転送量）</td><td>$30 (4,500円)</td><td>$60 (9,000円)</td></tr>
+      <tr><td>B2B Data Interchange</td><td>EDI 変換（処理ドキュメント数課金）</td><td>$10 (1,500円)</td><td>$50 (7,500円)</td></tr>
+      <tr><td>S3 (landing + アーカイブ)</td><td>~50GB + リクエスト + Glacier</td><td>$3 (450円)</td><td>$8 (1,200円)</td></tr>
+      <tr><td>Lambda (処理 + API)</td><td>Dev: ~50万req、Prod: ~1,000万req（ARM）</td><td>$1 (150円)</td><td>$25 (3,750円)</td></tr>
+      <tr><td>Step Functions</td><td>Standard、状態遷移課金</td><td>$2 (300円)</td><td>$20 (3,000円)</td></tr>
+      <tr><td>SQS (+ DLQ)</td><td>100万〜1,000万msg</td><td>$0 (0円)</td><td>$5 (750円)</td></tr>
+      <tr><td>EventBridge</td><td>カスタムイベント発行</td><td>$1 (150円)</td><td>$5 (750円)</td></tr>
+      <tr><td>Aurora Serverless v2</td><td>Dev: 0.5-2 ACU、Prod: 2-8 ACU Multi-AZ</td><td>$60 (9,000円)</td><td>$320 (48,000円)</td></tr>
+      <tr><td>DynamoDB (On-Demand)</td><td>処理ステータス + PITR</td><td>$5 (750円)</td><td>$40 (6,000円)</td></tr>
+      <tr><td>API Gateway (HTTP)</td><td>リクエスト課金</td><td>$2 (300円)</td><td>$15 (2,250円)</td></tr>
+      <tr><td>Direct Connect</td><td>ポート時間（1Gbps Hosted 想定）+ 転送量</td><td>$220 (33,000円)</td><td>$300 (45,000円)</td></tr>
+      <tr><td>Site-to-Site VPN</td><td>VPN 接続時間（冗長経路）</td><td>$36 (5,400円)</td><td>$36 (5,400円)</td></tr>
+      <tr><td>Transit Gateway</td><td>アタッチメント時間 + 転送量</td><td>$40 (6,000円)</td><td>$80 (12,000円)</td></tr>
+      <tr><td>CloudWatch / SNS</td><td>ログ取り込み + アラーム + 通知</td><td>$3 (450円)</td><td>$15 (2,250円)</td></tr>
+      <tr><td>KMS / Secrets Manager</td><td>CMK 1個 + シークレット数個</td><td>$3 (450円)</td><td>$5 (750円)</td></tr>
+      <tr class="cost-total"><td colspan="2"><strong>合計</strong></td><td><strong>$416 (約62,400円)</strong></td><td><strong>$984 (約147,600円)</strong></td></tr>
+    </tbody>
+  </table>
+  <h3>前提条件</h3>
+  <p>Dev は単一 AZ・少数取引先での検証規模（月 ~50万リクエスト）、Prod は中規模 EDI（複数取引先・月 ~1,000万リクエスト / 数万受発注）を想定。Direct Connect は 1Gbps の Hosted Connection（パートナー経由）でポート費が支配的。Aurora は Serverless v2 で Dev は最小、Prod は Multi-AZ 中負荷を想定。Transfer Family・B2B Data Interchange は処理量に応じた従量課金で試算。</p>
+  <h3>コスト最適化のポイント</h3>
+  <p>Direct Connect が固定費の中心になるため、移行完了後にトラフィックが小さければ <strong>VPN 単独構成へ縮退</strong>して DX を解約する選択も検討する（並行稼働期だけ DX を借りる）。Aurora はアクセスパターン安定後に Reserved Instance / Provisioned + Auto Scaling へ切替で 2〜4 割削減。Lambda は ARM (Graviton) で ~20% 単価削減。S3 は Intelligent-Tiering と Glacier ライフサイクルでアーカイブコストを圧縮。B2B Data Interchange はバッチ集約で処理ドキュメント単価を下げる。DynamoDB はステータス更新が安定したら On-Demand → Provisioned へ。</p>
+</div>
+
+<div class="section">
+  <h2>学習ポイント</h2>
+  <ul class="learning-points">
+    <li><strong>レガシー移行はストラングラーパターンで「切り戻せる並行稼働」を確保する</strong> &#8212; 基幹に近いシステムほど一斉切替（ビッグバン）の失敗コストは致命的になる。新旧を接続して機能単位で少しずつ移し、各段階で旧系へ戻せる状態を保つことで、本番データでの検証とリスク分散を両立できる。ハイブリッド接続（DX/VPN+TGW）はこの並行稼働を支える土台であり、移行の本質的な技術要件。</li>
+    <li><strong>業界標準フォーマットの変換はマネージドサービスへ外出しして業務ロジックと分離する</strong> &#8212; EDI の X12/EDIFACT のように方言が多く取引先依存のフォーマット変換を自前実装すると、取引先追加のたびにコード改修が必要になり保守が破綻しやすい。変換定義（B2Bi）と業務処理（Lambda）を分離すれば、変更の影響範囲が局所化され、新規取引先の追加が設定作業に収まる。関心の分離は普遍的に効く。</li>
+    <li><strong>イベントハブ（EventBridge）を中心に据えると後付けの拡張が安くなる</strong> &#8212; プロデューサーとコンシューマーをイベントバスで疎結合にすると、監査・分析・別システム連携といった購読者を後から追加してもプロデューサー側を変更せずに済む。最初に拡張余地を残す設計投資が、後の機能追加速度を決める。</li>
+    <li><strong>データはトランザクション特性で RDB と KVS を使い分ける</strong> &#8212; 整合性・SQL 資産の移行性が要る本体データは RDB（Aurora）、高頻度更新・固定キー参照の状態管理は KVS（DynamoDB）が向く。一つのストアに全部押し込まず、データ特性ごとに最適なストアを選ぶことが、スケーラビリティとコスト効率の両取りにつながる。</li>
+    <li><strong>企業間データを扱う移行は「層」でのセキュリティ設計を移行の初期から組み込む</strong> &#8212; 認証情報の隔離（Secrets Manager）、保管時暗号化（KMS）、最小権限（IAM）、ネットワーク分離（VPC/専用線）を組み合わせて初めて多層防御になる。移行後に後付けすると改修コストが跳ね上がるため、Infrastructure as Code として最初から各層に織り込むのがセオリー。</li>
+  </ul>
+</div>
+
+<p class="updated">生成: company-diagram-v2 (draw.io XML 直接生成方式 / MCP不使用) / EDI 受発注システム オンプレミス→AWS 移行（ハイブリッド・段階移行）</p>
+</body>
+</html>

--- a/docs/diagrams/edi-onprem-to-aws-migration.yaml
+++ b/docs/diagrams/edi-onprem-to-aws-migration.yaml
@@ -1,0 +1,437 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  EDI 受発注システム オンプレミス → AWS 移行構成。
+  Transfer Family (AS2/SFTP) で取引先から EDI を受信し、S3 に landing。
+  B2B Data Interchange で X12/EDIFACT を JSON へ変換し、EventBridge 経由で
+  Step Functions / Lambda / SQS による受発注処理ワークフローを駆動、
+  Aurora (Multi-AZ) と DynamoDB に書き込む。Direct Connect / Site-to-Site VPN +
+  Transit Gateway によりオンプレのレガシー受発注システムと移行期に並行稼働する。
+  実値は # TODO コメントで明示（本テンプレートは構成図と整合した骨子）。
+
+Parameters:
+  EnvName:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, prod]
+    Description: 環境名（dev / prod）。Aurora のインスタンス数・容量の出し分けに使用。
+  VpcCidr:
+    Type: String
+    Default: 10.0.0.0/16 # TODO: 実 CIDR に合わせる
+  OnPremCidr:
+    Type: String
+    Default: 192.168.0.0/16 # TODO: オンプレ DC の CIDR
+  CustomerGatewayIp:
+    Type: String
+    Default: 203.0.113.10 # TODO: オンプレ側 VPN 終端のグローバル IP
+
+Mappings:
+  EnvMap:
+    dev:
+      AuroraInstanceClass: db.serverless
+      AuroraMinAcu: 0.5
+      AuroraMaxAcu: 2
+    prod:
+      AuroraInstanceClass: db.serverless
+      AuroraMinAcu: 2
+      AuroraMaxAcu: 8
+
+Resources:
+  # ===== ネットワーク（VPC / Multi-AZ） =====
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "edi-${EnvName}-vpc"
+
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.0.1.0/24 # TODO
+      AvailabilityZone: !Select [0, !GetAZs ""]
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.0.2.0/24 # TODO
+      AvailabilityZone: !Select [1, !GetAZs ""]
+
+  # ===== ハイブリッド接続（Transit Gateway + Site-to-Site VPN） =====
+  # Direct Connect 本体（DX Gateway / VIF）はアカウント横断・物理回線手配のため
+  # 別スタック管理を想定。ここでは TGW と VPN による接続定義のみ記述。
+  TransitGateway:
+    Type: AWS::EC2::TransitGateway
+    Properties:
+      Description: !Sub "edi-${EnvName}-tgw (DX/VPN 集約)"
+      AmazonSideAsn: 64512 # TODO
+
+  TgwVpcAttachment:
+    Type: AWS::EC2::TransitGatewayVpcAttachment
+    Properties:
+      TransitGatewayId: !Ref TransitGateway
+      VpcId: !Ref Vpc
+      SubnetIds:
+        - !Ref PrivateSubnetA
+        - !Ref PrivateSubnetB
+
+  CustomerGateway:
+    Type: AWS::EC2::CustomerGateway
+    Properties:
+      Type: ipsec.1
+      BgpAsn: 65000 # TODO: オンプレ側 ASN
+      IpAddress: !Ref CustomerGatewayIp
+
+  SiteToSiteVpn:
+    Type: AWS::EC2::VPNConnection
+    Properties:
+      Type: ipsec.1
+      CustomerGatewayId: !Ref CustomerGateway
+      TransitGatewayId: !Ref TransitGateway
+      StaticRoutesOnly: false
+
+  # ===== セキュリティ（KMS / Secrets Manager / IAM） =====
+  EdiKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: EDI データ保管時暗号化（S3 / Aurora / DynamoDB / SQS）
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnableRoot
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+
+  PartnerCredentialsSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "edi-${EnvName}-partner-credentials"
+      Description: 取引先の AS2/SFTP 認証情報
+      KmsKeyId: !Ref EdiKmsKey
+
+  # ===== ファイル基盤（S3） =====
+  EdiLandingBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "edi-${EnvName}-landing-${AWS::AccountId}"
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: !Ref EdiKmsKey
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: ArchiveRawEdi
+            Status: Enabled
+            Transitions:
+              - StorageClass: GLACIER
+                TransitionInDays: 90 # TODO: アーカイブ要件に合わせる
+
+  # ===== EDI 受信（Transfer Family AS2/SFTP） =====
+  TransferServer:
+    Type: AWS::Transfer::Server
+    Properties:
+      Protocols:
+        - SFTP
+        - AS2
+      Domain: S3
+      EndpointType: VPC
+      EndpointDetails:
+        VpcId: !Ref Vpc
+        SubnetIds:
+          - !Ref PrivateSubnetA
+          - !Ref PrivateSubnetB
+      IdentityProviderType: SERVICE_MANAGED
+      Tags:
+        - Key: Name
+          Value: !Sub "edi-${EnvName}-transfer"
+
+  # ===== EDI 変換（B2B Data Interchange） =====
+  # B2Bi の Profile / Capability / Transformer / Partnership は
+  # AWS::B2BI::* リソースで定義する。X12/EDIFACT → JSON 変換を担う。
+  B2biProfile:
+    Type: AWS::B2BI::Profile
+    Properties:
+      Name: !Sub "edi-${EnvName}-profile"
+      Phone: "000-0000-0000" # TODO
+      BusinessName: "EDI Migration Org" # TODO
+      Logging: ENABLED
+
+  B2biTransformer:
+    Type: AWS::B2BI::Transformer
+    Properties:
+      Name: !Sub "edi-${EnvName}-x12-to-json"
+      Status: active
+      # TODO: EdiType (X12 / EDIFACT) と OutputConversion (JSON) を指定
+
+  # ===== 連携・オーケストレーション（EventBridge / SQS / Lambda / Step Functions） =====
+  OrderEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: !Sub "edi-${EnvName}-order-bus"
+
+  OrderProcessingDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "edi-${EnvName}-order-dlq"
+      KmsMasterKeyId: !Ref EdiKmsKey
+
+  OrderProcessingQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "edi-${EnvName}-order-queue"
+      KmsMasterKeyId: !Ref EdiKmsKey
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt OrderProcessingDlq.Arn
+        maxReceiveCount: 5
+
+  OrderProcessingFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "edi-${EnvName}-order-processor"
+      Runtime: python3.12
+      Architectures: [arm64]
+      Handler: index.handler
+      Timeout: 60
+      MemorySize: 512
+      Role: !GetAtt OrderProcessingRole.Arn
+      Code:
+        ZipFile: |
+          def handler(event, context):
+              # TODO: B2Bi 変換済み受発注 JSON を Aurora / DynamoDB に反映
+              return {"status": "ok"}
+
+  OrderApiFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "edi-${EnvName}-order-api"
+      Runtime: python3.12
+      Architectures: [arm64]
+      Handler: index.handler
+      Timeout: 30
+      MemorySize: 512
+      Role: !GetAtt OrderProcessingRole.Arn
+      Code:
+        ZipFile: |
+          def handler(event, context):
+              # TODO: 移行先 受発注 API バックエンド（Aurora 照会）
+              return {"statusCode": 200, "body": "{}"}
+
+  OrderWorkflow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub "edi-${EnvName}-order-workflow"
+      RoleArn: !GetAtt StepFunctionsRole.Arn
+      DefinitionString: !Sub |
+        {
+          "Comment": "受発注処理ワークフロー",
+          "StartAt": "Validate",
+          "States": {
+            "Validate": { "Type": "Task", "Resource": "${OrderProcessingFunction.Arn}", "Next": "Persist" },
+            "Persist":  { "Type": "Task", "Resource": "${OrderProcessingFunction.Arn}", "End": true }
+          }
+        }
+
+  # EventBridge ルール: B2Bi 変換完了イベント → Step Functions / SQS
+  B2biCompletedToWorkflowRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventBusName: !Ref OrderEventBus
+      EventPattern:
+        source: ["aws.b2bi"] # TODO: 実イベントソースに合わせる
+        detail-type: ["EDI Transformation Completed"]
+      Targets:
+        - Id: ToWorkflow
+          Arn: !Ref OrderWorkflow
+          RoleArn: !GetAtt EventBridgeInvokeRole.Arn
+        - Id: ToQueue
+          Arn: !GetAtt OrderProcessingQueue.Arn
+
+  OrderQueueEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn: !GetAtt OrderProcessingQueue.Arn
+      FunctionName: !Ref OrderProcessingFunction
+      BatchSize: 10
+
+  # ===== データ（Aurora Multi-AZ / DynamoDB） =====
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      Engine: aurora-postgresql
+      EngineMode: provisioned
+      DatabaseName: orders
+      MasterUsername: !Sub "{{resolve:secretsmanager:${PartnerCredentialsSecret}:SecretString:dbuser}}" # TODO
+      StorageEncrypted: true
+      KmsKeyId: !Ref EdiKmsKey
+      ServerlessV2ScalingConfiguration:
+        MinCapacity: !FindInMap [EnvMap, !Ref EnvName, AuroraMinAcu]
+        MaxCapacity: !FindInMap [EnvMap, !Ref EnvName, AuroraMaxAcu]
+
+  AuroraInstanceA:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: db.serverless
+      Engine: aurora-postgresql
+
+  AuroraInstanceB:
+    Type: AWS::RDS::DBInstance
+    Condition: IsProd
+    Properties:
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: db.serverless
+      Engine: aurora-postgresql
+
+  ProcessingStateTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "edi-${EnvName}-processing-state"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: orderId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: orderId
+          KeyType: HASH
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !Ref EdiKmsKey
+        SSEType: KMS
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
+  # ===== 社内 API（API Gateway） =====
+  OrderApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub "edi-${EnvName}-order-api"
+      ProtocolType: HTTP
+
+  # ===== 監視・通知（CloudWatch / SNS） =====
+  OpsAlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "edi-${EnvName}-ops-alerts"
+      KmsMasterKeyId: !Ref EdiKmsKey
+
+  DlqDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "edi-${EnvName}-order-dlq-depth"
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt OrderProcessingDlq.QueueName
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref OpsAlertTopic
+
+  # ===== IAM（最小権限ロール） =====
+  OrderProcessingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: order-processing-least-privilege
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: [sqs:ReceiveMessage, sqs:DeleteMessage, sqs:GetQueueAttributes]
+                Resource: !GetAtt OrderProcessingQueue.Arn
+              - Effect: Allow
+                Action: [dynamodb:PutItem, dynamodb:UpdateItem, dynamodb:GetItem]
+                Resource: !GetAtt ProcessingStateTable.Arn
+              - Effect: Allow
+                Action: [kms:Decrypt, kms:GenerateDataKey]
+                Resource: !GetAtt EdiKmsKey.Arn
+              - Effect: Allow
+                Action: [secretsmanager:GetSecretValue]
+                Resource: !Ref PartnerCredentialsSecret
+
+  StepFunctionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: invoke-order-lambda
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt OrderProcessingFunction.Arn
+
+  EventBridgeInvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: start-order-workflow
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource: !Ref OrderWorkflow
+
+Conditions:
+  IsProd: !Equals [!Ref EnvName, prod]
+
+Outputs:
+  TransferServerId:
+    Description: Transfer Family サーバー ID（取引先 AS2/SFTP 接続先）
+    Value: !Ref TransferServer
+  LandingBucketName:
+    Description: EDI raw landing / アーカイブ用 S3 バケット
+    Value: !Ref EdiLandingBucket
+  OrderApiEndpoint:
+    Description: 移行先 受発注 API エンドポイント
+    Value: !Sub "https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com"
+  AuroraClusterEndpoint:
+    Description: 受発注 DB（Aurora Multi-AZ）書き込みエンドポイント
+    Value: !GetAtt AuroraCluster.Endpoint.Address
+  TransitGatewayId:
+    Description: オンプレ DC とのハイブリッド接続を集約する Transit Gateway
+    Value: !Ref TransitGateway

--- a/docs/diagrams/index.html
+++ b/docs/diagrams/index.html
@@ -79,6 +79,17 @@ h1 { font-size:1.5rem; margin-bottom:8px; }
 <!-- ▲ 検索・フィルタ ここまで -->
 
 <div class="grid">
+  <a href="./edi-onprem-to-aws-migration.html" class="card">
+    <div class="card-body">
+      <div class="card-title">EDI 受発注システム オンプレミス→AWS 移行構成</div>
+      <div class="card-meta">
+        <span class="tag tag-project">EDI 受発注移行</span>
+        <span class="tag tag-area">ハイブリッド / サーバーレス</span>
+      </div>
+      <div class="card-desc">既存 EDI/VAN を Transfer Family + B2B Data Interchange + EventBridge/SQS/Lambda/Step Functions/Aurora へ移行。Direct Connect/VPN + Transit Gateway でレガシーと並行稼働するストラングラー型ハイブリッド構成（draw.io v2 方式）</div>
+      <div class="card-date">2026-06-13</div>
+    </div>
+  </a>
   <a href="./cc-sier-webapp-aws-migration.html" class="card">
     <img class="card-thumb" src="./cc-sier-webapp-aws-migration.png" alt="CC-SIer WebApp AWS Migration (Phase 4)">
     <div class="card-body">


### PR DESCRIPTION
## 概要

`/company-diagram-v2`（draw.io XML 方式）の**初の本番実行**。**EDI受発注システムのオンプレミス→AWS移行構成図**を生成しました。

- 図名: `edi-onprem-to-aws-migration`
- 図URL（マージ後）: https://sas-sasao.github.io/cc-sier-organization/diagrams/edi-onprem-to-aws-migration.html

## アーキテクチャ

- **受信**: 取引先 →（AS2/SFTP）→ AWS Transfer Family → S3（EDI raw landing）
- **変換・処理**: S3 → AWS B2B Data Interchange（X12/EDIFACT→JSON）→ EventBridge → SQS/Lambda/Step Functions → Aurora / DynamoDB
- **社内API**: API Gateway + Lambda
- **ハイブリッド（段階移行・ストラングラー型）**: 既存EDI/VAN・レガシー受発注 ↔ Direct Connect（主）/ Site-to-Site VPN（冗長）↔ Transit Gateway ↔ VPC
- **監視/セキュリティ**: CloudWatch / SNS / IAM / KMS / Secrets Manager

## 生成物

- `docs/diagrams/edi-onprem-to-aws-migration.drawio`（draw.io XML・MCP不使用）
- `docs/diagrams/edi-onprem-to-aws-migration.html`（必須7セクション）
- `docs/diagrams/edi-onprem-to-aws-migration.yaml`（CloudFormation・437行）
- `docs/diagrams/edi-onprem-to-aws-migration-iac.html`（IaCビューア）
- `docs/diagrams/index.html`（カード追記・件数はJS動的再計算）

## 3層レビュー結果

| ゲート | 結果 | retry |
|---|---|---|
| L0① validate_drawio.py（XML構造+AWS4シェイプ） | **PASS**（無効シェイプなし） | 0 |
| L0② review-drawio.js（エッジ貫通） | **PASS**（貫通0件） | 0 |
| L1 構造ゲート（7セクション/コスト/学習ポイント/index） | **PASS** | 0 |
| L2 独立レビュー（fresh general-purpose） | **composite 1.00 / pass**（s1-s6 全1.00・致命軸クリア） | 0 |

L2 reviewer は EDI移行アーキテクチャの技術的妥当性（Transfer Family/B2B DI/Direct Connect ハイブリッド）も確認済み。

## 補足

- **v2 は auto-merge なし**（人手レビュー用）。
- 無関係な作業外ファイル（`AGENTS.md` / daily-digest task-log）は本PRに含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
