### PR TITLE
docs: 活動レポート today (2026-07-17) [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-17-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-17-today.md
@@ -1,0 +1,83 @@
+# domain-tech-collection 活動レポート — 日次（today）
+
+> 生成日時: 2026-07-17 21:58 JST | 生成者: SAS-Sasao | 期間: 2026-07-17 〜 2026-07-17
+
+## エグゼクティブサマリー
+
+本日の最大の成果は **/company-diagram-v2（draw.io XML 直接生成方式）の初の実運用**で、オンプレ（Oracle・APP・ストレージ）→ AWS 移行アーキテクチャ構成図を L0①②/L1/L2 の全ゲート通過（L2 composite **0.98**）で完走し、PR #638 が人手レビューを経てマージされた。初回 L0② で VPC 実コンテナのネストによる貫通誤検知 11 件が発生したが、チェッカーの除外ロジック（2 階層上まで）を解析してフラット構造化で解消し、この知見を Issue #639 に Case Bank 向けに記録した。日次ダイジェスト 2026-07-17（金）も Actions で自動生成され（108 件規模の巡回、L2 composite 0.95）、#618 修正後の安定稼働が継続している。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数（ローカル） | 1 回（人間発言 95 / 応答 191 / ツール実行 178） |
+| 完了タスク数 | 2 件（daily-digest-actions / diagram-v2） |
+| 進行中タスク数 | 1 件（本 cycle） |
+| 作成・編集ファイル数（docs 配下） | 9 件 |
+| commit 数（main、本日 JST） | 7 件 |
+| マージ済み PR（本日 JST） | 2 件（#636 / #638） |
+| オープン Issue（本日新規） | 2 件（#637 / #639） |
+| クローズ Issue（本日） | 0 件 |
+
+## 完了タスク
+
+- 【agent-teams-actions】日次ダイジェスト 2026-07-17（金）自動生成
+  → 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-07-17.md`（PR #636）
+  → L1 pass / L2 composite **0.95**（s2_links=1.00, s6_violations=1.00、最弱軸 s3_summary/s5_dedup=0.90）、retry 0
+- 【direct】AWS構成図v2 onprem-to-aws-migration 生成（/company-diagram-v2 初実運用）
+  → 成果物: `docs/diagrams/onprem-to-aws-migration.{drawio,html,yaml}` + iac.html + index カード（PR #638 / Issue #639）
+  → L0① pass / L0② pass（retry 1）/ L1 pass / L2 composite **0.98**（s2_iac=0.90、他 5 軸 1.00）
+  → 図: MGN/DMS/DataSync の 3 移行フロー + DX/VPN ハイブリッド接続 + ALB/EC2/RDS for Oracle/EFS 本番構成（17 アイコン・17 エッジ・5 フロー色）
+
+## 進行中タスク
+
+- 【direct】/company-cycle today（本レポートを含むオーケストレーション実行）
+
+## 作成・更新された成果物
+
+**構成図（docs/diagrams/、Pages 配信）**:
+- `onprem-to-aws-migration.drawio` — draw.io XML（MCP 不使用の直接生成）
+- `onprem-to-aws-migration.html` — 詳細ページ（必須 7 セクション + GraphViewer 埋め込み）
+- `onprem-to-aws-migration.yaml` / `-iac.html` — CFn テンプレート + IaC ビューア
+- `index.html` — カード追記 + 件数 23→24
+
+**秘書室（daily-digest）**:
+- `.companies/domain-tech-collection/docs/daily-digest/2026-07-17.md` — 日次ダイジェスト MD（PR #636）
+
+**GitHub Pages 自動更新**:
+- `docs/daily-digest/index.html` / `docs/index.html` / `docs/insights/index.html`
+
+## Issue 動向
+
+### クローズされたIssue（期間内）
+
+- なし
+
+### 新規オープンのIssue（期間内）
+
+- #639 【domain-tech-collection】AWS構成図v2(drawio) onprem-to-aws-migration
+- #637 【domain-tech-collection】日次ダイジェスト 2026-07-17 (金) - auto
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション e3cd551c**（95発言 / 191応答 / 178ツール実行）
+  - /company-diagram-v2 でオンプレミス環境（Oracle・APP・ストレージ）の AWS 移行構成図を作成してほしい
+  - PR #638 マージ後のブランチ削除・後片付け
+  - /company-cycle 実行（本レポート）
+
+### ファイル生成を伴わなかったやり取り
+
+- PR マージ報告と後片付け依頼（マージ操作自体はユーザーが GitHub 上で実施）
+
+## 次のアクション候補
+
+1. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: Issue #639 に記録した「VPC/サブネットは実コンテナにせずフラット構造 + ラベル表現」は SKILL.md 5.3 の注意書きより踏み込んだ実装知見。`references/drawio/layout-guidelines.md` への追記で次回の初回リトライを 0 にできる）
+2. **diagram-v2 の auto-merge 昇格判断**（根拠: 初実運用が L2 0.98 で完走し人手レビューもマージ済み。SKILL.md 記載の「安定後に auto-merge 化を別途検討」の判断材料が揃い始めた。あと 1-2 回の実運用で判断可能）
+3. **日次ダイジェスト Issue のクローズ運用**（根拠: #613〜#637 の digest Issue が open のまま累積中。前回レポート（07-12）からの継続課題）
+4. **draw.io CLI の導入検討**（根拠: サムネイル PNG が fallback 運用のため index カードが画像なし。CLI 導入で export 正路が有効になる）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## 変更サマリー

/company-cycle today の Phase 1 (/company-report) で生成した日次活動レポート。

- 主な内容: /company-diagram-v2 初実運用（L2 0.98、PR #638 マージ済み）、日次ダイジェスト 2026-07-17 自動生成（L2 0.95）、貫通チェッカー知見の記録（Issue #639）

## 情報源

.session-summaries/ | .task-log/ | docs/ git log | GitHub Issues | .conversation-log/

🤖 Generated with [Claude Code](https://claude.com/claude-code)