### PR TITLE
docs: 活動レポート today 更新版 (2026-07-18 r2) [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-18-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-18-today.md
@@ -1,22 +1,22 @@
 # domain-tech-collection 活動レポート — 日次（today）
 
-> 生成日時: 2026-07-18 20:09 JST | 生成者: SAS-Sasao | 期間: 2026-07-18 〜 2026-07-18
+> 生成日時: 2026-07-18 20:51 JST（20:09 版を更新）| 生成者: SAS-Sasao | 期間: 2026-07-18 〜 2026-07-18
 
 ## エグゼクティブサマリー
 
-本日の中心成果は **ai-virtual-office 要件定義書 v0.1 の作成・マージ**（PR #648 / Issue #649）。昨日の設計ドキュメントの上位文書として、CC-SIer 理念の継承マッピング（組織 = フロア / 部署 = 部屋 / ロール = キャラ）と `.claude` 設定設計（`npx ai-office setup/teardown/doctor` による hooks の安全導入、9 イベント対応表、dogfooding 構成）を中核章に据えた。これで新リポジトリ切り出し（/company-spawn）に必要な文書 2 点セット（要件定義 + 設計）が揃った。日次ダイジェスト 2026-07-18（土）も Actions で自動生成され L2 composite **0.96** と本週最高値を記録、#618 修正後 8 日連続の安定稼働となった。
+本日は ai-virtual-office プロジェクトの文書化が大きく前進した一日。第一に **要件定義書 v0.1 の作成・マージ**（PR #648 / Issue #649）— CC-SIer 理念の継承マッピング（組織 = フロア / 部署 = 部屋 / ロール = キャラ）と `.claude` 設定設計（setup CLI・hooks 9 イベント・dogfooding）を中核章に据えた。第二に **AWS ホスティング版の構成図 ai-virtual-office-aws** を /company-diagram-v2 で生成・マージ（PR #653 / Issue #654、L2 composite **0.97**）。API Gateway WebSocket + DynamoDB + Lambda のフルサーバーレス構成で Vercel 案の AWS 翻訳を可視化し、**全ゲート retry 0 で完走**（前回記録した貫通チェッカー知見が有効に機能した初のケース）。これで spawn 用の資料は**要件定義 + 設計 + AWS 構成図の 3 点セット**になった。日次ダイジェスト 2026-07-18（土）も L2 **0.96** と本週最高値を記録、#618 修正後 8 日連続の安定稼働となった。
 
 ## 活動統計
 
 | 指標 | 値 |
 |------|-----|
-| セッション数（ローカル） | 1 回（継続セッション累計: 発言 181 / 応答 315 / ツール実行 324） |
-| 完了タスク数 | 2 件（daily-digest-actions / ai-virtual-office-requirements） |
-| 進行中タスク数 | 1 件（本 cycle） |
-| 作成・編集ファイル数（docs 配下） | 5 件 |
-| commit 数（main、本日 JST） | 7 件 |
-| マージ済み PR（本日 JST） | 2 件（#646 / #648） |
-| オープン Issue（本日新規） | 3 件（#647 / #649 / #650） |
+| セッション数（ローカル） | 1 回（継続セッション累計: 発言 181+ / ツール実行 324+） |
+| 完了タスク数 | 4 件（daily-digest-actions / ai-virtual-office-requirements / cycle 1回目 / diagram-v2 ai-virtual-office-aws） |
+| 進行中タスク数 | 1 件（本 cycle 2回目） |
+| 作成・編集ファイル数（docs 配下） | 11 件 |
+| commit 数（main、本日 JST） | 15 件超 |
+| マージ済み PR（本日 JST） | 4 件（#646 / #648 / #651 / #653） |
+| オープン Issue（本日新規） | 5 件（#647 / #649 / #650 / #652 / #654） |
 | クローズ Issue（本日） | 0 件 |
 
 ## 完了タスク
@@ -28,6 +28,13 @@
   → 成果物: `.companies/domain-tech-collection/docs/research/ai-virtual-office-requirements.md`（PR #648 / Issue #649）
   → 12 章構成: CC-SIer 概念マッピング（§2）/ FR-1〜8（P1-P3）/ NFR-1〜7 / **`.claude` 設定設計（§5: setup CLI・hooks 9 イベント・dogfooding）** / M0-M3 受入基準
   → secretary セルフ judge: total 0.94
+- 【direct】/company-cycle today 1回目（20:09）
+  → 成果物: 本レポート初版（PR #651）+ Case Bank 172 件 / ダッシュボード更新
+- 【direct】AWS構成図v2 ai-virtual-office-aws 生成（/company-diagram-v2 2回目実運用）
+  → 成果物: `docs/diagrams/ai-virtual-office-aws.{drawio,html,yaml}` + iac.html + index カード 24→25（PR #653 / Issue #654）
+  → **全ゲート retry 0**: L0① pass / L0② pass / L1 pass / L2 composite **0.97**（s2_iac=0.80、他 5 軸 1.00）
+  → 図: API GW WebSocket + DynamoDB 接続テーブル + PostToConnection のリアルタイム層、CloudFront/S3/Cognito、VPC 不要フルサーバーレス（15 アイコン・14 エッジ・4 フロー色）
+  → 新知見: WebSocket API は JWT オーソライザ非対応 → Lambda REQUEST オーソライザで Cognito JWT 検証（Issue #654 に記録）
 
 ## 進行中タスク
 
@@ -36,7 +43,13 @@
 ## 作成・更新された成果物
 
 **技術リサーチ室（research）**:
-- `ai-virtual-office-requirements.md` — 要件定義書 v0.1（PR #648）。設計ドキュメントと合わせて spawn 用 2 点セット完成
+- `ai-virtual-office-requirements.md` — 要件定義書 v0.1（PR #648）
+
+**構成図（docs/diagrams/、Pages 配信）**:
+- `ai-virtual-office-aws.{drawio,html,yaml}` + `-iac.html` — AWS サーバーレス構成図（PR #653）
+- `index.html` — カード追記 + 件数 24→25
+
+→ 要件定義 + 設計ドキュメント + AWS 構成図の **spawn 用 3 点セット完成**
 
 **秘書室（daily-digest）**:
 - `.companies/domain-tech-collection/docs/daily-digest/2026-07-18.md` — 日次ダイジェスト MD（PR #646）
@@ -52,6 +65,8 @@
 
 ### 新規オープンのIssue（期間内）
 
+- #654 【domain-tech-collection】AWS構成図v2(drawio) ai-virtual-office-aws
+- #652 【domain-tech-collection】活動レポート 日次 (2026-07-18)
 - #650 【domain-tech-collection】インタラクションログ 2026-07-18
 - #649 【domain-tech-collection】ai-virtual-office 要件定義書 v0.1 作成
 - #647 【domain-tech-collection】日次ダイジェスト 2026-07-18 (土) - auto
@@ -62,19 +77,21 @@
 
 - **セッション e3cd551c**（継続セッション）
   - ai-virtual-office の要件定義を作成したい（別リポジトリ・cc-sier 理念ベース・`.claude` 設定を重視）
-  - PR #648 マージ後の後片付け
-  - /company-cycle 実行（本レポート）
+  - ai-virtual-office を AWS 側で作成する場合の構成図を作成してほしい（/company-diagram-v2）
+  - PR #648 / #651 / #653 マージ後の後片付け（3 回）
+  - /company-cycle 実行（20:09 と 20:51 の 2 回）
 
 ### ファイル生成を伴わなかったやり取り
 
-- なし（本日は要件定義タスクに集中）
+- なし（本日は文書化タスクに集中）
 
 ## 次のアクション候補
 
-1. **/company-spawn で ai-virtual-office リポジトリ切り出し**（根拠: 要件定義 v0.1 + 設計ドキュメントの 2 点セットが main に揃った。残る確定事項は Supabase/Realtime 選定のみで、M0 PoC には影響しない）
+1. **/company-spawn で ai-virtual-office リポジトリ切り出し**（根拠: 要件定義 + 設計 + AWS 構成図の 3 点セットが main に揃い、spawn の準備は完了。残る確定事項は Supabase/Realtime 選定のみで M0 PoC には影響しない）
 2. **M0 PoC 着手**（根拠: hooks → ingest → SSE → 最小描画のループを 1 日で検証する計画。App Router の SSE buffering 検証が最初の技術リスク）
-3. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: 前日からの継続。`layout-guidelines.md` 追記で次回リトライ 0 化）
-4. **open Issue の棚卸し**（根拠: #613〜#650 で完了済みタスクの Issue が累積。週次一括クローズのルール化を推奨）
+3. **diagram-v2 の auto-merge 昇格判断**（根拠: 2 回連続の高スコア完走（0.98 → 0.97）、今回は全ゲート retry 0。次回実運用で判断可能な水準）
+4. **diagram-v2 の貫通チェッカー知見の references 反映**（根拠: MEMORY.md 経由で有効性は実証済み。`layout-guidelines.md` への正式反映で Skill 単体でも retry 0 を再現可能にする）
+5. **open Issue の棚卸し**（根拠: #613〜#654 で完了済みタスクの Issue が累積。週次一括クローズのルール化を推奨）
 
 ---
 _このレポートは /company-report Skill によって自動生成されました_


### PR DESCRIPTION
## 変更サマリー

/company-cycle today 2 回目（20:51）のリフレッシュ実行。20:09 版に夕方以降の活動を追記更新。

- 追加反映: AWS構成図 ai-virtual-office-aws（PR #653 / L2 0.97 / 全ゲート retry 0）、PR #651/#653 マージ
- 統計更新: 完了タスク 2→4 件、マージ PR 2→4 件
- spawn 用 3 点セット（要件定義 + 設計 + AWS 構成図）完成を明記

※ 同日ファイルは同一パス更新・Issue は #652 へコメント方式（重複防止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)