### PR TITLE
docs: 日次レポート 2026-06-14 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-06-14-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-06-14-today.md
@@ -1,0 +1,81 @@
+# domain-tech-collection 活動レポート — 日次（2026-06-14）
+
+> 生成日時: 2026-06-14 10:00 JST | 生成者: SAS-Sasao | 期間: 2026-06-14（当日）
+
+## エグゼクティブサマリー
+
+本日は新規 Skill **`/company-sheet`**（壁打ちで中間表現 YAML を確定 → 決定論的に xlsx 生成 → 3層レビュー → PR auto-merge）を設計・実装し、その場で初回実運用まで一周させた。実運用では EDI受発注 AWS移行(prod) の月額コスト試算 Excel（約 ¥34万/月）を生成し、L0/L1/L2 をすべて通過（L2 composite 0.99）。さらに実運用中に L0 機械レビューの範囲式パース false-positive を発見し、その教訓を Skill リファレンスへ即日フィードバックした（「使って気づく→Skill 改善」の継続学習サイクルが 1 日で成立）。並行して日次ダイジェスト（2026-06-14）が agent-teams で自動生成済み。未完了の懸念は特になし。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 11 回 |
+| ツール実行数（合計・概算） | 688 回 |
+| 作成・編集ファイル数 | 12 件（docs 配下 git tracked） |
+| 完了タスク数 | 2 件（task-log） + プラグイン開発 PR 2 件 |
+| オープンIssue数（当日新規） | 2 件（#580, #583） |
+| クローズIssue数（当日） | 0 件 |
+| マージ PR数（当日） | 3 件（#581, #582, #584） |
+
+## 完了タスク
+
+- **[direct]** /company-sheet で EDI受発注 AWS移行の月額コスト試算 Excel を作成 → 成果物: `docs/office/aws-cost-estimate.xlsx`、`.companies/domain-tech-collection/docs/research/sheet-aws-cost-estimate.yaml`（L0 pass / L1 pass / L2 0.99、PR #582 / Issue #583）
+- **[agent-teams]** 日次ダイジェスト自動生成（daily-digest-automation.yml Phase 2-5,8）→ 成果物: `docs/daily-digest/2026-06-14.md`、`docs/daily-digest/index.html`（Issue #580）
+
+### プラグイン開発（task-log 対象外・PR）
+
+- **[plugin]** 新規 Skill `/company-sheet` 追加（SKILL.md + references 2本、plugins↔.claude 同期、artifact-placement/CLAUDE/README 追記）→ PR #581
+- **[plugin]** `/company-sheet` L0 範囲式パースの注意を追記（実運用の教訓フィードバック）→ PR #584
+
+## 進行中タスク
+
+- **[direct]** /company-cycle today（本レポート生成中）
+
+## 作成・更新された成果物
+
+**research 室**
+- `docs/research/sheet-aws-cost-estimate.yaml`（中間表現 YAML 設計図）
+- `docs/office/aws-cost-estimate.xlsx`（試算 xlsx・DL用）
+
+**secretary 室**
+- 本レポート
+
+**Pages 配信（docs/）**
+- `docs/daily-digest/2026-06-14.md` + `index.html`
+- `docs/diagrams/edi-onprem-to-aws-migration.{drawio,html,yaml,iac.html}` + `index.html`
+- `docs/index.html` / `docs/insights/index.html`
+
+## Issue 動向
+
+### クローズされたIssue（期間内）
+- （なし）
+
+### 新規オープンのIssue（期間内）
+- #583 [domain-tech-collection] Excel試算表 aws-cost-estimate
+- #580 [domain-tech-collection] 日次ダイジェスト 2026-06-14 (日) - auto
+
+## 会話トピック
+
+### セッション別の依頼内容
+- **セッション b00362ee**（/company-sheet 設計〜実装）
+  - 新規 Skill `/company-sheet` の作成（前半=対話/後半=自動の二層、中間表現 YAML 承認ゲート、9 Phase + L0/L1/L2）
+  - SKILL.md 骨子の承認 → 本文作成 → plugins/.claude 同期 → PR #581 → マージ
+  - `/company-sheet` 初回実運用（AWS月額コスト試算 / research 部署）→ PR #582 → マージ
+  - 実運用で発見した L0 範囲式パースの教訓を Skill へフィードバック → PR #584 → マージ
+- **セッション 83a6412c**（環境設定・MCP 接続確認）
+  - `/mcp`（aws-knowledge-mcp-server 再接続確認）、`/effort` 設定
+
+### ファイル生成を伴わなかったやり取り
+- xlsx 純正スキル不在環境での openpyxl 代替方針の確認（壁打ち）
+- 試算表の前提（為替・Direct Connect 帯域・Aurora 構成）の赤入れ往復（Phase 2 壁打ち）
+
+## 次のアクション候補
+
+1. **`/company-sheet` の dev 環境シート追加 or 感度分析シート**（根拠: L2 s5 で「為替レンジ感度分析」「概算項目の精緻化」が改善提案として挙がった）
+2. **artifact-placement の Office 行運用の定着確認**（根拠: 新設した `docs/office/` 配置が今後の試算表でも一貫するか）
+3. **EDI試算の実単価精緻化**（根拠: Lambda/StepFunctions/SQS/DynamoDB を概算ラム金で置いており、実トランザクション量から分解する余地）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
/company-cycle today Phase 1 で生成した日次活動レポート。

- 当日: /company-sheet 新規追加→初回実運用→教訓フィードバックの一周、日次ダイジェスト自動生成
- 統計: 11 セッション / 約688ツール実行 / merged PR 3件(#581,#582,#584)
- レポート Issue: #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)