### PR TITLE
fix: daily-digest workflow の Task subagent バックグラウンド化による早期終了を修正

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260711-202500-daily-digest-workflow-fix.md
+++ b/.companies/domain-tech-collection/.task-log/20260711-202500-daily-digest-workflow-fix.md
@@ -1,0 +1,56 @@
+---
+task_id: "20260711-202500-daily-digest-workflow-fix"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: in-progress
+mode: "direct"
+started: "2026-07-11T20:25:00+09:00"
+completed: ""
+request: "Daily Digest Automation (07:30 JST) というgit hub actinpsが7/2から失敗している。原因をちょうさしてして修正して"
+issue_number: null
+pr_number: null
+subagents: []
+l0_gate: null
+l0_retries: 0
+l1_gate: null
+l1_retries: 0
+l2_composite: null
+l2_retries: 0
+---
+
+## 実行計画
+
+- **実行モード**: direct
+- **アサインされたロール**: secretary（調査・修正を直接実施）
+- **参照したマスタ**: なし（リポジトリ infra 修正のため）
+- **判断理由**: GitHub Actions 障害調査は run ログの直接解析が最短のため direct 実行
+
+## エージェント作業ログ
+
+### [2026-07-11 20:25] secretary
+受付: daily-digest-automation.yml が 2026-07-02 以降 10 日連続失敗している原因調査と修正
+
+### [2026-07-11 20:30] secretary
+調査結果:
+- 全失敗 run が「Verify output & enforce scope」step で `MD ファイル未生成` により fail
+- Claude Code Action 自体は num_turns=8 / 約 80 秒 / is_error=false で「成功」終了
+- 最後の成功 run (6/30) は CLI v2.1.197 / 14 turns / 19.5 分
+- 最初の失敗 run (7/1 夜 = 7/2 分) から CLI が v2.1.198 に自動更新されていた
+
+### [2026-07-11 20:40] secretary
+根本原因を特定:
+- Claude Code CLI 2.1.198+ で Task subagent がバックグラウンド実行デフォルト化
+  （changelog 2.1.202 で明文化）
+- headless SDK モードではメインエージェントが subagent 完了を待たずに end_turn
+  → セッションが即終了し MD 未生成のまま "success" になる
+- 既知バグ: anthropics/claude-code#23909, anthropics/claude-code-action#1124
+
+### [2026-07-11 20:45] secretary
+修正:
+1. job-level env に `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"` を追加
+   （公式 env var、subagent spawn をフォアグラウンドに固定）
+2. prompt の Phase 2 に「バックグラウンド実行禁止・2 agent の完了を待つ」を明記
+3. ヘッダーコメントの既知の課題一覧に本件を追記
+
+他 workflow への影響確認: daily-todo-sync / daily-kanban-sync 等は正常稼働中
+（Task を実際に並列 spawn するのは daily-digest のみ）のため修正対象外。

--- a/.github/workflows/daily-digest-automation.yml
+++ b/.github/workflows/daily-digest-automation.yml
@@ -25,6 +25,11 @@ name: Daily Digest Automation (07:30 JST)
 #       認証は input parameter と job-level env の両方で渡す
 #   - git remote 書き換え:
 #       push 前に https://x-access-token:${GH_TOKEN}@... で再設定
+#   - Task subagent のバックグラウンド化（Claude Code CLI 2.1.198+）:
+#       subagent がバックグラウンド実行になり、メインが完了を待たずに
+#       セッション終了 → MD 未生成のまま "success" 扱いになる
+#       (anthropics/claude-code#23909)。
+#       CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 でフォアグラウンド実行を強制
 
 on:
   schedule:
@@ -70,6 +75,10 @@ jobs:
       # issue #690 WebFetch/WebSearch 黙殺対策: DISALLOWED_TOOLS を明示的に空化
       DISALLOWED_TOOLS: ""
       CLAUDE_CODE_DISALLOWED_TOOLS: ""
+      # CLI 2.1.198+ で Task subagent がバックグラウンド実行デフォルトになり、
+      # メインエージェントが subagent 完了前にセッション終了する regression の対策
+      # (2026-07-02 以降の連続失敗の根本原因)。フォアグラウンド実行を強制する。
+      CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
 
     steps:
       # -----------------------------------------------------------------
@@ -195,6 +204,8 @@ jobs:
 
             **Task ツール**で **同一メッセージ内** に 2 つの `general-purpose` agent を並列起動する。
             subagent_type は必ず `"general-purpose"`（tech-researcher 等は WebFetch を持たないため不可）。
+            **バックグラウンド実行は禁止**（`run_in_background` を指定しない）。
+            2 agent の結果が両方返ってくるまで待ってから Phase 3 に進むこと。
 
             ## tech agent への prompt テンプレート
 


### PR DESCRIPTION
## 概要

**Daily Digest Automation (07:30 JST)** が 2026-07-02 以降 10 日連続で失敗していた問題の修正。

## 原因調査

| 観点 | 内容 |
|---|---|
| 失敗箇所 | 全 run が `Verify output & enforce scope` step で「MD ファイル未生成」により fail |
| Claude Action の挙動 | num_turns=8 / 約 80 秒 / is_error=false で「成功」終了（正常時は 14 turns / 約 20 分） |
| 境界 | 最後の成功 6/30 = CLI **v2.1.197**、最初の失敗 7/1 夜 = CLI **v2.1.198**（action が最新 CLI を自動インストール） |

## 根本原因

Claude Code CLI 2.1.198+ で **Task subagent がバックグラウンド実行デフォルト**になった（changelog 2.1.202 で明文化）。headless SDK モードではメインエージェントが Phase 2 の 2 subagent を spawn した直後に end_turn → セッションが subagent 完了を待たずに終了し、MD 未生成のまま success 扱いになる。

既知バグ: anthropics/claude-code#23909 / anthropics/claude-code-action#1124

## 修正内容

1. job-level env に `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"` を追加（公式 env var、subagent をフォアグラウンド実行に固定）
2. prompt Phase 2 に「バックグラウンド実行禁止・2 agent の完了を待つ」を明記（防御的二重化）
3. ヘッダーコメントの既知の課題一覧に本件を追記

## レビュー

- L0/L1/L2: 対象外（workflow infra 修正のため 3 層レビュー付き Skill 成果物ではない）
- 検証: マージ後に workflow_dispatch で実実行して本日分ダイジェスト生成を確認する

## 関連
- task-log: `.companies/domain-tech-collection/.task-log/20260711-202500-daily-digest-workflow-fix.md`
- tracking issue: #274

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)