### PR TITLE
fix: feedbackメモリがCase Bankに統合されない問題を修正 + レポート期間フィルタの取りこぼし

### DIFF
--- a/.claude/hooks/rebuild-case-bank.sh
+++ b/.claude/hooks/rebuild-case-bank.sh
@@ -341,7 +341,13 @@ if feedback_dir and feedback_dir.exists():
         r'devops-coordinator|standards-lead|technical-writer)'
     )
 
-    for fb_file in sorted(feedback_dir.glob("feedback_*.md")):
+    # NOTE: ファイル名で絞らず全 .md を走査する。
+    # 以前は glob("feedback_*.md") だったが、実在するメモリは
+    # `cc-sier-design-review-lessons.md`（プレフィックスなし）や
+    # `feedback-verify-review-numbers.md`（ハイフン区切り）であり
+    # 1 件もマッチせず failure_patterns が常に 0 件だった。
+    # 絞り込みは下の `type: feedback` 判定のみで行う（命名規約に依存しない）。
+    for fb_file in sorted(feedback_dir.glob("*.md")):
         fb_text = fb_file.read_text(encoding="utf-8", errors="ignore")
         fb_id = fb_file.stem
 
@@ -358,7 +364,9 @@ if feedback_dir and feedback_dir.exists():
         # Verify type: feedback
         fb_type = ""
         for line in fm.split("\n"):
-            m = re.match(r'type:\s*(.+)', line)
+            # `type:` は metadata: 配下にインデントされる形式が現行。
+            # 行頭固定だと `  type: feedback` を取りこぼす。
+            m = re.match(r'\s*type:\s*(.+)', line)
             if m:
                 fb_type = m.group(1).strip()
         if fb_type != "feedback":
@@ -376,7 +384,9 @@ if feedback_dir and feedback_dir.exists():
 
         # Extract "How to apply" section
         how_match = re.search(
-            r'\*\*How to apply:\*\*\s*(.*?)(?=\n##|\n\*\*Why|\n\*\*How to apply|\Z)',
+            # `**How to apply:**`（コロン内側）と `**How to apply**:`（コロン外側）の
+            # 両表記を許容する。実データには後者が存在する。
+            r'\*\*How to apply:?\*\*:?\s*(.*?)(?=\n##|\n\*\*Why|\n\*\*How to apply|\Z)',
             fb_text, re.DOTALL
         )
         how_to_apply = how_match.group(1).strip()[:200] if how_match else ""

--- a/.claude/skills/company-report/SKILL.md
+++ b/.claude/skills/company-report/SKILL.md
@@ -60,13 +60,33 @@ ls .companies/{org-slug}/.session-summaries/${TODAY_COMPACT}*.json 2>/dev/null
 
 ```
 対象: .companies/{org-slug}/.task-log/*.md
-期間フィルタ: frontmatter の started フィールドで絞り込む
+期間フィルタ: frontmatter の started **または** completed が期間内のもの
 収集内容:
   - 完了タスクのリクエスト原文（status: completed）
   - 実行モード（subagent / agent-teams / direct）
   - 成果物パス一覧
   - 進行中タスク（status: in-progress）
 ```
+
+**重要: `started` だけで絞ると複数日にまたがるタスクを取りこぼす。**
+
+長期タスクは開始日と完了日が別日になる。`started` のみでフィルタすると、
+「前日までに開始し当日完了した」最も成果の大きいタスクがレポートから消える。
+
+実例: 2026-08-01 の today レポートで、`started: 2026-07-26` / `completed: 2026-08-01` の
+設計タスク（PR #710、6,189 行）が `started` フィルタでは検出されず、
+当日の成果が日次ダイジェストのみになりかけた。
+
+```bash
+# started が期間内
+grep -l "started: \"{DATE}" .companies/{org-slug}/.task-log/*.md
+# completed が期間内（開始日が別日のものを拾う）
+grep -l "completed: \"{DATE}" .companies/{org-slug}/.task-log/*.md
+# 両者の和集合を対象とする（重複は task_id で排除）
+```
+
+レポート本文では、開始日が期間外のタスクに「{開始日} 開始・{完了日} 完了」と
+補足を添えると、期間内の作業量が読み手に正しく伝わる。
 
 ### 2.3 docs/ 配下の成果物
 

--- a/.companies/domain-tech-collection/.task-log/20260801-201500-fix-case-bank-feedback.md
+++ b/.companies/domain-tech-collection/.task-log/20260801-201500-fix-case-bank-feedback.md
@@ -1,0 +1,103 @@
+---
+task_id: "20260801-201500-fix-case-bank-feedback"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "direct"
+started: "2026-08-01T20:15:00"
+completed: "2026-08-01T20:22:00"
+request: "（/company-cycle の実行中に発見した evolve の機能不全）反映しておいて！"
+issue_number: null
+pr_number: null
+subagents: []
+l0_gate: null
+l0_retries: 0
+l1_gate: null
+l1_retries: 0
+l2_composite: null
+l2_retries: 0
+---
+
+## 実行計画
+
+- **実行モード**: direct（hook / SKILL.md の局所修正のため subagent 委譲は不要）
+- **契機**: `/company-cycle` の Phase 1.5（evolve）で `failure_patterns: 0` を観測し、原因を調査
+
+## 背景
+
+`/company-evolve` の Read フェーズは、Case Bank の `failure_patterns` を秘書の判断に注入する設計。
+しかし実際には `failure_patterns` が常に 0 件で、**学習した失敗パターンが次セッションで一切参照されていなかった**。
+
+feedback メモリは蓄積されていたが、Case Bank に取り込まれる経路が 3 箇所で断線していた。
+
+## 修正内容
+
+### 1. `.claude/hooks/rebuild-case-bank.sh` — 3 点の断線を修正
+
+| # | 問題 | 修正 |
+|---|---|---|
+| 1 | `glob("feedback_*.md")` がどのファイルにもマッチしない | `glob("*.md")` に変更し、絞り込みは `type: feedback` 判定のみに任せる |
+| 2 | `re.match(r'type:\s*(.+)')` が行頭固定でインデントを取りこぼす | `re.match(r'\s*type:\s*(.+)')` に変更 |
+| 3 | `How to apply` の正規表現がコロン内側形式のみ | `\*\*How to apply:?\*\*:?` で両表記を許容 |
+
+**#1 の詳細**: 実在するメモリはいずれもマッチしなかった。
+
+| ファイル | 不一致の理由 |
+|---|---|
+| `memory/cc-sier-design-review-lessons.md` | プレフィックスなし |
+| `memory/user-prefers-decisive-action.md` | 同上 |
+| `agent-memory/system-architect/feedback-verify-review-numbers.md` | ハイフン区切り |
+
+ファイル名規約に依存すると命名のたびに漏れるため、**命名ではなく frontmatter の `type` で判定**する方式に変更した。
+
+**#2 の詳細**: 現行のメモリ形式は `type` が `metadata:` 配下にインデントされる。
+
+```yaml
+metadata:
+  type: feedback     # ← 行頭固定の正規表現では拾えない
+```
+
+### 2. `.claude/skills/company-report/SKILL.md` — 期間フィルタの取りこぼし
+
+`started` のみで絞ると、**複数日にまたがるタスクが期間内の成果から消える**。
+
+実例: 2026-08-01 の today レポートで、`started: 2026-07-26` / `completed: 2026-08-01` の
+設計タスク（PR #710、6,189 行）が検出されず、当日の成果が日次ダイジェストのみになりかけた。
+
+→ `started` **または** `completed` が期間内のものを対象とする（和集合、task_id で重複排除）に変更。
+開始日が期間外の場合は「{開始日} 開始・{完了日} 完了」と補足を添える運用も明記した。
+
+## 検証結果
+
+修正後に `rebuild_case_bank` を再実行:
+
+```
+failure_patterns: 0 件 → 2 件
+  - [feedback-memory] cc-sier-design-review-lessons
+    subagent: general / how_to_apply 抽出成功
+  - [feedback-memory] user-prefers-decisive-action
+    subagent: general / how_to_apply 抽出成功
+```
+
+`type: reference` のメモリ（`claude-code-spec-reference-errors.md`）は
+意図どおり対象外（feedback ではないため）。
+
+## 残る課題（別途対応）
+
+`match_keywords` が英語スラッグ（`['cc', 'sier', 'design', 'review', 'lessons']`）中心になっており、
+日本語の依頼文との照合精度が低い。`description` 側も文全体が 1 トークンになる場合がある。
+
+ただし現状の 2 件はいずれも `subagent: general` であり、
+SKILL.md の Read フェーズ仕様「general の feedback は依頼内容に関わらず常に注入候補」により
+キーワード照合に関わらず注入されるため、実害は限定的。
+
+改善するなら形態素分割の導入が必要で、スコープが大きいため本タスクでは扱わない。
+
+## 影響範囲
+
+- `.claude/hooks/rebuild-case-bank.sh`（`/company-evolve` から呼ばれる。全組織に影響）
+- `.claude/skills/company-report/SKILL.md`（`/company-report` と `/company-cycle` Phase 1）
+- `plugins/` 側への同期は不要（両ファイルとも `plugins/cc-sier/` に存在しない）
+
+## reward
+（post-merge hook が自動追記）


### PR DESCRIPTION
## 背景

`/company-cycle` の Phase 1.5（evolve）実行中に **`failure_patterns` が常に 0 件**であることを発見した。

`/company-evolve` の Read フェーズは Case Bank の `failure_patterns` を秘書の判断に注入する設計だが、**学習した失敗パターンが次セッションで一切参照されていなかった**。feedback メモリは蓄積されていたのに、Case Bank に取り込まれる経路が断線していた。

## 修正 1: `rebuild-case-bank.sh` の 3 点の断線

| # | 問題 | 修正 |
|---|---|---|
| 1 | `glob("feedback_*.md")` がどのファイルにもマッチしない | `glob("*.md")` に変更し、絞り込みは `type: feedback` 判定のみに任せる |
| 2 | `re.match(r'type:\s*(.+)')` が行頭固定でインデントを取りこぼす | `\s*type:` に変更 |
| 3 | `How to apply` の正規表現がコロン内側形式のみ | `\*\*How to apply:?\*\*:?` で両表記を許容 |

### #1 の詳細

実在するメモリはいずれもマッチしなかった。

| ファイル | 不一致の理由 |
|---|---|
| `memory/cc-sier-design-review-lessons.md` | プレフィックスなし |
| `memory/user-prefers-decisive-action.md` | 同上 |
| `agent-memory/system-architect/feedback-verify-review-numbers.md` | ハイフン区切り |

ファイル名規約に依存すると命名のたびに漏れるため、**命名ではなく frontmatter の `type` で判定**する方式に変更した。

### #2 の詳細

現行のメモリ形式は `type` が `metadata:` 配下にインデントされる。

```yaml
metadata:
  type: feedback     # ← 行頭固定の正規表現では拾えない
```

## 修正 2: `company-report/SKILL.md` の期間フィルタ

`started` のみで絞ると、**複数日にまたがるタスクが期間内の成果から消える**。

実例: 2026-08-01 の today レポートで、`started: 2026-07-26` / `completed: 2026-08-01` の設計タスク（PR #710、6,189 行）が検出されず、**当日の成果が日次ダイジェストのみになりかけた**。

→ `started` **または** `completed` が期間内のものを対象とする（和集合、task_id で重複排除）。開始日が期間外の場合は「{開始日} 開始・{完了日} 完了」と補足を添える運用も明記。

## 検証

修正後に `rebuild_case_bank` を再実行:

```
failure_patterns: 0 件 → 2 件
  - [feedback-memory] cc-sier-design-review-lessons  (how_to_apply 抽出成功)
  - [feedback-memory] user-prefers-decisive-action   (how_to_apply 抽出成功)
```

`type: reference` のメモリは意図どおり対象外。

## 残る課題（本 PR では扱わない）

`match_keywords` が英語スラッグ中心で日本語依頼文との照合精度が低い。ただし現状の 2 件はいずれも `subagent: general` であり、Read フェーズ仕様「general の feedback は依頼内容に関わらず常に注入候補」により実害は限定的。改善には形態素分割の導入が必要でスコープが大きい。

## 影響範囲

- `.claude/hooks/rebuild-case-bank.sh` — `/company-evolve` から呼ばれる（全組織に影響）
- `.claude/skills/company-report/SKILL.md` — `/company-report` と `/company-cycle` Phase 1
- `plugins/` への同期不要（両ファイルとも `plugins/cc-sier/` に存在しない）

task-log: `.task-log/20260801-201500-fix-case-bank-feedback.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)