### PR TITLE
fix: reward プレースホルダが評価を塞いでいた問題を是正 [domain-tech-collection]

### DIFF
--- a/.claude/rules/task-log.md
+++ b/.claude/rules/task-log.md
@@ -44,7 +44,10 @@ l2_retries: 0
 **重要**:
 - **Subagent 名は必ず英字**で記録（日本語名だと Case Bank 検出不可）
 - **YAML フロントマター形式必須**（MD リスト形式はパーサ検出不可）
-- judge 評価済みなのに reward が null のまま残らないよう post-merge hook で補完される
+- **`reward` の補完は自動化されていない**（2026-08-16 実測）。`.claude/rules/` にも `.git/hooks/` にも `post-merge` hook は存在しない
+- **`skill-evaluator.sh` はべき等**（`## reward` が既にあればスキップ）。**タスクが `in-progress` のうちに評価が走ると低いスコアが固定され、完了後も更新されない**
+  - 実例: `20260816-150510-cycle-today` は evolve 実行時点で `in-progress` だったため `score: 0.2`（`completed: false` / `artifacts_exist: false`）が付き、完了後も自動では直らなかった
+  - **対処**: `## reward` セクションを手で削ってから `evaluate_session` を再実行する（上記の例は 0.2 → **1.0** に是正）
 
 ## セクション構成
 
@@ -66,7 +69,7 @@ l2_retries: 0
 完了: tech team 73件収集
 
 ## reward
-（post-merge hook が自動追記）
+（`skill-evaluator.sh` が追記。**タスク完了後に実行すること** — in-progress のうちに走ると低スコアが固定される）
 ```
 
 ## Issue 自動作成

--- a/.companies/domain-tech-collection/.case-bank/index.json
+++ b/.companies/domain-tech-collection/.case-bank/index.json
@@ -1,6 +1,6 @@
 {
   "org_slug": "domain-tech-collection",
-  "updated_at": "2026-08-16T15:07:18",
+  "updated_at": "2026-08-16T15:22:11",
   "case_count": 239,
   "failure_patterns": [
     {
@@ -7389,7 +7389,7 @@
         "mode": "direct",
         "artifact_count": 9
       },
-      "reward": null,
+      "reward": 1.0,
       "judge": null,
       "outcome": {
         "files_written": [
@@ -7422,18 +7422,24 @@
       "action": {
         "subagent": "secretary",
         "mode": "direct",
-        "artifact_count": 0
+        "artifact_count": 1
       },
-      "reward": 0.2,
-      "judge": null,
+      "reward": 1.0,
+      "judge": {
+        "completeness": 1.0,
+        "accuracy": 1.0,
+        "clarity": 1.0,
+        "total": 1.0,
+        "failure_reason": "",
+        "judge_comment": "/company-cycle 合成 judge: report(2026-08-16-today.md) / evolve(case_bank 239件) / dashboard(67.2KB) の 3 sub-skill が完了。evolve の PR 生成は 0 件だが、これは新規パターンが閾値(3件)に達しなかった正常系。詳細な L2 レビューは無い(cycle はオーケストレータのため)",
+        "judged_at": "2026-08-16T15:10:00+09:00"
+      },
       "outcome": {
-        "files_written": [],
+        "files_written": [
+          ".companies/domain-tech-collection/docs/secretary/reports/2026-08-16-today.md"
+        ],
         "started": "2026-08-16T15:05:10"
-      },
-      "conversation_context": [
-        "最後の点は、今回の解析で指摘した「台帳と実体のドリフト」そのものです。ルール側を実態に合わせて更新しておきますか？　更新しておいて。あとこのAI解析をgithubpagesにアップできる？？トップページ（既存の）にカードリンクつけてアップできる形にしてほしい。あと既存のスキルもアップできる所までいき"
-      ],
-      "conversation_enriched": true
+      }
     },
     {
       "id": "20260816-152000-insights-cycle",

--- a/.companies/domain-tech-collection/.conversation-log/2026-08-16-9637b4fe.md
+++ b/.companies/domain-tech-collection/.conversation-log/2026-08-16-9637b4fe.md
@@ -1,7 +1,7 @@
 ---
 session_id: "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e"
 date: "2026-08-16"
-datetime: "2026-08-16 15:02:35"
+datetime: "2026-08-16 15:10:36"
 operator: "SAS-Sasao"
 org: "domain-tech-collection"
 masked: true
@@ -9,7 +9,7 @@ masked: true
 
 # 会話ログ — 2026-08-16 `9637b4fe`
 
-> 組織: domain-tech-collection ／ オペレーター: SAS-Sasao ／ 生成: 2026-08-16 15:02:35
+> 組織: domain-tech-collection ／ オペレーター: SAS-Sasao ／ 生成: 2026-08-16 15:10:36
 
 ---
 
@@ -5719,6 +5719,390 @@ Phase 3  task-log    合成 judge 1.00 / 未検証事項 5 件
 
 ---
 
+## 👤 Human
+
+<command-message>company-cycle</command-message>
+<command-name>/company-cycle</command-name>
+
+---
+
+## 👤 Human
+
+Base directory for this skill: /home/toyoki05/cc-sier-organization/.claude/skills/company-cycle
+
+# CC-SIer サイクルオーケストレータ Skill（軽量型）
+
+3 つの skill (`company-report` / `company-evolve` / `company-dashboard`) を直列実行する軽量オーケストレータ。
+
+## 1. 適用条件
+
+- **必ずローカル Claude Code 実行**（GitHub Actions では gitignored データが欠落するため非対応）
+- `.companies/.active` に org-slug が存在する
+- `.claude/skills/company-report/`, `company-evolve/`, `company-dashboard/` がインストール済み
+- 既存 sub-skill の git 動作を尊重する（複数 PR + main 直コミットの混在を許容）
+
+---
+
+## 2. 4 フェーズ概要
+
+| Phase | 名称 | 中断条件 |
+|---|---|---|
+| 0 | 前処理（org / period / git clean / task-log 初期化） | git dirty |
+| 1 | `/company-report` 実行（内部で `/company-evolve` を自動連携） | report 失敗 |
+| 2 | `/company-dashboard` 実行 | dashboard 失敗 |
+| 3 | 統合 task-log 更新 + tracking Issue にコメント + 最終報告 | - |
+
+各 phase 失敗時は task-log を `status: blocked` で保存し、ユーザーに復旧手順を報告する。
+
+---
+
+## 3. Phase 0: 前処理
+
+```
+1. .companies/.active から {org-slug} を取得
+2. git config user.name → {operator}
+3. period を解釈（today / week / month / カスタム、デフォルト today）
+4. git status --porcelain が空でなければ中断
+5. {date_jst} = TZ=Asia/Tokyo date +%Y-%m-%d
+6. {task-id} = YYYYMMDD-HHMMSS-cycle-{period}
+7. .companies/{org}/.task-log/{task-id}.md を YAML フロントマター形式で作成
+   subagents: [company-report, company-evolve, company-dashboard]
+```
+
+task-log の `subagents` 欄には必ず英字で記録する（Case Bank 検出のため）。
+
+---
+
+## 4. Phase 1: /company-report 実行
+
+`@.claude/skills/company-report/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- report の **Section 6** で `/company-evolve` が自動起動される（既存仕様）
+- evolve の副作用（synthesizer / refiner / wf-auto-generation の **複数 PR 生成**）はそのまま許容
+- evolve の `enrich-case-bank.sh` `rebuild-case-bank.sh` などの hook は全て発火する（ローカル実行のため）
+- 各 sub-skill の git 動作（report の PR、evolve の複数 PR）は変更しない
+
+### 完了時に記録する情報
+
+- report MD ファイルパス: `.companies/{org}/docs/secretary/reports/{date}-{period}.md`
+- report Issue URL
+- evolve が生成した PR URL 一覧（synthesizer / refiner / auto-workflow ぞれぞれあれば）
+- evolve のサマリー（評価タスク件数 / 平均 reward / Case Bank 件数）
+
+### Phase 1 の実行方法
+
+ユーザー（あなた = Claude）は以下を順次行う:
+
+1. `@.claude/skills/company-report/SKILL.md` を Read
+2. report の指示に従って Phase 2-1 から Phase 2-5 のデータ収集を実行
+3. AI 要約してレポート MD を生成
+4. ファイル保存・Git commit・Issue 投稿
+5. report Section 6 に従って `/company-evolve` を自動起動
+6. evolve の Phase 2 (Write) と Phase 5.5 を実行
+7. 完了情報を Phase 0 で作成した task-log に追記
+
+---
+
+## 5. Phase 2: /company-dashboard 実行
+
+`@.claude/skills/company-dashboard/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- dashboard は **main 直コミット**（PR 経由ではない、既存仕様）
+- `bash .claude/hooks/generate-dashboard.sh {org-slug}` を実行するだけ
+- 出力: `.companies/{org}/docs/secretary/dashboard.html` および `docs/index.html`
+- **Phase 1 で evolve が更新した Case Bank がここで反映される**（順序が重要）
+
+### 完了時に記録する情報
+
+- dashboard HTML ファイルパス
+- 生成サイズ (KB)
+- GitHub Pages URL
+
+---
+
+## 6. Phase 3: 統合 task-log + Issue + 最終報告
+
+### 6.1 統合 task-log 更新
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: completed
+mode: "direct"
+started: "..."
+completed: "..."
+request: "/company-cycle {period}"
+issue_number: null
+pr_number: null
+subagents: [company-report, company-evolve, company-dashboard]
+sub_skill_results:
+  report:
+    file: ".companies/{org}/docs/secretary/reports/{date}-{period}.md"
+    issue: "https://github.com/.../issues/N"
+    pr: "https://github.com/.../pull/N"
+  evolve:
+    case_bank_count: N
+    avg_reward: 0.00
+    pr_synthesizer: "..." or null
+    pr_refiner: "..." or null
+    pr_workflow: "..." or null
+  dashboard:
+    file: ".companies/{org}/docs/secretary/dashboard.html"
+    size_kb: N
+---
+```
+
+### 6.1.5 `## judge` セクション追記（dashboard 統合のため必須）
+
+cycle 自体には L2 レビューが無いため、**3 つの sub-skill の判定結果から合成 judge** を生成する。これは `rebuild-case-bank.sh` が読み取り、`/company-dashboard` の「judge スコア推移」グラフに反映される。
+
+合成ロジック（sub_skill_results から導出）:
+- `completeness` = `1.00 if (report.file && evolve.case_bank_count > 0 && dashboard.file) else 0.50`（3 sub-skill 全完了で 1.00）
+- `accuracy` = `report success ? 1.00 : 0.00`（report が判定の中核）
+- `clarity` = `dashboard success ? 1.00 : 0.00`（最終的に可視化されたか）
+- `total` = `(completeness + accuracy + clarity) / 3`
+
+**ただし** sub-skill が独自に judge を書いている場合は **追記しなくてよい**（重複防止）。cycle はオーケストレータなので、判定済みの sub-skill task-log を尊重し、cycle 自身の task-log には judge を書かないのもオプション。デフォルトは「合成 judge を書く」。
+
+```markdown
+## judge
+
+\`\`\`yaml
+completeness: {0.00}
+accuracy: {0.00}
+clarity: {0.00}
+total: {0.00}
+failure_reason: ""
+judge_comment: "/company-cycle 合成 judge: 3 sub-skill (report/evolve/dashboard) 完了状態から導出。詳細な L2 レビューは各 sub-skill の task-log を参照"
+judged_at: "{ISO8601 with TZ}"
+\`\`\`
+```
+
+### 6.2 統合 tracking Issue にコメント
+
+label: `cycle-tracker`
+
+既存 Issue があればコメント追加、なければ新規作成:
+
+- title: `cycle: 統合実行ログ（継続トラッキング）`
+- body 冒頭: workflow の説明 + ローカル実行が必要な理由
+
+コメント内容:
+
+```markdown
+## 🔄 {date_jst} ({DOW_JP}) - /company-cycle {period} 完了
+
+| Phase | 状態 | 成果物 |
+|---|---|---|
+| 1. report | ✅ | [Issue #N](url) / [PR #N](url) |
+| 1.5 evolve (auto) | ✅ | case bank: N 件 / avg reward: X / 生成 PR: N 件 |
+| 2. dashboard | ✅ | [HTML](url) ({size} KB) |
+
+実行時間: N 分
+```
+
+### 6.3 最終報告（ユーザーへ）
+
+```
+✅ /company-cycle {period} 完了
+
+Phase 1 (report):    {report_issue_url}
+  └ 自動連携 evolve: case_bank {N}件 / avg reward {X}
+                    生成 PR: {N}件
+Phase 2 (dashboard): {dashboard_url}
+
+統合 tracking: #{tracking_issue_number}
+合計時間: {duration}
+```
+
+---
+
+## 7. オプションフラグ
+
+| フラグ | 既定 | 効果 |
+|---|---|---|
+| `--period` | today | today / week / month / カスタム日付範囲 |
+| `--skip-evolve` | off | report の自動 evolve 連携をスキップ（debug 用） |
+| `--dashboard-only` | off | report/evolve をスキップし dashboard のみ実行 |
+| `--report-only` | off | dashboard をスキップし report (+ auto evolve) のみ |
+
+---
+
+## 8. なぜローカル実行が必須か
+
+GitHub Actions runner では以下のデータが**完全に存在しない**:
+
+| データ | gitignore | 影響 |
+|---|---|---|
+| `.session-summaries/` | ✅ | report の Section 2.1（最優先） / dashboard のセッション統計 |
+| `.conversation-log/` | ✅ | report の「会話トピック」/ dashboard の頻出フレーズ・enrich-case-bank.sh |
+| `.quality-gate-log/` | ✅ | dashboard の品質ゲート通過率（ドーナツチャート） |
+| `.case-bank/` | ✅ | 毎回 rebuild 必要、永続化されない |
+| `~/.claude/.../memory/feedback_*.md` | - | rebuild-case-bank.sh の feedback memory 統合 |
+
+加えて、`enrich-case-bank.sh` などの hook はローカル Claude Code セッション内で発火する設計のため、Actions 環境では動作しない。
+
+→ **完全な observability を得るためにはローカル実行が必須**。GitHub Actions は補完的に `daily-cycle-supplement.yml` で git tracked データのみの軽量サマリーを生成し、ユーザーに「今日 cycle がまだ走っていない」をリマインドする。
+
+---
+
+## 9. エラー時の中断ポリシー
+
+- 各 Phase で fail → task-log を `status: blocked` で保存
+- ユーザーへの報告に Phase 名・原因・手動復旧コマンドを含める
+- 部分作成済みの PR / コミットは削除しない（手動引き継ぎ用）
+- Phase 1 の report/evolve が部分成功している場合、Phase 2 dashboard はスキップして報告
+
+---
+
+## 10. 関連
+
+- @.claude/skills/company-report/SKILL.md — Phase 1 の本体
+- @.claude/skills/company-evolve/SKILL.md — Phase 1.5 の本体（report から自動起動）
+- @.claude/skills/company-dashboard/SKILL.md — Phase 2 の本体
+- @.github/workflows/daily-cycle-supplement.yml — 19:00 JST の補完 Actions
+- @.claude/rules/review-pattern.md — 将来的な L0/L1/L2 統合（Phase 2 昇格時）
+- @.claude/rules/git-workflow.md — ブランチ・コミット・PR 規約
+
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+`/company-cycle` を実行します。Phase 0（前処理）から。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+ORG=$(tr -d '[:space:]' < .companies/.active); OP=$(git config user.name)
+echo "org=$ORG / operator=$OP / period=today"
+echo "date_jst=$(TZ=Asia/Tokyo date +%Y-%
+description: Phase 0: preprocessing
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+org=domain-tech-collection / operator=SAS-Sasao / period=today
+date_jst=2026-08-16 (日)
+現在ブランチ: domain-tech-collection/fix/2026-08-16-digest-scope-correction
+=== git status ===
+ M .companies/domain-tech-collection/.case-bank/index.json
+ M .companies/domain-tech-collection/.conversation-log/2026-[PHONE]b4fe.md
+ M .companies/domain-tech-collection/.task-log/[PHONE]00-insights-cycle.md
+?? .companies/domain-tech-collection/.session-summaries/[PHONE]34-9637b4fe.json
+=== PR #784 状態 ===
+MERGED mergeable
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+PR #784 はマージ済みです。main に戻して観測データを整理し、clean 化します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git stash push -q -u -m "cycle-phase0" && git checkout -q main && git fetch -q --prune && git pull -q --ff-only && echo "main 同期 OK: $(git log --oneline -1)"
+git
+description: Sync main and clean working tree
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+main 同期 OK: 030bbf7 fix+docs: 対象期間の誤りを訂正 + 2026-08-10〜08-15 を追補解析 [domain-tech-collection] (#784)
+clean 化完了
+残り未コミット: 0
+Deleted branch domain-tech-collection/fix/2026-08-16-digest-scope-correction (was b349878).
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection
+D=$(TZ=Asia/Tokyo date +%Y-%m-%d); DC=$(TZ=Asia/Tokyo date +%Y%m%d)
+echo "=== 2.1 session-summaries（$DC）==="
+ls .session-summar
+description: Phase 1: collect data sources
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 2.1 session-summaries（[PHONE]）===
+  セッション数: 5
+   [PHONE]34-9637b4fe.json -> ['session_id', 'org_slug', 'date', 'datetime', 'tool_count', 'by_type', 'files_written', 'log_file']
+
+=== 2.2 task-log（started または completed が 2026-08-16）===
+  [PHONE]45-daily-digest-actions.md | completed | "agent-teams-actions"
+  [PHONE]19-ai-week-analysis.md | completed | "direct"
+  [PHONE]00-insights-cycle.md | completed | "direct"
+
+=== 2.3 docs/ 成果物（本日 main）===
+  変更ファイル数: 21
+=== 2.5 conversation-log ===
+  会話ログ: 
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection
+DC=$(TZ=Asia/Tokyo date +%Y%m%d); D=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+python3 - <<PY
+import json,glob,collections
+tot=0; by=colle
+description: Aggregate session stats and GitHub activity
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+セッション 5 / ツール実行合計 379
+ツール種別 上位: {'bash': 282, 'write': 59, 'read': 28, 'other': 10}
+書き込みファイル（ユニーク）: 0
+
+=== 会話ログの統計 ===
 ## 統計
 
 | 項目 | 値 |
@@ -5726,6 +6110,509 @@ Phase 3  task-log    合成 judge 1.00 / 未検証事項 5 件
 | 人間の発言数 | 164 |
 | Claudeの応答数 | 286 |
 | ツール実行数 | 312 |
+| マスキング適用 | 0 種類 |
+
+Human 発言数: 164
+
+=== 本日の Issue / PR ===
+  merged #784 fix+docs: 対象期間の誤りを訂正 + 2026-08-10〜08-15 を追補解析 [domain-tech-collection]
+  merged #781 feat: AI 配信解析 + 解析レポートの Pages 公開 + /company-insights-cycle [domain-tech-collection]
+  merged #772 feat: 日次ダイジェスト 2026-08-12 [domain-tech-col
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+D=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+echo "=== 本日変更された成果物（21件）==="
+git log --since="$D 00:00" --name-only --pretty=format: -- ".companies/domain-tech-collection/doc
+description: List artifacts and commits
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 本日変更された成果物（21件）===
+.companies/domain-tech-collection/docs/daily-digest/2026-08-12.md
+.companies/domain-tech-collection/docs/daily-digest/2026-08-16.md
+.companies/domain-tech-collection/docs/insights/README.md
+.companies/domain-tech-collection/docs/insights/catalog.md
+docs/daily-digest/index.html
+docs/index.html
+docs/insights/analyses/2026-08-digest-ai.html
+docs/insights/analyses/2026-08-digest-ai.md
+docs/insights/analyses/2026-08-w2-claude-code-codex-agent.html
+docs/insights/analyses/2026-08
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+T=$(TZ=Asia/Tokyo date +%H%M%S); echo "task-id: [PHONE]-${T}-cycle-today"
+git checkout -q -b domain-tech-collection/docs/2026-08-16-report-today && git branch -
+description: Create cycle branch
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+task-id: [PHONE]10-cycle-today
+domain-tech-collection/docs/2026-08-16-report-today
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Write
+file_path: /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md
+content: ---
+task_id: "[PHONE]10-cycle-today"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: in-progress
+mode: "direct"
+started: "2026-08-16T15:05:10"
+completed: ""
+request: "/company-cycle 
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+File created successfully at: /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md (file state is current in your context — no need to Read it back)
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Write
+file_path: /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection/docs/secretary/reports/2026-08-16-today.md
+content: # domain-tech-collection 活動レポート — 2026-08-16（日）
+
+> 生成日時: 2026-08-16 15:10 JST | 生成者: SAS-Sasao | 期間: 2026-08-16（today）
+
+## エグゼクティブサマリー
+
+**8/9 週の AI 配信解析**を主軸に、解析レポート 7 本の GitHub Pages 公開基盤と `/company-
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+File created successfully at: /home/toyoki05/cc-sier-organization/.companies/domain-tech-collection/docs/secretary/reports/2026-08-16-today.md (file state is current in your context — no need to Read it back)
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git add .companies/domain-tech-collection/
+git commit -q -m "docs: todayレポートを生成 [domain-tech-collection] 2026-08-16 by SAS-Sasao"
+git push -q -u origin domain-te
+description: Commit report and create PR
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+remote: 
+https://github.com/SAS-Sasao/cc-sier-organization/pull/785
+```
+
+---
+
+## 🤖 Claude
+
+Phase 1.5（`/company-evolve` 自動連携）を実行します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+set +e
+echo "=== 2.1 Skill Evaluator ==="
+source .claude/hooks/skill-evaluator.sh 2>/dev/null && evaluate_session "domain-tech-collection" "$(TZ=Asia/Tokyo date 
+description: Evolve: run skill evaluator
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 2.1 Skill Evaluator ===
+exit=0
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+set +e
+echo "=== 2.2 Case Bank 再構築 ==="
+source .claude/hooks/rebuild-case-bank.sh 2>/dev/null && rebuild_case_bank "domain-tech-collection" 2>&1 | tail -10
+echo 
+description: Evolve: rebuild case bank
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 2.2 Case Bank 再構築 ===
+Case Bank: 239 cases
+--- 結果 ---
+cases: 239
+failure_patterns: 2
+reward 付き: 200 / 平均: 0.81
+keys: ['org_slug', 'updated_at', 'case_count', 'failure_patterns', 'cases', 'frequent_phrases', 'intent_patterns', 'conversation_enriched_at']
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+set +e
+echo "=== 3.1 Skill Synthesizer ==="
+source .claude/hooks/skill-synthesizer.sh 2>/dev/null && synthesize_skills "domain-tech-collection" "SAS-Sasao" 2>&1 
+description: Evolve: synthesizer, refiner, enrich
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 3.1 Skill Synthesizer ===
+Skill Synthesizer: no viable groups (need 3+)
+
+=== 3.2 Subagent Refiner & Spawner ===
+Subagent Refiner: no changes needed
+
+=== 5.5 会話コンテキスト付加 ===
+[enrich] 会グ: 1件処理
+[enrich] Case Bankエントリ強化: 4件
+[enrich] 頻出フレーズ: 0件
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git status --porcelain | head
+git stash push -q -u -m "evolve-output" && git checkout -q main && git pull -q --ff-only && git stash pop -q 2>&1 | tail -2
+echo "現
+description: Move evolve output to main for dashboard phase
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+ M .companies/domain-tech-collection/.case-bank/enrich-log.json
+ M .companies/domain-tech-collection/.case-bank/index.json
+ M .companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md
+The stash entry is kept in case you need it again.
+現在: main
+M  .companies/domain-tech-collection/.case-bank/enrich-log.json
+M  .companies/domain-tech-collection/.case-bank/index.json
+DU .companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+TL=.companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md
+git show 'stash@{0}':"$TL" > /tmp/cycle-tasklog.md 2>/dev/null && echo "task-log を 
+description: Resolve stash conflict, keep task-log for branch
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+task-log を /tmp へ退避（58 行）
+stash 破棄
+M  .companies/domain-tech-collection/.case-bank/enrich-log.json
+M  .companies/domain-tech-collection/.case-bank/index.json
+```
+
+---
+
+## 🤖 Claude
+
+Phase 2（`/company-dashboard`）を実行します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+bash .claude/hooks/generate-dashboard.sh domain-tech-collection 2>&1 | tail -12
+echo "--- 生成物 ---"
+ls -la .companies/domain-tech-collection/docs/secretary/dashbo
+description: Phase 2: generate dashboard
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+✅ ダッシュボード生成完了: .companies/domain-tech-collection/docs/secretary/dashboard.html (67.2 KB)
+docs/index.html を更新しました
+[main 0deedf2] chore: ダッシュボード更新 [domain-tech-collection] 2026-08-16 15:08
+ 5 files changed, 154 insertions(+), 243 deletions(-)
+ rewrite .companies/domain-tech-collection/.case-bank/enrich-log.json (69%)
+To https://github.com/SAS-Sasao/cc-sier-organization.git
+   c12050e..0deedf2  main -> main
+✅ docs/ を更新しました（GitHub Pages 組織別ダッシュボード）
+--- 生成物 ---
+67.2 KB  .companies/domain-tech-collect
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+`generate-dashboard.sh` の再生成後もカードが残ることを実測で確認できました（前回「未検証」としていた項目）。Phase 3 に進みます。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git checkout -q domain-tech-collection/docs/2026-08-16-report-today
+cp /tmp/cycle-tasklog.md .companies/domain-tech-collection/.task-log/[PHONE]10-cycle-to
+description: Phase 3: complete task-log
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+push OK
+status: completed
+completed: "2026-08-16T15:10:00"
+pr_number: 785
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+python3 - <<'PY'
+from pathlib import Path
+p=Path(".companies/domain-tech-collection/.task-log/[PHONE]10-cycle-today.md")
+t=p.read_text(encoding="utf-8")
+ju
+description: Add synthetic judge and push
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+judge 追記完了
+pushed
+PR #785 OPEN
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+gh label create "cycle-tracker" --color "0e8a16" --description "cycle 統合実行ログ" --force >/dev/null 2>&1
+N=$(gh issue list --label cycle-tracker --state open --json
+description: Post to cycle tracking issue
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+https://github.com/SAS-Sasao/cc-sier-organization/issues/270#issuecomment-[PHONE]
+tracking Issue: #270
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git checkout -q main && git pull -q --ff-only
+echo "現在: $(git branch --show-current) / $(git log --oneline -1)"
+echo "未コミット: $(git status --porcelain | wc -l) 件"
+description: Return to main and verify Pages
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+現在: main / 0deedf2 chore: ダッシュボード更新 [domain-tech-collection] 2026-08-16 15:08
+未コミット: 0 件
+
+=== Pages 反映確認 ===
+https://sas-sasao.github.io/cc-sier-organization/                      200
+https://sas-sasao.github.io/cc-sier-organization/secretary/domain-tech-collection/dashboard.html 200
+https://sas-sasao.github.io/cc-sier-organization/insights/analyses/    200
+```
+
+---
+
+## 🤖 Claude
+
+✅ `/company-cycle today` 完了
+
+```
+Phase 1 (report):     PR #785 — docs/secretary/reports/2026-08-16-today.md
+  └ 自動連携 evolve:  case_bank 239 件 / 平均 reward 0.81
+                      生成 PR: 0 件
+Phase 2 (dashboard):  67.2 KB（main 直コミット 0deedf2・push 済み）
+
+統合 tracking: #270
+```
+
+## 本日の実績
+
+| 指標 | 値 |
+|---|---|
+| セッション | 5 |
+| ツール実行 | 379（bash 282 / write 59 / read 28） |
+| 変更ファイル | 21 |
+| 完了タスク | 3 |
+| マージ PR | 3（#784 / #781 / #772） |
+
+主軸は 8/9 週の AI 配信解析でした。ユニーク 349 件から 20 件を curl で精読し、解析レポート 7 本の Pages 公開基盤と `/company-insights-cycle` の新設まで到達しています。
+
+## 副次的に取れた検証
+
+前タスクで「未実測」と書いていた項目が 1 つ潰れました。**`generate-dashboard.sh` が `docs/index.html` を丸ごと再生成した後も「知見解析レポート」カードが残る**ことを確認できました（カード数 1）。今日カード定義を 2 箇所に置いた判断が正しかった、という実測です。
+
+Pages も 3 ページとも 200 で応答しています。
+
+## evolve が PR を作らなかった件
+
+これは失敗ではありません。
+
+- Skill Synthesizer → `no viable groups (need 3+)`
+- Subagent Refiner → `no changes needed`
+
+いずれも新規パターンが閾値（3 件以上）に達しなかった正常系です。Case Bank 側は 239 件・平均 reward 0.81 に更新され、会話ログから 4 エントリが強化されました。
+
+## 確認していないこと
+
+- **Skill Evaluator が本 cycle の task-log に付けた reward は 0.2** です。評価実行時点でまだ `in-progress` だったためで、成果物の不在を意味しません。post-merge hook が補完する設計ですが、**実際に走るかは未確認**です
+- **`.session-summaries` の `files_written` が 5 セッションとも 0 件**でした。フィールドの故障か仕様かは調べていません。レポートの「21 件」は `git log` 側の値を使っています
+- ダッシュボード HTML の**ブラウザ目視は未実施**（生成成功とサイズのみ）
+- `--skip-evolve` / `--dashboard-only` / `--report-only` は**未使用・未検証**
+
+## 残っているもの
+
+PR #785（本日のレポート）が open です。マージすると post-merge hook が reward を補完します。
+
+採用候補は **AD〜AU の 12 件が未着手**のままです。レポートの「次のアクション候補」では、根拠が実測で揃っている **AO + AD のセット**（CLAUDE.md を削る作業をやめて、2 ヶ月分岐した `AGENTS.md` の畳み込みに振り替える）を筆頭に挙げました。
+
+---
+
+## 統計
+
+| 項目 | 値 |
+|---|---|
+| 人間の発言数 | 185 |
+| Claudeの応答数 | 319 |
+| ツール実行数 | 350 |
 | マスキング適用 | 0 種類 |
 
 ---

--- a/.companies/domain-tech-collection/.session-summaries/20260816-151035-9637b4fe.json
+++ b/.companies/domain-tech-collection/.session-summaries/20260816-151035-9637b4fe.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e",
+  "org_slug": "domain-tech-collection",
+  "date": "2026-08-16",
+  "datetime": "2026-08-16 15:10:35",
+  "tool_count": 143,
+  "by_type": {
+    "write": 26,
+    "read": 9,
+    "bash": 105,
+    "other": 3
+  },
+  "files_written": [],
+  "log_file": ".companies/domain-tech-collection/.interaction-log/2026-08-16.md"
+}

--- a/.companies/domain-tech-collection/.task-log/20260816-141319-ai-week-analysis.md
+++ b/.companies/domain-tech-collection/.task-log/20260816-141319-ai-week-analysis.md
@@ -125,5 +125,12 @@ l2_retries: 0
 - `artifact-placement.md` を例外に合わせて更新するかは**未判断**（現状はルールと実態が食い違ったまま）
 
 ## reward
-
-（post-merge hook が自動追記）
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-08-16T15:22:11"
+```

--- a/.companies/domain-tech-collection/.task-log/20260816-150510-cycle-today.md
+++ b/.companies/domain-tech-collection/.task-log/20260816-150510-cycle-today.md
@@ -63,16 +63,6 @@ l2_retries: 0
 
 **注記**: `files_written` は 5 セッションとも 0 件だった。`.session-summaries` の当該フィールドが機能していない可能性があるが、**未調査**（本サイクルでは `git log` 側の 21 ファイルを採用した）。
 
-## reward
-```yaml
-score: 0.2
-signals:
-    completed: false
-    artifacts_exist: false
-    excessive_edits: false
-    retry_detected: false
-evaluated_at: "2026-08-16T15:06:59"
-```
 
 ### [2026-08-16 15:09] Phase 1 レポート生成 + PR
 
@@ -126,5 +116,12 @@ judged_at: "2026-08-16T15:10:00+09:00"
 - `--skip-evolve` / `--dashboard-only` / `--report-only` の各フラグは**未使用・未検証**
 
 ## reward
-
-（post-merge hook が自動補完）
+```yaml
+score: 1.0
+signals:
+    completed: true
+    artifacts_exist: true
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-08-16T15:20:35"
+```

--- a/.companies/domain-tech-collection/docs/insights/catalog.md
+++ b/.companies/domain-tech-collection/docs/insights/catalog.md
@@ -720,6 +720,56 @@ claudex は非公式構成で、**アカウント停止事例あり**（Anthropi
 
 ---
 
+## 5.17 reward プレースホルダが評価を塞いでいた（自組織の実測のみ・外部記事なし）
+
+**出典**: なし。2026-08-16 の `/company-cycle` 後始末で実測により発見。
+**関連**: 本日の主テーマ「台帳と実体のドリフト」（§5.13 / 候補 AO）と同型の問題。
+
+### 何が起きていたか
+
+`.claude/rules/task-log.md` のテンプレートが `## reward` の下に **「（post-merge hook が自動追記）」というプレースホルダを書くよう指示していた**。しかし:
+
+1. **その post-merge hook は存在しない。** `.git/hooks/` にも `.claude/hooks/` にも無い（`daily-insights-sync.py` が `chore: post-merge` という**コミットメッセージのパターンを除外しているだけ**）
+2. **`skill-evaluator.sh` は `^## reward` の存在でべき等判定している。** プレースホルダだけでもヘッダは存在するため、**評価がスキップされる**
+3. `rebuild-case-bank.sh` は `score:` を探すが見つからず `reward: None`
+4. `judge` セクションがあれば total から自動導出されるが、無ければ null のまま
+
+つまり **テンプレートに従うほど reward が付かなくなる**構造だった。
+
+### 実測
+
+| 項目 | 値 |
+|---|---|
+| プレースホルダで評価が塞がれている task-log | **31 件** |
+| Case Bank の reward null | **38 / 239 件（15.9%）** |
+| 是正した件数 | 2 件（本日分。`ai-week-analysis` と `cycle-today`） |
+| 是正の効果 | `ai-week-analysis` **null → 1.0** / `cycle-today` **0.2 → 1.0** |
+
+`cycle-today` の 0.2 は別の失敗モードで、**タスクが `in-progress` のうちに evolve が評価を走らせた**ため（`completed: false` / `artifacts_exist: false`）。べき等なので完了後も自動では直らなかった。
+
+### 対処済み
+
+- `.claude/rules/task-log.md` の記述を実態へ修正（post-merge hook は未実装であること、in-progress 中に評価すると低スコアが固定されること、対処手順）
+- 本日分 2 件の reward を是正し Case Bank を再構築（reward 付き 200 → **201 件** / 平均 0.814 → **0.815**）
+
+### 採用候補
+
+**(AV) 残り 29 件の reward を復旧する** — ⬜ 優先度 **中**
+
+**一括再評価は危険**。`skill-evaluator.sh` の `artifacts_exist` は**現在のファイル存在**を見るため、パスが変わった成果物を参照する古い task-log は不当に `false` となり、**べき等ゆえに誤った低スコアが恒久固定される**。
+
+実例: 2026-08-16 に解析レポート 7 本を `docs/insights/analyses/` へ移設したため、`20260808-comment-density-analysis` など **4 件**が旧パスを参照している。
+
+**取りうる方針**（未決定）:
+
+1. パス移設の対応表を作ってから個別に再評価する
+2. `artifacts_exist` を「当時の git 履歴でファイルが存在したか」に変える（evaluator の改修）
+3. 復旧せず、null のまま「評価不能」として残す
+
+**未検証**: どの方針でも、当時の `.interaction-log/` が残っていない古いタスクは `no_excessive_edits` / `no_retry` を正しく判定できない。**遡及評価には原理的な限界がある。**
+
+---
+
 ## 6. Claude Code 仕様に関する注意（実測で判明）
 
 **詳細**: `claude-code-spec-reference-errors`（メモリ）
@@ -783,6 +833,7 @@ claudex は非公式構成で、**アカウント停止事例あり**（Anthropi
 | **AS** | 指摘の `count` を強制力に接続する | ⬜ | cc-sier | 中 | 中 — 候補 AA への対処にもなる |
 | **AU** | claudex は見送り、委譲マトリクスの考え方のみ採用 | ⬜ | cc-sier | 小 | 低 — 非公式構成でアカウント停止事例あり |
 | **AT** | Agent Plugins 1.0.0 準拠 | ❌ 不採用 | — | — | Claude Code 自体が標準に非対応。準拠しても得るものがない |
+| **AV** | reward プレースホルダで塞がれた 29 件を復旧 | ⬜ | cc-sier | 中 | 中 — **一括再評価は危険**（`artifacts_exist` が現在のパスを見るため誤スコアが恒久固定される） |
 
 **候補 C と N の関係**: N（不確実性の明示）を CLAUDE.md にルール化したことで、C（task-log の「未検証事項」欄）は N の適用先の 1 つに含まれる。C を独立して実装するか、N の運用で足りるかは、次回以降の task-log を観察して判断する。
 


### PR DESCRIPTION
## 発見の経緯

PR #785 のマージ後、cycle task-log に書いた「reward は post-merge hook が補完する」という前提を確認したところ、**その hook が存在しなかった。**

## 何が起きていたか

`.claude/rules/task-log.md` のテンプレートが `## reward` の下に「（post-merge hook が自動追記）」というプレースホルダを書くよう指示していた。しかし:

1. **post-merge hook は実在しない。** `.git/hooks/` にも `.claude/hooks/` にも無い（`daily-insights-sync.py` は `chore: post-merge` という**コミットメッセージのパターンを除外しているだけ**）
2. **`skill-evaluator.sh` は `^## reward` の存在でべき等判定する。** プレースホルダだけでもヘッダは存在するため、**評価がスキップされる**
3. `rebuild-case-bank.sh` は `score:` を探すが見つからず `reward: None`
4. `judge` セクションがあれば total から導出されるが、無ければ null のまま

**テンプレートに従うほど reward が付かなくなる**構造だった。

## 実測

| 項目 | 値 |
|---|---|
| プレースホルダで評価が塞がれている task-log | **31 件** |
| Case Bank の reward null | **38 / 239 件（15.9%）** |

さらに別の失敗モードも 1 件。`20260816-150510-cycle-today` は **タスクが `in-progress` のうちに evolve が評価を走らせた**ため `score: 0.2`（`completed: false` / `artifacts_exist: false`）が付き、べき等ゆえに完了後も自動では直らなかった。

## 本 PR の修正

| 対象 | 内容 |
|---|---|
| `.claude/rules/task-log.md` | 「post-merge hook で補完される」を**実態に修正**。in-progress 中に評価すると低スコアが固定されること、対処手順を明記。テンプレートのプレースホルダ文言も差し替え |
| `20260816-141319-ai-week-analysis` | プレースホルダ除去 → 再評価 → **null → 1.0** |
| `20260816-150510-cycle-today` | 重複していた `## reward` を解消 → 再評価 → **0.2 → 1.0** |
| `.case-bank/index.json` | 再構築（reward 付き 200 → **201 件** / 平均 0.814 → **0.815**） |
| `catalog.md` | §5.17 として記録 + 候補 **AV** |

## 残り 29 件を一括再評価しなかった理由

**危険だから。** `skill-evaluator.sh` の `artifacts_exist` は**現在のファイル存在**を見る。パスが変わった成果物を参照する古い task-log は不当に `false` となり、**べき等ゆえに誤った低スコアが恒久固定される**。

実例: 本日 解析レポート 7 本を `docs/insights/analyses/` へ移設したため、`20260808-comment-density-analysis` など **4 件**が旧パスを参照している。

候補 AV として方針 3 案を記録した（対応表を作って個別再評価 / `artifacts_exist` を git 履歴ベースに改修 / 復旧せず「評価不能」として残す）。**いずれも未決定。**

## 確認していないこと

- **遡及評価には原理的な限界がある。** 当時の `.interaction-log/` が残っていない古いタスクは `no_excessive_edits` / `no_retry` を正しく判定できない
- 他組織（`jutaku-dev-team` / `standardization-initiative`）の task-log は**調べていない**
- 修正した `task-log.md` の記述に従って次回以降 reward が正しく付くかは**次サイクルでの観察待ち**

関連: #785 / #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)