### PR TITLE
docs: today レポート（2026-07-19）[domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.task-log/20260719-212338-cycle-today.md
+++ b/.companies/domain-tech-collection/.task-log/20260719-212338-cycle-today.md
@@ -1,0 +1,31 @@
+---
+task_id: "20260719-212338-cycle-today"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: in-progress
+mode: "direct"
+started: "2026-07-19T21:23:38"
+completed: ""
+request: "/company-cycle today"
+issue_number: null
+pr_number: null
+subagents: [company-report, company-evolve, company-dashboard]
+l0_gate: null
+l0_retries: 0
+l1_gate: null
+l1_retries: 0
+l2_composite: null
+l2_retries: 0
+---
+
+## 実行計画
+
+- **実行モード**: direct（cycle オーケストレータ）
+- **アサインされたロール**: secretary
+- **参照したマスタ**: company-cycle / company-report / company-evolve / company-dashboard SKILL.md
+- **判断理由**: /company-cycle 定型フロー（Phase 0 前処理 → 1 report+evolve → 2 dashboard → 3 統合記録）
+
+## エージェント作業ログ
+
+### [2026-07-19 21:23:38] secretary
+Phase 0 完了: 観測データを main 直コミット（97bedfe）で先行取り込みし working tree をクリーン化。period = today

--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-19-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-19-today.md
@@ -1,0 +1,82 @@
+# domain-tech-collection 活動レポート — 日次（2026-07-19）
+
+> 生成日時: 2026-07-19 21:25 | 生成者: SAS-Sasao | 期間: 2026-07-19 〜 2026-07-19
+
+## エグゼクティブサマリー
+
+本日は ai-virtual-office プロジェクトの**ループエンジニアリング設計デー**だった。Addy Osmani / LayerX の2記事を起点とした壁打ちから始まり、検証 hooks（settings.json + スクリプト5本仕様）・SKILL カタログ・E2E AI 自動化の設計書を新規作成、要件定義を v0.2 系に改訂した。ユーザー指摘「レビュー用サブエージェントに合格基準がない」を受け、cc-sier L2 レビュー設計を移植した office-qa 合格基準（verdict JSON）と開発サイクル Skill /office-develop（設計→レビュー→実装TDD→レビュー→E2E→反映、fail でループ）を同日中に追補。設計は ai-virtual-office リポジトリへも2回同期し（PR #1/#2）、`.claude` 実装用のセットアッププロンプト txt も作成した。朝は daily-digest が GitHub Actions で自動実行済み。懸念点は ai-virtual-office 側に作成途中の未追跡ファイル3件（settings.json + hooks 2本、実行権限なし・スコープ4〜6未完）が残っていること。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 2 回（ローカル 1 + GitHub Actions daily-digest 1） |
+| ツール実行数（ローカル、21:20 時点） | 57 回（write 30 / bash 26 / read 1） |
+| 作成・編集ファイル数（docs/） | 3 件 |
+| 完了タスク数 | 4 件 |
+| 本日オープン Issue | 4 件 |
+| 本日クローズ Issue | 0 件 |
+| 本日 merged PR（cc-sier） | 3 件（#662 / #665 / #666）+ ai-virtual-office 側 2 件 |
+
+## 完了タスク
+
+- [agent-teams-actions] daily-digest 自動実行（07:30 JST cron）→ 成果物: `docs/daily-digest/2026-07-19.md`
+- [direct] ai-virtual-office ループエンジニアリング設計（検証 hooks / SKILL / E2E 自動化）+ 要件定義 v0.2 → PR #662 / Issue #663
+- [direct] ai-virtual-office への設計ドキュメント反映（origin.md 更新ルール準拠、ai-vir PR #1）→ Issue #664
+- [direct] office-qa 合格基準（verdict JSON）+ 開発サイクル /office-develop の設計反映（cc-sier PR #666、ai-vir PR #2）→ Issue #667
+
+## 進行中タスク
+
+- [direct] /company-cycle today（本レポート生成を含むサイクル実行）
+
+## 作成・更新された成果物
+
+**research（技術リサーチ室）**
+- `docs/research/ai-virtual-office-loop-engineering-design.md`（新規 → 同日 v0.2 改訂）
+- `docs/research/ai-virtual-office-requirements.md`（v0.1 → v0.2 → v0.2.1）
+
+**daily-digest**
+- `docs/daily-digest/2026-07-19.md`（Actions 自動生成）
+
+**リポジトリ外**
+- ai-virtual-office: `docs/design/loop-engineering-design.md` / `requirements.md` / `origin.md` / `CLAUDE.md`（PR #1・#2）
+- ローカル: `/home/toyoki05/ai-virtual-office-claude-setup-prompt.txt`（.claude 実装用プロンプト、意図的にリポジトリ非反映）
+
+## Issue 動向
+
+### クローズされた Issue（期間内）
+- なし
+
+### 新規オープンの Issue（期間内）
+- #667 office-qa レビュー合格基準（verdict JSON）と開発サイクル /office-develop を設計反映
+- #664 ai-virtual-office へループエンジニアリング設計ドキュメントを反映（origin.md 同期）
+- #663 ai-virtual-office ループエンジニアリング設計（検証 hooks/SKILL/E2E 自動化）+ 要件定義 v0.2
+- #661 インタラクションログ 2026-07-19
+
+## 会話トピック
+
+### セッション別の依頼内容
+- **セッション 215860a3**（ローカル、ツール実行 57 回）
+  - /company 起動 → domain-tech-collection で作業継続を選択
+  - ai-virtual-office の SKILL/hooks について壁打ち（ループエンジニアリング2記事ベース）
+  - 検証 hooks settings.json 設計・§5.4 改訂・SKILL 明確化・E2E AI 自動化の文書化依頼
+  - ai-virtual-office リポジトリへのドキュメント反映依頼（.claude 設定は対象外と明示）
+  - .claude 設定実装用プロンプトの txt 出力依頼
+  - 「レビュー合格基準を設けているか」の指摘 → verdict JSON + 開発サイクルの反映依頼
+  - ローカル未 add ファイルの確認 → /company-cycle 実行
+
+### ファイル生成を伴わなかったやり取り
+- ループエンジニアリング思想の壁打ち（2記事の層の違い、観測面としての ai-virtual-office の位置づけ）
+- 未コミットファイルの正体確認（観測データ自動更新 + ai-vir 側の作成途中ファイル発見）
+
+## 次のアクション候補
+
+1. **ai-virtual-office の M0 セット実装の完了**（根拠: `.claude/settings.json` + hooks 2本が未追跡・実行権限なし・スコープ 4〜6（office-verify / office-qa / office-develop）未着手のまま残っている。セットアッププロンプト txt で再実行するか続きを引き取る）
+2. hooks スクリプトへの `chmod +x` 付与（根拠: 現状 `-rw-r--r--` のままでは hook 実行時に Permission denied）
+3. ai-virtual-office M0 PoC 着手（根拠: 設計・検証基盤の定義が完了し、実装開始の前提が揃った）
+4. オープン Issue #663 / #664 / #667 のクローズ判断（根拠: 対応する PR はすべて merge 済みで実質完了）
+5. 設計書ギャップ記録の運用開始（根拠: SKILL 実装後、スキルなし失敗3件の記録を貯めるプロセスが未開始）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## 概要

/company-cycle today の Phase 1（/company-report）成果物。

- レポート: .companies/domain-tech-collection/docs/secretary/reports/2026-07-19-today.md
- cycle task-log 初期化を含む

🤖 Generated with [Claude Code](https://claude.com/claude-code)