### PR TITLE
docs: 活動レポート today 更新版 (2026-07-17 r2) [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-17-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-17-today.md
@@ -1,22 +1,22 @@
 # domain-tech-collection 活動レポート — 日次（today）
 
-> 生成日時: 2026-07-17 21:58 JST | 生成者: SAS-Sasao | 期間: 2026-07-17 〜 2026-07-17
+> 生成日時: 2026-07-17 22:49 JST（21:58 版を更新）| 生成者: SAS-Sasao | 期間: 2026-07-17 〜 2026-07-17
 
 ## エグゼクティブサマリー
 
-本日の最大の成果は **/company-diagram-v2（draw.io XML 直接生成方式）の初の実運用**で、オンプレ（Oracle・APP・ストレージ）→ AWS 移行アーキテクチャ構成図を L0①②/L1/L2 の全ゲート通過（L2 composite **0.98**）で完走し、PR #638 が人手レビューを経てマージされた。初回 L0② で VPC 実コンテナのネストによる貫通誤検知 11 件が発生したが、チェッカーの除外ロジック（2 階層上まで）を解析してフラット構造化で解消し、この知見を Issue #639 に Case Bank 向けに記録した。日次ダイジェスト 2026-07-17（金）も Actions で自動生成され（108 件規模の巡回、L2 composite 0.95）、#618 修正後の安定稼働が継続している。
+本日は 3 本柱の一日となった。第一に **/company-diagram-v2（draw.io XML 直接生成方式）の初の実運用**で、オンプレ（Oracle・APP・ストレージ）→ AWS 移行アーキテクチャ構成図を全ゲート通過（L2 composite **0.98**）で完走し PR #638 がマージされた。初回 L0② の貫通誤検知 11 件はチェッカーの除外ロジック解析とフラット構造化で解消し、知見を Issue #639 と MEMORY.md に記録した。第二に、pixel-agents を題材にした壁打ちから **AI 仮想オフィスの構築設計ドキュメント**を作成（PR #643 マージ済み / Issue #644）。別リポジトリ・Vercel 前提の本格アプリとして技術選定・monorepo 構成・Claude Code hooks 設定を定義し、**CC-SIer 組織の取り込み（部署 = 部屋、ロール = キャラのマスタ駆動生成）をコア要件**に据えた。第三に日次ダイジェスト 2026-07-17（金）が Actions で自動生成され（L2 composite 0.95）、#618 修正後の安定稼働が継続している。
 
 ## 活動統計
 
 | 指標 | 値 |
 |------|-----|
-| セッション数（ローカル） | 1 回（人間発言 95 / 応答 191 / ツール実行 178） |
-| 完了タスク数 | 2 件（daily-digest-actions / diagram-v2） |
-| 進行中タスク数 | 1 件（本 cycle） |
-| 作成・編集ファイル数（docs 配下） | 9 件 |
-| commit 数（main、本日 JST） | 7 件 |
-| マージ済み PR（本日 JST） | 2 件（#636 / #638） |
-| オープン Issue（本日新規） | 2 件（#637 / #639） |
+| セッション数（ローカル） | 1 回（継続セッション、発言 95+ / ツール実行 178+） |
+| 完了タスク数 | 4 件（daily-digest-actions / diagram-v2 / cycle 1回目 / ai-virtual-office-design） |
+| 進行中タスク数 | 1 件（本 cycle 2回目） |
+| 作成・編集ファイル数（docs 配下） | 10 件 |
+| commit 数（main、本日 JST） | 15 件超 |
+| マージ済み PR（本日 JST） | 4 件（#636 / #638 / #641 / #643） |
+| オープン Issue（本日新規） | 4 件（#637 / #639 / #642 / #644） |
 | クローズ Issue（本日） | 0 件 |
 
 ## 完了タスク
@@ -28,6 +28,11 @@
   → 成果物: `docs/diagrams/onprem-to-aws-migration.{drawio,html,yaml}` + iac.html + index カード（PR #638 / Issue #639）
   → L0① pass / L0② pass（retry 1）/ L1 pass / L2 composite **0.98**（s2_iac=0.90、他 5 軸 1.00）
   → 図: MGN/DMS/DataSync の 3 移行フロー + DX/VPN ハイブリッド接続 + ALB/EC2/RDS for Oracle/EFS 本番構成（17 アイコン・17 エッジ・5 フロー色）
+- 【direct】/company-cycle today 1回目（21:58）
+  → 成果物: 本レポート初版（PR #641）+ Case Bank 167 件 / ダッシュボード更新
+- 【direct】AI 仮想オフィス構築設計ドキュメント作成（壁打ち → 設計化）
+  → 成果物: `.companies/domain-tech-collection/docs/research/ai-virtual-office-design.md`（PR #643 / Issue #644）
+  → pixel-agents 分析 / Relay 分離アーキテクチャ（Phase 1 ローカル SSE → Phase 2 Vercel + Supabase Realtime）/ 技術スタック選定 / pnpm monorepo 構成 / Claude Code hooks 設定例 / **CC-SIer 組織取り込み設計（コア要件）** / M0-M3 ロードマップ
 
 ## 進行中タスク
 
@@ -41,8 +46,13 @@
 - `onprem-to-aws-migration.yaml` / `-iac.html` — CFn テンプレート + IaC ビューア
 - `index.html` — カード追記 + 件数 23→24
 
-**秘書室（daily-digest）**:
+**技術リサーチ室（research）**:
+- `.companies/domain-tech-collection/docs/research/ai-virtual-office-design.md` — AI 仮想オフィス構築設計ドキュメント（PR #643）
+
+**秘書室（daily-digest / reports / MEMORY）**:
 - `.companies/domain-tech-collection/docs/daily-digest/2026-07-17.md` — 日次ダイジェスト MD（PR #636）
+- `.companies/domain-tech-collection/docs/secretary/reports/2026-07-17-today.md` — 本レポート（PR #641 → 本 PR で更新）
+- `.companies/domain-tech-collection/docs/secretary/MEMORY.md` — diagram-v2 知見・Actions 自動化定着を追記
 
 **GitHub Pages 自動更新**:
 - `docs/daily-digest/index.html` / `docs/index.html` / `docs/insights/index.html`
@@ -55,6 +65,8 @@
 
 ### 新規オープンのIssue（期間内）
 
+- #644 【domain-tech-collection】AI仮想オフィス構築設計ドキュメント作成
+- #642 【domain-tech-collection】活動レポート 日次 (2026-07-17)
 - #639 【domain-tech-collection】AWS構成図v2(drawio) onprem-to-aws-migration
 - #637 【domain-tech-collection】日次ダイジェスト 2026-07-17 (金) - auto
 
@@ -62,21 +74,25 @@
 
 ### セッション別の依頼内容
 
-- **セッション e3cd551c**（95発言 / 191応答 / 178ツール実行）
+- **セッション e3cd551c**（継続セッション）
   - /company-diagram-v2 でオンプレミス環境（Oracle・APP・ストレージ）の AWS 移行構成図を作成してほしい
-  - PR #638 マージ後のブランチ削除・後片付け
-  - /company-cycle 実行（本レポート）
+  - PR #638 / #641 / #643 マージ後のブランチ削除・後片付け（3 回）
+  - /company-cycle 実行（21:58 と 22:49 の 2 回）
+  - /company 起動 → pixel-agents（AI 仮想オフィス）構築方法論の壁打ち
+  - AI 仮想オフィスを別リポジトリ・Vercel 前提の本格アプリとして設計ドキュメント化（追加要望: CC-SIer 組織の取り込み / 参考リポジトリ URL 掲載）
 
 ### ファイル生成を伴わなかったやり取り
 
+- pixel-agents の仕組み分析と構築アプローチの壁打ち（A: 既製品利用 / B: フォーク / C: 自作の比較 → 別リポジトリ自作 + 組織取り込みの方針に確定）
 - PR マージ報告と後片付け依頼（マージ操作自体はユーザーが GitHub 上で実施）
 
 ## 次のアクション候補
 
-1. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: Issue #639 に記録した「VPC/サブネットは実コンテナにせずフラット構造 + ラベル表現」は SKILL.md 5.3 の注意書きより踏み込んだ実装知見。`references/drawio/layout-guidelines.md` への追記で次回の初回リトライを 0 にできる）
-2. **diagram-v2 の auto-merge 昇格判断**（根拠: 初実運用が L2 0.98 で完走し人手レビューもマージ済み。SKILL.md 記載の「安定後に auto-merge 化を別途検討」の判断材料が揃い始めた。あと 1-2 回の実運用で判断可能）
-3. **日次ダイジェスト Issue のクローズ運用**（根拠: #613〜#637 の digest Issue が open のまま累積中。前回レポート（07-12）からの継続課題）
-4. **draw.io CLI の導入検討**（根拠: サムネイル PNG が fallback 運用のため index カードが画像なし。CLI 導入で export 正路が有効になる）
+1. **AI 仮想オフィスのリポジトリ切り出し**（根拠: 設計ドキュメントがマージ済みで方針確定待ちは Supabase/Realtime 選定のみ。`/company-spawn` で ai-virtual-office リポジトリを作成し M0 PoC（hooks → ingest → SSE 最小ループ）に着手できる状態）
+2. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: Issue #639 の「VPC/サブネットはフラット構造 + ラベル表現」を `references/drawio/layout-guidelines.md` に追記すれば次回の初回リトライを 0 にできる）
+3. **diagram-v2 の auto-merge 昇格判断**（根拠: 初実運用が L2 0.98 で完走し人手レビューもマージ済み。あと 1-2 回の実運用で判断可能）
+4. **日次ダイジェスト / レポート Issue のクローズ運用**（根拠: #613〜#644 で open Issue が累積中。完了タスクの Issue は週次一括クローズ等のルール化が望ましい）
+5. **draw.io CLI の導入検討**（根拠: サムネイル PNG が fallback 運用のため index カードが画像なし）
 
 ---
 _このレポートは /company-report Skill によって自動生成されました_


### PR DESCRIPTION
## 変更サマリー

/company-cycle today 2 回目（22:49）のリフレッシュ実行。21:58 版レポートに夕方以降の活動を追記更新。

- 追加反映: AI 仮想オフィス構築設計ドキュメント（PR #643 / Issue #644）、cycle 1 回目の完了、PR #641/#643 マージ
- 統計更新: 完了タスク 2→4 件、マージ PR 2→4 件
- 次のアクション筆頭を「/company-spawn での ai-virtual-office リポジトリ切り出し」に更新

※ 組織ルール「同日ファイルは追記・新規作成しない」に従い同一パスを更新。Issue は #642 へコメント追記（重複 Issue 防止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)