### PR TITLE
feat: 小売月次統計の配信ページに組織ポータルへ戻る導線を追加

### DIFF
--- a/docs/retail-stats/index.html
+++ b/docs/retail-stats/index.html
@@ -10,7 +10,11 @@
 body{margin:0;font-family:system-ui,-apple-system,"Hiragino Sans","Noto Sans JP",sans-serif;
 color:var(--fg);background:var(--bg);line-height:1.7;font-size:15px}
 header,nav,section,footer{max-width:1080px;margin:0 auto;padding:0 20px}
-header{padding-top:28px}
+header{padding-top:20px}
+.backlink{margin:0 0 10px;font-size:13px}
+.backlink a{color:var(--accent);text-decoration:none;border:1px solid var(--line);
+border-radius:999px;padding:4px 12px;display:inline-block;background:var(--panel)}
+.backlink a:hover{border-color:var(--accent)}
 h1{font-size:22px;margin:0 0 4px}
 h2{font-size:18px;border-bottom:2px solid var(--line);padding-bottom:6px;margin:28px 0 16px}
 h3{font-size:15px;margin:20px 0 8px}
@@ -54,7 +58,7 @@ padding-top:12px;padding-bottom:28px}
 button{cursor:pointer;font-size:14px;padding:6px 14px;border:1px solid var(--line);
 border-radius:4px;background:var(--panel);color:var(--fg)}
 @media print{
-  .tabs,.controls,button{display:none!important}
+  .tabs,.controls,button,.backlink{display:none!important}
   .view{display:block!important;page-break-inside:avoid}
   .view[hidden]{display:block!important}
   .chartbox{height:300px;page-break-inside:avoid}
@@ -65,6 +69,11 @@ border-radius:4px;background:var(--panel);color:var(--fg)}
 </head>
 <body>
 <header>
+  <!-- 組織ポータルへ戻る導線。**相対パス**にしてあるのは、公開時
+       （docs/retail-stats/ 配下）に ../ が組織ポータルへ解決し、かつ
+       docs/ ツリーごとローカルに置いた場合も file:// で同じく動くため。
+       絶対 URL にするとオフラインのローカル確認で外部へ飛んでしまう。 -->
+  <p class="backlink"><a href="../">← cc-sier-organization ポータルへ戻る</a></p>
   <h1>小売月次統計トラッカー</h1>
   <p class="meta" id="meta"></p>
 </header>


### PR DESCRIPTION
配信ページから組織ポータルへ戻れるようにしました。

```
https://sas-sasao.github.io/cc-sier-organization/retail-stats/
  → https://sas-sasao.github.io/cc-sier-organization/
```

## 相対パス（`../`）にしています

絶対 URL ではなく `../` にしました。**公開時とローカル確認の両方で正しく動く**ためです。

| | `../` の解決先 |
|---|---|
| 公開時 | `https://sas-sasao.github.io/cc-sier-organization/` |
| ローカル（docs/ ツリー） | `docs/index.html`（同じツリー内に実在） |

絶対 URL だと、ネットワークを切ったローカル確認（NFR-08 の自己完結性を確かめる場面）で外部へ飛んでしまいます。

印刷時は `@media print` で非表示にしています。

## このページは生成物です

直接編集せず、retail-stats-tracker 側の `retail_stats/html/template.html` を直してから再生成してください。生成器側の変更は retail-stats-tracker#14 です。

自己完結性は維持（`src="http` / `fetch(` / `import(` / `@import` すべて 0 件）。サイズ 426,388 bytes。

関連: SAS-Sasao/retail-stats-tracker#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)