### PR TITLE
docs: todayレポートを生成 [domain-tech-collection] 2026-07-25

### DIFF
--- a/.companies/domain-tech-collection/docs/secretary/reports/2026-07-25-today.md
+++ b/.companies/domain-tech-collection/docs/secretary/reports/2026-07-25-today.md
@@ -1,0 +1,77 @@
+# domain-tech-collection 活動レポート — 日次（2026-07-25）
+
+> 生成日時: 2026-07-25 23:18 | 生成者: SAS-Sasao | 期間: 2026-07-25 〜 2026-07-25
+
+## エグゼクティブサマリー
+
+Codex App Server を題材にした新規テーマ「codex-review-gateway（セカンドオピニオン・レビューゲートウェイ）」が、壁打ち → 要件定義書 v0.1（PR #684）→ AWS 構成図 v2（PR #686）まで 1 日で一気通貫した。構成図は `/company-diagram-v2`（draw.io XML 直接生成方式）の 3 回目の実運用で、L2 composite 0.99・L0 リトライ 1 回で完走し、「外部アクターも icon-to-icon 接続が正」という新たな L0 知見を獲得した。朝の日次ダイジェスト（PR #681、L2 0.97）も自動完走しており、未完了の懸念は App Server 疎通 PoC が未着手である点のみ。
+
+## 活動統計
+
+| 指標 | 値 |
+|------|-----|
+| セッション数 | 2 回（ローカル 1 + GitHub Actions 日次ダイジェスト 1） |
+| ツール実行数（合計） | 約 144 回（ローカルセッション） |
+| 作成・編集ファイル数 | 8 件（docs 配下） |
+| 完了タスク数 | 3 件 |
+| マージ PR | 3 件（#681 / #684 / #686） |
+| 新規オープン Issue | 2 件（#685 / #687、interaction-log 除く） |
+
+## 完了タスク
+
+- 【direct】codex app server アプリの要件定義書 v0.1 作成 → 成果物: `.companies/domain-tech-collection/docs/research/codex-review-gateway-requirements.md`（PR #684 / Issue #685、judge composite 0.93）
+- 【direct】`/company-diagram-v2` codex-review-gateway AWS 構成図生成 → 成果物: `docs/diagrams/codex-review-gateway.{drawio,html,yaml}` + iac.html + index 更新（PR #686 / Issue #687、L0 pass(retry1) / L1 pass / L2 composite 0.99）
+- 【agent-teams-actions】日次ダイジェスト 2026-07-25 自動実行 → 成果物: `.companies/domain-tech-collection/docs/daily-digest/2026-07-25.md` + `docs/daily-digest/index.html`（PR #681、L2 composite 0.97）
+
+## 進行中タスク
+
+- 【direct】/company-cycle today（本レポート生成を含む定例サイクル）
+
+## 作成・更新された成果物
+
+**技術リサーチ室（research）**
+- `docs/research/codex-review-gateway-requirements.md` — 要件定義書 v0.1（FR-01〜18 / NFR-01〜13 / データ定義 7 エンティティ / フロント定義 7 画面）
+
+**構成図（GitHub Pages）**
+- `docs/diagrams/codex-review-gateway.drawio` / `.html` / `.yaml` / `-iac.html` — AWS 構成図 v2 一式（11 サービス + 外部アクター 3、エッジ 6 色 12 本、CFn 599 行）
+- `docs/diagrams/index.html` — カード追記（25 → 26 件）
+
+**日次ダイジェスト**
+- `docs/daily-digest/2026-07-25.md` + `docs/daily-digest/index.html`
+
+## Issue 動向
+
+### クローズされたIssue（期間内）
+- なし
+
+### 新規オープンのIssue（期間内）
+- #685 【domain-tech-collection】Codexレビューゲートウェイ要件定義書v0.1作成
+- #687 【domain-tech-collection】AWS構成図v2(drawio) codex-review-gateway
+
+## 会話トピック
+
+### セッション別の依頼内容
+- **セッション 7f48cf1d**（80発言 / 155応答 / 144ツール実行）
+  - /company 起動（domain-tech-collection で作業継続）
+  - Codex App Server を使ったアプリのオススメ提案依頼（壁打ち）
+  - 「自作 Web サービスで App Server は使えないのでは？」の技術検証依頼（壁打ち）
+  - 要件定義書の作成依頼（機能要件・非機能要件・データ定義・フロント定義中心）
+  - /company-diagram-v2 実行（AWS 構成図生成）
+  - PR #686 マージ後のブランチ掃除依頼
+  - /company-cycle 実行（本サイクル）
+
+### ファイル生成を伴わなかったやり取り
+- Codex App Server 活用アプリ案の壁打ち（5 案提示 → セカンドオピニオン・レビューゲートウェイをイチ推し選定）
+- App Server の Web サービス組み込み可否検証（stdio 子プロセス spawn で可能、WebSocket transport は experimental、という結論をソース付きで確認）
+
+## 次のアクション候補
+
+1. **App Server 疎通 PoC の実施**（根拠: 要件定義書 §8 の次ステップ。spawn → 採点 JSON 回収の最小ループで技術リスクを早期検証）
+2. **要件定義 v0.2 の作成**（根拠: v0.1 で API 詳細仕様・採点軸定義を明示的にスコープ送りしている）
+3. **Issue #685 / #687 のクローズ**（根拠: 対応 PR #684 / #686 はマージ済み、タスク完了 Issue として閉じられる状態）
+4. **`/company-spawn` での実装リポジトリ切り出し検討**（根拠: 要件・構成図が揃い、実装フェーズへの移行判断が可能になった）
+5. **L0 知見の references への還元検討**（根拠: 「外部アクターも icon-to-icon 接続」は xml-rules.md の記述と実際の review-drawio.js 挙動が食い違う点で、次回 v2 実行の初回 PASS 率に直結）
+
+---
+_このレポートは /company-report Skill によって自動生成されました_
+_情報源: .session-summaries/ | .task-log/ | docs/ | GitHub Issues | .conversation-log/_


### PR DESCRIPTION
## 概要

/company-cycle Phase 1 (/company-report today) による日次活動レポート。

- 完了タスク 3 件（要件定義 #684 / AWS構成図v2 #686 / 日次ダイジェスト #681）
- codex-review-gateway テーマが壁打ち → 要件定義 → 構成図まで 1 日で完走

🤖 Generated with [Claude Code](https://claude.com/claude-code)