### PR TITLE
docs: 活動レポート today (2026-07-18) [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-18-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-18-today.md
@@ -1,0 +1,81 @@
+# domain-tech-collection 活動レポート — 日次（today）
+
+> 生成日時: 2026-07-18 20:09 JST | 生成者: SAS-Sasao | 期間: 2026-07-18 〜 2026-07-18
+
+## エグゼクティブサマリー
+
+本日の中心成果は **ai-virtual-office 要件定義書 v0.1 の作成・マージ**（PR #648 / Issue #649）。昨日の設計ドキュメントの上位文書として、CC-SIer 理念の継承マッピング（組織 = フロア / 部署 = 部屋 / ロール = キャラ）と `.claude` 設定設計（`npx ai-office setup/teardown/doctor` による hooks の安全導入、9 イベント対応表、dogfooding 構成）を中核章に据えた。これで新リポジトリ切り出し（/company-spawn）に必要な文書 2 点セット（要件定義 + 設計）が揃った。日次ダイジェスト 2026-07-18（土）も Actions で自動生成され L2 composite **0.96** と本週最高値を記録、#618 修正後 8 日連続の安定稼働となった。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数（ローカル） | 1 回（継続セッション累計: 発言 181 / 応答 315 / ツール実行 324） |
+| 完了タスク数 | 2 件（daily-digest-actions / ai-virtual-office-requirements） |
+| 進行中タスク数 | 1 件（本 cycle） |
+| 作成・編集ファイル数（docs 配下） | 5 件 |
+| commit 数（main、本日 JST） | 7 件 |
+| マージ済み PR（本日 JST） | 2 件（#646 / #648） |
+| オープン Issue（本日新規） | 3 件（#647 / #649 / #650） |
+| クローズ Issue（本日） | 0 件 |
+
+## 完了タスク
+
+- 【agent-teams-actions】日次ダイジェスト 2026-07-18（土）自動生成
+  → 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-07-18.md`（PR #646）
+  → L1 pass / L2 composite **0.96**、retry 0
+- 【direct】ai-virtual-office 要件定義書 v0.1 作成
+  → 成果物: `.companies/domain-tech-collection/docs/research/ai-virtual-office-requirements.md`（PR #648 / Issue #649）
+  → 12 章構成: CC-SIer 概念マッピング（§2）/ FR-1〜8（P1-P3）/ NFR-1〜7 / **`.claude` 設定設計（§5: setup CLI・hooks 9 イベント・dogfooding）** / M0-M3 受入基準
+  → secretary セルフ judge: total 0.94
+
+## 進行中タスク
+
+- 【direct】/company-cycle today（本レポートを含むオーケストレーション実行）
+
+## 作成・更新された成果物
+
+**技術リサーチ室（research）**:
+- `ai-virtual-office-requirements.md` — 要件定義書 v0.1（PR #648）。設計ドキュメントと合わせて spawn 用 2 点セット完成
+
+**秘書室（daily-digest）**:
+- `.companies/domain-tech-collection/docs/daily-digest/2026-07-18.md` — 日次ダイジェスト MD（PR #646）
+
+**GitHub Pages 自動更新**:
+- `docs/daily-digest/index.html` / `docs/index.html` / `docs/insights/index.html`
+
+## Issue 動向
+
+### クローズされたIssue（期間内）
+
+- なし
+
+### 新規オープンのIssue（期間内）
+
+- #650 【domain-tech-collection】インタラクションログ 2026-07-18
+- #649 【domain-tech-collection】ai-virtual-office 要件定義書 v0.1 作成
+- #647 【domain-tech-collection】日次ダイジェスト 2026-07-18 (土) - auto
+
+## 会話トピック
+
+### セッション別の依頼内容
+
+- **セッション e3cd551c**（継続セッション）
+  - ai-virtual-office の要件定義を作成したい（別リポジトリ・cc-sier 理念ベース・`.claude` 設定を重視）
+  - PR #648 マージ後の後片付け
+  - /company-cycle 実行（本レポート）
+
+### ファイル生成を伴わなかったやり取り
+
+- なし（本日は要件定義タスクに集中）
+
+## 次のアクション候補
+
+1. **/company-spawn で ai-virtual-office リポジトリ切り出し**（根拠: 要件定義 v0.1 + 設計ドキュメントの 2 点セットが main に揃った。残る確定事項は Supabase/Realtime 選定のみで、M0 PoC には影響しない）
+2. **M0 PoC 着手**（根拠: hooks → ingest → SSE → 最小描画のループを 1 日で検証する計画。App Router の SSE buffering 検証が最初の技術リスク）
+3. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: 前日からの継続。`layout-guidelines.md` 追記で次回リトライ 0 化）
+4. **open Issue の棚卸し**（根拠: #613〜#650 で完了済みタスクの Issue が累積。週次一括クローズのルール化を推奨）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## 変更サマリー

/company-cycle today の Phase 1 (/company-report) で生成した日次活動レポート。

- 主な内容: ai-virtual-office 要件定義書 v0.1 作成・マージ（PR #648）、日次ダイジェスト L2 0.96（今週最高値・8 日連続安定稼働）、spawn 用文書 2 点セット完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)