### PR TITLE
docs: 活動レポート today (2026-07-12) [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-12-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-12-today.md
@@ -1,0 +1,74 @@
+# domain-tech-collection 活動レポート — 日次（today）
+
+> 生成日時: 2026-07-12 16:01 JST | 生成者: SAS-Sasao | 期間: 2026-07-12 〜 2026-07-12
+
+## エグゼクティブサマリー
+
+本日は GitHub Actions 経由の自動運用が中心の一日となった。日次ダイジェスト 2026-07-12（日）が agent-teams 3 エージェント構成で自動生成され、収集 108 件（技術 60 + 小売 48）・L2 composite 0.95 で一発 pass した。前日 #618 で修正した daily-digest workflow（Task subagent バックグラウンド化問題）の修正後初の週末自動実行が成功しており、修正の有効性が確認できた。nightly CLAUDE.md 更新（daily-24h / weekly-7d）も 2 件マージされ、#618 の教訓（`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`）が CLAUDE.md 注意事項に反映された。ローカルセッションは本 /company-cycle 実行のみで、対話的な作業依頼はなかった。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数（ローカル） | 1 回（本 cycle セッション） |
+| 完了タスク数 | 1 件（daily-digest-actions） |
+| 進行中タスク数 | 1 件（本 cycle） |
+| 作成・編集ファイル数（docs 配下） | 4 件 |
+| commit 数（main、本日 JST） | 6 件 |
+| マージ済み PR（本日 JST） | 3 件（#623 / #622 / #599） |
+| オープン Issue（本日新規） | 1 件（#624） |
+| クローズ Issue（本日） | 0 件 |
+
+## 完了タスク
+
+- 【agent-teams】日次ダイジェスト 2026-07-12 自動生成（GitHub Actions 経由）
+  → 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-07-12.md`（108件、技術60+小売48）
+  → L1 pass / L2 composite **0.95**（s2_links=1.00, s6_violations=1.00, s5_dedup=0.85）、retry 0 回
+
+## 進行中タスク
+
+- 【direct】/company-cycle today（本レポートを含むオーケストレーション実行）
+
+## 作成・更新された成果物
+
+**秘書室（daily-digest）**:
+- `.companies/domain-tech-collection/docs/daily-digest/2026-07-12.md` — 日次ダイジェスト MD（PR #623）
+
+**GitHub Pages 配信（docs/）**:
+- `docs/daily-digest/index.html` — ダイジェスト HTML 再生成
+- `docs/index.html` — トップページ更新
+- `docs/insights/index.html` — TodoInsights HTML 更新（daily-insights-sync）
+
+**リポジトリ基盤**:
+- `CLAUDE.md` / `.claude/rules/` — nightly 更新 2 件（#622 daily-24h / #599 weekly-7d）。#618 の教訓「claude-code-action で Task subagent を spawn する workflow は `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"` を job-level env に追加」が注意事項へ反映された
+
+## Issue 動向
+
+### クローズされたIssue（期間内）
+
+- なし
+
+### 新規オープンのIssue（期間内）
+
+- #624 【domain-tech-collection】日次ダイジェスト 2026-07-12 (日) - auto
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- 本日のローカル会話ログは未生成（本 cycle セッションのログはセッション終了時に記録される）
+
+### ファイル生成を伴わなかったやり取り
+
+- なし
+
+## 次のアクション候補
+
+1. **日次ダイジェスト tracking Issue のクローズ運用検討**（根拠: #613〜#624 のダイジェスト Issue が open のまま累積している。生成完了後の自動クローズまたは週次一括クローズのルール化が望ましい）
+2. **workflow 修正 #618 の平日実行確認**（根拠: 週末 2 回の自動実行は成功。平日（月曜）の実行成功を確認して修正の有効性判断を完了させる）
+3. **s5_dedup（重複排除）の改善**（根拠: 本日 L2 で最低スコア 0.85。トライアル西友浦安店・AWS MCP OAuth 等が複数ソースで重複掲載。集約フェーズでの重複検知強化を検討）
+4. **storcon 準備 WBS の週次進捗確認**（根拠: WBS ベースの学習タスクの進捗が今週の task-log に現れていない。/company-today での着手を推奨）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## 変更サマリー

/company-cycle today の Phase 1 (/company-report) で生成した日次活動レポート。

- 対象期間: 2026-07-12（当日）
- 主な内容: 日次ダイジェスト 2026-07-12 自動生成成功（108件、L2 composite 0.95）、nightly CLAUDE.md 更新 2 件（#622/#599）、#618 修正後初の週末自動実行の成功確認

## 情報源

.session-summaries/ | .task-log/ | docs/ git log | GitHub Issues | .conversation-log/

🤖 Generated with [Claude Code](https://claude.com/claude-code)