### PR TITLE
feat: ai-virtual-office をスポーン [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260718-212520-spawn-ai-virtual-office.md
+++ b/.companies/domain-tech-collection/.task-log/20260718-212520-spawn-ai-virtual-office.md
@@ -1,0 +1,57 @@
+---
+task_id: "20260718-212520-spawn-ai-virtual-office"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "subagent"
+started: "2026-07-18T21:25:20"
+completed: "2026-07-18T21:35:00"
+request: "ai-virtual-office の切り出し（/company-spawn）。元ファイルは cc-sier にも残しておく"
+issue_number: null
+pr_number: null
+subagents: [devops-coordinator]
+l0_gate: null
+l0_retries: 0
+l1_gate: null
+l1_retries: 0
+l2_composite: null
+l2_retries: 0
+---
+
+## 実行計画
+
+- **実行モード**: subagent（devops-coordinator に委譲）
+- **アサインされたロール**: secretary（受付・パラメータ確定・cc-sier 側記録）+ devops-coordinator（新リポジトリ作成）
+- **参照したマスタ**: projects.md、docs/research/ai-virtual-office-requirements.md（§5.4 .claude 構成・§6 技術スタック）
+- **判断理由**: /company-spawn の定型フロー。ヒアリング 6 問は要件定義 v0.1 と会話文脈から全て導出可能なため確認を省略（Q6 公開設定のみ private を既定選択・可逆）
+
+## エージェント作業ログ
+
+### [2026-07-18 21:25:20] secretary
+受付: ai-virtual-office リポジトリ切り出し。コピー対象 = 要件定義 / 設計 / AWS 構成図（drawio + CFn）、元ファイル温存。Subagent は要件定義 §5.4 の 4 種を新規生成。
+
+### [2026-07-18 21:26:00] secretary → devops-coordinator
+委譲: gh repo create → pnpm monorepo スキャフォールド → docs/design/ コピー + origin.md → .claude/agents/ 4 種生成 → CLAUDE.md / README / .gitignore → 初期コミット & push
+
+### [2026-07-18 21:31:00] devops-coordinator
+完了: https://github.com/SAS-Sasao/ai-virtual-office 作成（初期コミット 10a697e）。設計 4 ファイルコピー（リンク修正のみ・本文無変更・cc-sier 側温存）、Subagent 4 種生成、monorepo 骨格（install なし）。ハマり 2 件を agent-memory に記録: ① 新規クローンに git identity なし → --local 設定で解決 ② クローン直後 master → main へ改名して push。
+
+### [2026-07-18 21:33:00] secretary
+ユーザー指示により公開設定を private → **public** に変更（gh repo edit）。projects.md に proj-ai-virtual-office を登録、task-log 完了更新、PR 作成。
+
+## 成果物
+
+- 新リポジトリ: https://github.com/SAS-Sasao/ai-virtual-office（public、初期コミット 10a697e）
+- `masters/projects.md` — proj-ai-virtual-office 登録（cc-sier 側）
+
+## judge
+
+```yaml
+completeness: 1.00
+accuracy: 0.95
+clarity: 0.95
+total: 0.97
+failure_reason: ""
+judge_comment: "secretary 評価: spawn の全工程完了（リポ作成/設計コピー/Subagent 4種/origin.md/projects.md 登録）。ユーザー追加指示（public 化）も即時反映。devops-coordinator が git identity・default branch の 2 つの環境ハマりを自己解決し agent-memory に記録した点を評価"
+judged_at: "2026-07-18T21:35:00+09:00"
+```

--- a/.companies/domain-tech-collection/.task-log/20260718-212520-spawn-ai-virtual-office.md
+++ b/.companies/domain-tech-collection/.task-log/20260718-212520-spawn-ai-virtual-office.md
@@ -7,8 +7,8 @@ mode: "subagent"
 started: "2026-07-18T21:25:20"
 completed: "2026-07-18T21:35:00"
 request: "ai-virtual-office の切り出し（/company-spawn）。元ファイルは cc-sier にも残しておく"
-issue_number: null
-pr_number: null
+issue_number: 658
+pr_number: 657
 subagents: [devops-coordinator]
 l0_gate: null
 l0_retries: 0

--- a/.companies/domain-tech-collection/masters/projects.md
+++ b/.companies/domain-tech-collection/masters/projects.md
@@ -1,3 +1,14 @@
 # プロジェクト一覧
 
-（まだプロジェクトは定義されていません。`/company-admin` で追加できます。）
+## proj-ai-virtual-office
+
+- **名称**: AI Virtual Office — Claude Code のエージェント活動を CC-SIer 仮想組織のピクセルオフィスとして可視化する Web アプリ
+- **ステータス**: active
+- **実装リポジトリ**: https://github.com/SAS-Sasao/ai-virtual-office（public）
+- **スポーン日**: 2026-07-18
+- **スポーン作業者**: SAS-Sasao
+- **スポーン元コミット**: 646a417adc87c4adcdbca9bc6c7b054c60fe3916
+- **コピーした成果物**: [docs/research/ai-virtual-office-requirements.md → docs/design/requirements.md, docs/research/ai-virtual-office-design.md → docs/design/architecture-design.md, docs/diagrams/ai-virtual-office-aws.drawio → docs/design/aws-architecture.drawio, docs/diagrams/ai-virtual-office-aws.yaml → docs/design/aws-architecture.cfn.yaml]（元ファイルは本リポジトリに温存）
+- **コピーしたSubagent**: [game-engine-dev, pipeline-dev, ui-dev, org-adapter-dev]（要件定義 §5.4 準拠の新規生成）
+- **技術スタック**: TypeScript / Next.js 15 / pnpm monorepo（apps/web + packages/{protocol, relay, cc-sier-adapter}）
+- **次のマイルストーン**: M0 PoC（hooks → ingest → SSE → 最小描画）


### PR DESCRIPTION
## 概要

/company-spawn で ai-virtual-office アプリケーションリポジトリを切り出し。

- **新リポジトリ**: https://github.com/SAS-Sasao/ai-virtual-office（**public**、初期コミット 10a697e）
- 設計成果物 4 点をコピー（要件定義 / 設計 / AWS 構成図 drawio + CFn）— **元ファイルは cc-sier に温存**
- Subagent 4 種を要件定義 §5.4 準拠で新規生成（game-engine-dev / pipeline-dev / ui-dev / org-adapter-dev）
- pnpm monorepo 骨格（apps/web + packages/{protocol, relay, cc-sier-adapter}、install なし）
- トレーサビリティ: 新リポ docs/design/origin.md に記録

## cc-sier 側の変更

- `masters/projects.md` に proj-ai-virtual-office を登録
- spawn task-log

🤖 Generated with [Claude Code](https://claude.com/claude-code)