### PR TITLE
docs: Pages デザイン刷新の移植計画 [domain-tech-collection]

### DIFF
--- a/.companies/domain-tech-collection/.conversation-log/2026-08-22-9637b4fe.md
+++ b/.companies/domain-tech-collection/.conversation-log/2026-08-22-9637b4fe.md
@@ -1,7 +1,7 @@
 ---
 session_id: "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e"
 date: "2026-08-22"
-datetime: "2026-08-22 16:28:50"
+datetime: "2026-08-22 19:52:44"
 operator: "SAS-Sasao"
 org: "domain-tech-collection"
 masked: true
@@ -9,7 +9,7 @@ masked: true
 
 # 会話ログ — 2026-08-22 `9637b4fe`
 
-> 組織: domain-tech-collection ／ オペレーター: SAS-Sasao ／ 生成: 2026-08-22 16:28:50
+> 組織: domain-tech-collection ／ オペレーター: SAS-Sasao ／ 生成: 2026-08-22 19:52:44
 
 ---
 
@@ -11898,13 +11898,1377 @@ Pages build: built  0cb1f873
 
 ---
 
+## 👤 Human
+
+<command-message>company-cycle</command-message>
+<command-name>/company-cycle</command-name>
+
+---
+
+## 👤 Human
+
+Base directory for this skill: /home/toyoki05/cc-sier-organization/.claude/skills/company-cycle
+
+# CC-SIer サイクルオーケストレータ Skill（軽量型）
+
+3 つの skill (`company-report` / `company-evolve` / `company-dashboard`) を直列実行する軽量オーケストレータ。
+
+## 1. 適用条件
+
+- **必ずローカル Claude Code 実行**（GitHub Actions では gitignored データが欠落するため非対応）
+- `.companies/.active` に org-slug が存在する
+- `.claude/skills/company-report/`, `company-evolve/`, `company-dashboard/` がインストール済み
+- 既存 sub-skill の git 動作を尊重する（複数 PR + main 直コミットの混在を許容）
+
+---
+
+## 2. 4 フェーズ概要
+
+| Phase | 名称 | 中断条件 |
+|---|---|---|
+| 0 | 前処理（org / period / git clean / task-log 初期化） | git dirty |
+| 1 | `/company-report` 実行（内部で `/company-evolve` を自動連携） | report 失敗 |
+| 2 | `/company-dashboard` 実行 | dashboard 失敗 |
+| 3 | 統合 task-log 更新 + tracking Issue にコメント + 最終報告 | - |
+
+各 phase 失敗時は task-log を `status: blocked` で保存し、ユーザーに復旧手順を報告する。
+
+---
+
+## 3. Phase 0: 前処理
+
+```
+1. .companies/.active から {org-slug} を取得
+2. git config user.name → {operator}
+3. period を解釈（today / week / month / カスタム、デフォルト today）
+4. git status --porcelain が空でなければ中断
+5. {date_jst} = TZ=Asia/Tokyo date +%Y-%m-%d
+6. {task-id} = YYYYMMDD-HHMMSS-cycle-{period}
+7. .companies/{org}/.task-log/{task-id}.md を YAML フロントマター形式で作成
+   subagents: [company-report, company-evolve, company-dashboard]
+```
+
+task-log の `subagents` 欄には必ず英字で記録する（Case Bank 検出のため）。
+
+---
+
+## 4. Phase 1: /company-report 実行
+
+`@.claude/skills/company-report/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- report の **Section 6** で `/company-evolve` が自動起動される（既存仕様）
+- evolve の副作用（synthesizer / refiner / wf-auto-generation の **複数 PR 生成**）はそのまま許容
+- evolve の `enrich-case-bank.sh` `rebuild-case-bank.sh` などの hook は全て発火する（ローカル実行のため）
+- 各 sub-skill の git 動作（report の PR、evolve の複数 PR）は変更しない
+
+### 完了時に記録する情報
+
+- report MD ファイルパス: `.companies/{org}/docs/secretary/reports/{date}-{period}.md`
+- report Issue URL
+- evolve が生成した PR URL 一覧（synthesizer / refiner / auto-workflow ぞれぞれあれば）
+- evolve のサマリー（評価タスク件数 / 平均 reward / Case Bank 件数）
+
+### Phase 1 の実行方法
+
+ユーザー（あなた = Claude）は以下を順次行う:
+
+1. `@.claude/skills/company-report/SKILL.md` を Read
+2. report の指示に従って Phase 2-1 から Phase 2-5 のデータ収集を実行
+3. AI 要約してレポート MD を生成
+4. ファイル保存・Git commit・Issue 投稿
+5. report Section 6 に従って `/company-evolve` を自動起動
+6. evolve の Phase 2 (Write) と Phase 5.5 を実行
+7. 完了情報を Phase 0 で作成した task-log に追記
+
+---
+
+## 5. Phase 2: /company-dashboard 実行
+
+`@.claude/skills/company-dashboard/SKILL.md` の指示に従って実行する。
+
+### 重要事項
+
+- dashboard は **main 直コミット**（PR 経由ではない、既存仕様）
+- `bash .claude/hooks/generate-dashboard.sh {org-slug}` を実行するだけ
+- 出力: `.companies/{org}/docs/secretary/dashboard.html` および `docs/index.html`
+- **Phase 1 で evolve が更新した Case Bank がここで反映される**（順序が重要）
+
+### 完了時に記録する情報
+
+- dashboard HTML ファイルパス
+- 生成サイズ (KB)
+- GitHub Pages URL
+
+---
+
+## 6. Phase 3: 統合 task-log + Issue + 最終報告
+
+### 6.1 統合 task-log 更新
+
+```yaml
+---
+task_id: "{task-id}"
+org: "{org-slug}"
+operator: "{operator}"
+status: completed
+mode: "direct"
+started: "..."
+completed: "..."
+request: "/company-cycle {period}"
+issue_number: null
+pr_number: null
+subagents: [company-report, company-evolve, company-dashboard]
+sub_skill_results:
+  report:
+    file: ".companies/{org}/docs/secretary/reports/{date}-{period}.md"
+    issue: "https://github.com/.../issues/N"
+    pr: "https://github.com/.../pull/N"
+  evolve:
+    case_bank_count: N
+    avg_reward: 0.00
+    pr_synthesizer: "..." or null
+    pr_refiner: "..." or null
+    pr_workflow: "..." or null
+  dashboard:
+    file: ".companies/{org}/docs/secretary/dashboard.html"
+    size_kb: N
+---
+```
+
+### 6.1.4 ⚠️ 自分の task-log の reward を再評価する（必須）
+
+**Phase 1.5 の evolve は、cycle 自身の task-log をまだ `in-progress` の状態で評価してしまう。**
+
+```
+Phase 1.5  evolve → evaluate_session          ← ここで自分を評価（in-progress）
+Phase 3    task-log を completed にする        ← 評価はもう終わっている
+```
+
+`skill-evaluator.sh` はべき等（`^## reward` があればスキップ）なので、**一度付いた低スコアは完了後も自動では直らない**。
+
+実測（2026-08-16）: 過去の cycle task-log **10 件が `reward = 0.2` で固定**されていた（`completed: false` / `artifacts_exist: false`）。さらに悪いことに、reward が付かなかった 9 件は `rebuild-case-bank.sh` の judge フォールバックで **0.8** を得ている。**早すぎる 0.2 は、reward が無いより悪い。**
+
+**Phase 3 で必ず次を行う**:
+
+```bash
+# 1. フロントマターを status: completed / completed: {ISO8601} に更新したうえで
+# 2. Phase 1.5 が付けた ## reward セクションを削除し
+# 3. 再評価する
+source .claude/hooks/skill-evaluator.sh
+evaluate_session "{org-slug}" "{date_jst}"
+```
+
+実績: 2026-08-16 の 2 回目サイクルで **0.2 → 0.8** に是正。
+
+**注**: `--report-only` など evolve を通らない実行では Phase 1.5 の評価自体が走らないため、この手順は不要（`## reward` が無い状態で再評価すれば正しく付く）。
+
+### 6.1.5 `## judge` セクション追記（dashboard 統合のため必須）
+
+cycle 自体には L2 レビューが無いため、**3 つの sub-skill の判定結果から合成 judge** を生成する。これは `rebuild-case-bank.sh` が読み取り、`/company-dashboard` の「judge スコア推移」グラフに反映される。
+
+合成ロジック（sub_skill_results から導出）:
+- `completeness` = `1.00 if (report.file && evolve.case_bank_count > 0 && dashboard.file) else 0.50`（3 sub-skill 全完了で 1.00）
+- `accuracy` = `report success ? 1.00 : 0.00`（report が判定の中核）
+- `clarity` = `dashboard success ? 1.00 : 0.00`（最終的に可視化されたか）
+- `total` = `(completeness + accuracy + clarity) / 3`
+
+**ただし** sub-skill が独自に judge を書いている場合は **追記しなくてよい**（重複防止）。cycle はオーケストレータなので、判定済みの sub-skill task-log を尊重し、cycle 自身の task-log には judge を書かないのもオプション。デフォルトは「合成 judge を書く」。
+
+```markdown
+## judge
+
+\`\`\`yaml
+completeness: {0.00}
+accuracy: {0.00}
+clarity: {0.00}
+total: {0.00}
+failure_reason: ""
+judge_comment: "/company-cycle 合成 judge: 3 sub-skill (report/evolve/dashboard) 完了状態から導出。詳細な L2 レビューは各 sub-skill の task-log を参照"
+judged_at: "{ISO8601 with TZ}"
+\`\`\`
+```
+
+### 6.2 統合 tracking Issue にコメント
+
+label: `cycle-tracker`
+
+既存 Issue があればコメント追加、なければ新規作成:
+
+- title: `cycle: 統合実行ログ（継続トラッキング）`
+- body 冒頭: workflow の説明 + ローカル実行が必要な理由
+
+コメント内容:
+
+```markdown
+## 🔄 {date_jst} ({DOW_JP}) - /company-cycle {period} 完了
+
+| Phase | 状態 | 成果物 |
+|---|---|---|
+| 1. report | ✅ | [Issue #N](url) / [PR #N](url) |
+| 1.5 evolve (auto) | ✅ | case bank: N 件 / avg reward: X / 生成 PR: N 件 |
+| 2. dashboard | ✅ | [HTML](url) ({size} KB) |
+
+実行時間: N 分
+```
+
+### 6.3 最終報告（ユーザーへ）
+
+```
+✅ /company-cycle {period} 完了
+
+Phase 1 (report):    {report_issue_url}
+  └ 自動連携 evolve: case_bank {N}件 / avg reward {X}
+                    生成 PR: {N}件
+Phase 2 (dashboard): {dashboard_url}
+
+統合 tracking: #{tracking_issue_number}
+合計時間: {duration}
+```
+
+---
+
+## 7. オプションフラグ
+
+| フラグ | 既定 | 効果 |
+|---|---|---|
+| `--period` | today | today / week / month / カスタム日付範囲 |
+| `--skip-evolve` | off | report の自動 evolve 連携をスキップ（debug 用） |
+| `--dashboard-only` | off | report/evolve をスキップし dashboard のみ実行 |
+| `--report-only` | off | dashboard をスキップし report (+ auto evolve) のみ |
+
+---
+
+## 8. なぜローカル実行が必須か
+
+GitHub Actions runner では以下のデータが**完全に存在しない**:
+
+| データ | gitignore | 影響 |
+|---|---|---|
+| `.session-summaries/` | ✅ | report の Section 2.1（最優先） / dashboard のセッション統計 |
+| `.conversation-log/` | ✅ | report の「会話トピック」/ dashboard の頻出フレーズ・enrich-case-bank.sh |
+| `.quality-gate-log/` | ✅ | dashboard の品質ゲート通過率（ドーナツチャート） |
+| `.case-bank/` | ✅ | 毎回 rebuild 必要、永続化されない |
+| `~/.claude/.../memory/feedback_*.md` | - | rebuild-case-bank.sh の feedback memory 統合 |
+
+加えて、`enrich-case-bank.sh` などの hook はローカル Claude Code セッション内で発火する設計のため、Actions 環境では動作しない。
+
+→ **完全な observability を得るためにはローカル実行が必須**。GitHub Actions は補完的に `daily-cycle-supplement.yml` で git tracked データのみの軽量サマリーを生成し、ユーザーに「今日 cycle がまだ走っていない」をリマインドする。
+
+---
+
+## 9. エラー時の中断ポリシー
+
+- 各 Phase で fail → task-log を `status: blocked` で保存
+- ユーザーへの報告に Phase 名・原因・手動復旧コマンドを含める
+- 部分作成済みの PR / コミットは削除しない（手動引き継ぎ用）
+- Phase 1 の report/evolve が部分成功している場合、Phase 2 dashboard はスキップして報告
+
+---
+
+## 10. 関連
+
+- @.claude/skills/company-report/SKILL.md — Phase 1 の本体
+- @.claude/skills/company-evolve/SKILL.md — Phase 1.5 の本体（report から自動起動）
+- @.claude/skills/company-dashboard/SKILL.md — Phase 2 の本体
+- @.github/workflows/daily-cycle-supplement.yml — 19:00 JST の補完 Actions
+- @.claude/rules/review-pattern.md — 将来的な L0/L1/L2 統合（Phase 2 昇格時）
+- @.claude/rules/git-workflow.md — ブランチ・コミット・PR 規約
+
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+Phase 0（前処理）です。今回は **PR #788 で追加した §6.1.4（自分の reward を再評価する手順）の初回検証**を兼ねます。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+ORG=$(tr -d '[:space:]' < .companies/.active); OP=$(git config user.name)
+D=$(TZ=Asia/Tokyo date +%Y-%m-%d); DC=$(TZ=Asia/Tokyo date +%Y%m%d)
+echo "org=$ORG / op
+description: Phase 0: preprocessing
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+org=domain-tech-collection / operator=SAS-Sasao / period=today / date=2026-08-22 (土)
+main: 0cb1f87 docs: ループエンジニアリングと Proof-or-Stop を解析 + 解析カード消失を修正 [domain-tech-collection] by SAS-Sasao (#805)
+未コミット: 0 件
+task-id: [PHONE]30-cycle-today
+branch: domain-tech-collection/docs/2026-08-22-report-today
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+D=2026-08-22; DC=[PHONE]
+echo "=== 2.1 session-summaries ==="
+python3 - <<PY
+import json,glob,collections
+tot=0;by=collections.Counter();n=0
+for f in sorted(glo
+description: Phase 1: collect 5 sources
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 2.1 session-summaries ===
+  セッション 3 / ツール実行 60
+  種別: {'bash': 59, 'other': 1, 'write': 0, 'read': 0}
+
+=== 2.2 task-log（started または completed が 2026-08-22）===
+  [PHONE]53-daily-digest-actions          completed
+  [PHONE]39-insights-cycle                completed
+
+=== 2.3 成果物 / コミット ===
+  変更ファイル: 18
+  main コミット: 6
+
+=== 2.4 PR / Issue ===
+  merged #805 docs: ループエンジニアリングと Proof-or-Stop を解析 + 解析カード消失を修正 [domain-tech
+
+=== 2.5 conversation-log ===
+| 項目 | 値 |
+|---|---|
+| 人間の発言数 | 164 |
+| Claudeの応答数 
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+CL=.companies/domain-tech-collection/.conversation-log
+echo "=== 本日の会話ログファイル ==="
+ls -la $CL/2026-08-22*.md 2>/dev/null | awk '{print "  "$9" ("$5" bytes)"}'
+ech
+description: Verify conversation log stats are for today
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 本日の会話ログファイル ===
+  .companies/domain-tech-collection/.conversation-log/2026-[PHONE]b4fe.md (377293 bytes)
+=== 統計セクション（実値）===
+  2026-[PHONE]b4fe.md:
+    | 人間の発言数 | 164 |
+    | Claudeの応答数 | 286 |
+    | ツール実行数 | 312 |
+    | 人間の発言数 | 319 |
+    | Claudeの応答数 | 550 |
+    | ツール実行数 | 556 |
+    Human 発言 grep 実数: 319
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+会話ログに統計セクションが 2 つあり、最初のものを拾っていました。実数は **319 発言**です（`grep -c` で照合済み）。レポートを作ります。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+mkdir -p .companies/domain-tech-collection/docs/secretary/reports
+cat > .companies/domain-tech-collection/docs/secretary/reports/2026-08-22-today.md <<'EOF'
+# do
+description: Generate today report
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+レポート: 131 .companies/domain-tech-collection/docs/secretary/reports/2026-08-22-today.md
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+T=$(cat /tmp/cyc_ts)
+cat > .companies/domain-tech-collection/.task-log/[PHONE]-${T}-cycle-today.md <<EOF
+---
+task_id: "[PHONE]-${T}-cycle-today"
+org: "domain-t
+description: Create task-log and commit report
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+task-log 作成: [PHONE]30-cycle-today
+remote:
+```
+
+---
+
+## 🤖 Claude
+
+Phase 1.5（`/company-evolve`）を実行します。ここで **§6.1.4 の検証対象**が発生します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+set +e
+TL=.companies/domain-tech-collection/.task-log/[PHONE]30-cycle-today.md
+echo "実行前: status=$(grep -m1 '^status:' $TL | awk '{print $2}') / ## reward=
+description: Phase 1.5: evolve
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+実行前: status=in-progress / ## reward=0 個
+
+=== Skill Evaluator ===
+  → 本 cycle の reward: 0.2  （§6.1.4 が想定する 0.2 が付くはず）
+
+=== Case Bank 再構築 ===
+Case Bank: 250 cases
+=== Synthesizer / Refiner / Enrich ===
+Skill Synthesizer: no viable groups (need 3+)
+Subagent Refiner: no changes needed
+[enrich] Case Bankエントリ強化: 3件
+[enrich] 頻出フレーズ: 1件
+  - 「っぽくコードと関連付けて見れるようにして」(2回)
+  cases 250 / reward 付き 212 / 平均 0.811 / failure_patterns 2
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+§6.1.4 の想定どおり **0.2** が付きました。Phase 2（dashboard）へ。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git add -A && git commit -q -m "chore: evolve 出力を記録 [domain-tech-collection] by SAS-Sasao" && git push -q
+git checkout -q main && git pull -q --ff-only
+echo "mai
+description: Phase 2: dashboard + card survival check
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+main: main / 未コミット 0
+docs/index.html を更新しました
+[main 103875f] chore: ダッシュボード更新 [domain-tech-collection] 2026-08-22 16:41
+ 3 files changed, 73 insertions(+), 76 deletions(-)
+To https://github.com/SAS-Sasao/cc-sier-organization.git
+   422dfb7..103875f  main -> main
+✅ docs/ を更新しました（GitHub Pages 組織別ダッシュボード）
+
+=== ⚠️ dashboard 再生成後も解析カードが残るか（本日の修正の副次確認）===
+  解析カード: 1
+  TodoInsights: 1
+  日次ダイジェスト: 1
+```
+
+---
+
+## 🤖 Claude
+
+3 枚とも生存しています。Phase 3 で **§6.1.4 の再評価手順**を実行します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+git checkout -q domain-tech-collection/docs/2026-08-22-report-today
+TL=.companies/domain-tech-collection/.task-log/[PHONE]30-cycle-today.md
+echo "=== §6.1.
+description: Phase 3: apply 6.1.4 re-evaluation
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== §6.1.4 実行前 ===
+  status: in-progress / reward: 0.2
+  → completed 化 + reward 削除
+=== §6.1.4 実行後 ===
+```yaml
+score: 0.8
+signals:
+    completed: true
+    artifacts_exist: false
+    excessive_edits: false
+    retry_detected: false
+evaluated_at: "2026-08-22T16:41:23"
+```
+```
+
+---
+
+## 🤖 Claude
+
+**§6.1.4 が機能しました。0.2 → 0.8。** 前サイクルで「次サイクルまで未検証」としていた項目が取れました。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+TL=.companies/domain-tech-collection/.task-log/[PHONE]30-cycle-today.md
+python3 - "$TL" <<'PY'
+import sys
+from pathlib import Path
+p=Path(sys.argv[1]); t=p
+description: Complete task-log with verification result
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+Phase 1.5-3 のログ + judge を追記
+pushed
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+gh pr create --title "docs: todayレポートを生成 [domain-tech-collection] 2026-08-22" --body "$(cat <<'EOF'
+## 概要
+
+`/company-cycle today` の Phase 1（`/company-report`）で生成
+description: Create PR and post to tracking issue
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+https://github.com/SAS-Sasao/cc-sier-organization/pull/806
+https://github.com/SAS-Sasao/cc-sier-organization/issues/270#issuecomment-[PHONE]
+```
+
+---
+
+## 🤖 Claude
+
+✅ `/company-cycle today` 完了
+
+```
+Phase 1 (report):     PR #806 — 2026-08-22-today.md
+  └ 自動連携 evolve:  case_bank 250 件 / 平均 reward 0.811
+                      生成 PR: 0 件
+Phase 2 (dashboard):  main 直コミット 103875f
+
+統合 tracking: #270
+```
+
+## 本サイクルの主成果 — §6.1.4 の初回検証に成功
+
+PR #788 で追加した「**自分の task-log の reward を再評価する（必須）**」手順を、初めて実データで通しました。
+
+| 段階 | reward | signals |
+|---|---|---|
+| Phase 1.5 直後（`in-progress`） | **0.2** | `completed: false` |
+| Phase 3 で手順適用後（`completed`） | **0.8** | `completed: true` |
+
+**前サイクルから 2 回持ち越していた「次サイクルまで未検証」が、これで解消しました。** 想定どおり 0.2 が付き、想定どおりの手順で 0.8 に戻りました。
+
+## 本日の実績
+
+| 指標 | 値 |
+|---|---|
+| セッション | 3 |
+| ツール実行（会話ログ実測） | **556** |
+| 人間の発言 | **319** |
+| 変更ファイル | 18 |
+| マージ PR | 1（#805） |
+
+主軸は sbbit 記事の解析（ループエンジニアリング / Proof-or-Stop）と、その過程で見つかった**カード消失の修正**でした。
+
+**副次確認**: dashboard 再生成後も、解析カード / TodoInsights / 日次ダイジェストの **3 枚とも生存**することを実測しました。
+
+## 新たに見つかった懸念
+
+`.session-summaries` が **ツール実行 60** を返す一方、会話ログは **556** でした。**9 倍の乖離**です。長時間継続セッションでサマリーが未書き出しと推測していますが、**調べていません**。
+
+8/16 のレポートでも `files_written` が全件 0 という別の異常を記録しており、**2 回続けて異常値**です。レポートの「次のアクション候補」に調査を入れました。
+
+## 確認していないこと
+
+- **`.session-summaries` の数値乖離は未調査**
+- 本日修正した regex が**実際の nightly で効くかは次の夜まで未確認**（模擬実行と dashboard 再生成での確認のみ）
+- `artifacts_exist: false` の原因（成果物パスの記法）は**未対処**
+- `--skip-evolve` / `--dashboard-only` / `--report-only` は**未使用**
+
+## 残っているもの
+
+PR #806 が open です。採用候補は **A〜BF の 58 項目**、**優先度「高」6 件**（BC / AO / AD / AE / AP / X）を含めて未着手のままです。
+
+次にやるなら **候補 BC（Proof-or-Stop の明文化）**が筋です。今日「消えない」と報告して証拠を取っていなかった実例が出たばかりで、既存の B / C / S / AL を 1 本に束ねられます。
+
+---
+
+## 👤 Human
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+---
+
+## 👤 Human
+
+<command-name>/design</command-name>
+            <command-message>design</command-message>
+            <command-args></command-args>
+
+---
+
+## 👤 Human
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+---
+
+## 👤 Human
+
+<command-name>/design</command-name>
+            <command-message>design</command-message>
+            <command-args>これどうやって使用すればいいの？</command-args>
+
+---
+
+## 👤 Human
+
+'/design'これどうやって使用すればいいの？
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+`/design` は今のセッションのスキル一覧に無い CLI 組み込みコマンドです。推測で答えたくないので、実体を確認します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:ToolSearch
+query: select:DesignSync
+max_results: 3
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+`/design` の実体が分かりました。裏にある `DesignSync` ツールの定義を読みました。ローカル側の状況も確認します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+echo "=== design 関連の Skill がローカルにあるか ==="
+ls -d ~/.claude/skills/*design* .claude/skills/*design* 2>/dev/null || echo "  ローカルには無し（CLI 組み込み側の想定）"
+echo
+echo "=== プ
+description: Check local design-related setup
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== design 関連の Skill がローカルにあるか ===
+  ローカルには無し（CLI 組み込み側の想定）
+
+=== プラグイン由来の design 系 ===
+  frontend-design
+
+=== claude.ai ログインの有無（design 認可の前提）===
+
+=== claude --help に design があるか ===
+```
+
+---
+
+## 🤖 Claude
+
+`/design` は **claude.ai のデザインシステム連携を「使ってよいか」を切り替えるだけのコマンド**です。単体では何も作りません。
+
+## 使い方
+
+```
+/design consent   ← 連携を許可する
+/design revoke    ← 許可を取り消す
+```
+
+引数はこの 2 つだけです。何かを生成したり同期したりはしません。**スイッチです。**
+
+## 何のスイッチか
+
+裏側に `DesignSync` というツールがあり、その説明にこうあります。
+
+> **claude.ai/design のデザインシステムプロジェクト**を、ユーザーの claude.ai ログイン経由で読み書きする。
+
+つまり、
+
+```
+ローカルのコンポーネントライブラリ  ⇄  claude.ai/design のプロジェクト
+```
+
+を同期するための口です。`/design consent` はその**アクセスを認可する行為**で、`revoke` で取り消せます。
+
+## 実際に使うときの流れ
+
+`DesignSync` の説明には、**単体で使うものではない**と明記されています。
+
+> **`/design-sync` スキルと併用**して、ローカルのコンポーネントライブラリを Claude Design プロジェクトと同期し続けること。**1 コンポーネントずつ段階的に。丸ごと置き換えは決してしない。**
+
+なので実運用はこうなります。
+
+| 手順 | やること |
+|---|---|
+| 1 | `/design consent` で認可 |
+| 2 | `/design-sync` でローカル ⇄ リモートを同期 |
+| 3 | 不要になったら `/design revoke` |
+
+書き込みには**プランの確定**という関門があります。「どのパスに書き、どれを消すか」を先に確定させてからでないと write/delete が通りません。誤って全部消す事故を構造的に防ぐ作りです。
+
+## この環境で今すぐ使えるか — 使えません
+
+測った結果です。
+
+| 項目 | 状態 |
+|---|---|
+| `/design-sync` スキル | **ローカルに無い** |
+| design 系プラグイン | `frontend-design` のみ（**別物**。UI のデザイン指針を与えるスキルで、claude.ai 連携ではない） |
+| claude.ai ログイン | `~/.claude.json` から**検出できず** |
+
+`/design consent` を実行しても、**同期する相手（`/design-sync`）が無い**ので先に進めません。
+
+## そもそも、この組織に必要か
+
+**必要ないと思います。** 理由は 2 つです。
+
+- cc-sier が作っているのは **draw.io 図・HTML ダッシュボード・Markdown レポート**で、**React/Vue のコンポーネントライブラリを持っていません**。同期する対象が存在しません
+- HTML は `generate-*.sh` が MD から毎回生成する方式です。デザインシステムとして切り出して管理する構造になっていません
+
+`/company-spawn` で切り出した派生アプリがフロントエンドを持つようになったら、そのとき再検討する価値があります。
+
+## 確認していないこと
+
+- **`/design consent` を実行していません**（認可という外向きの操作なので、指示なく実行するのは避けました）
+- `/design-sync` スキルの**入手方法を調べていません**（プラグインマーケットプレイスにあるのか、CLI に同梱される想定なのかは未確認）
+- claude.ai ログインの検出は `~/.claude.json` の grep のみです。**別の場所に保存されている可能性**は排除できていません
+
+試すなら `/design consent` を打ってみて、何が起きるか（認可ダイアログが出るか、エラーになるか）を見るのが早いです。実行するのは笹尾さんの操作になります。
+
+---
+
+## 👤 Human
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+---
+
+## 👤 Human
+
+<command-name>/design</command-name>
+            <command-message>design</command-message>
+            <command-args>consent</command-args>
+
+---
+
+## 👤 Human
+
+❯ /design consent
+  ⎿  Design agent access granted for your Claude Design projects. Use /design revoke to undo.
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+認可されました。**実際に使える状態になったか**を確認します（読み取りのみ）。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:DesignSync
+method: list_projects
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+{"method":"list_projects","projects":[{"projectId":"9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23","name":"Organic","isOwned":true,"updatedAt":"2026-08-02T01:28:21.296606Z"}]}
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:DesignSync
+method: get_project
+projectId: 9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+{"method":"get_project","projectId":"9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23","name":"Organic","type":"PROJECT_TYPE_DESIGN_SYSTEM","canEdit":true}
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+echo "=== design-sync スキルの厳密な探索（前回は grep が甘かった）==="
+find ~/.claude -maxdepth 5 -iname "*design*sync*" 2>/dev/null | head -5
+find ~/.claude/plugins -maxdepth 4 -i
+description: Verify design-sync skill and login detection
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== design-sync スキルの厳密な探索（前回は grep が甘かった）===
+  /home/toyoki05/.claude/plugins/cache/claude-plugins-official/frontend-design
+  /home/toyoki05/.claude/plugins/marketplaces/claude-plugins-official/plugins/frontend-design
+--- スキル一覧に design-sync はあるか ---
+  ~/.claude/skills/ に design 系なし
+
+=== 前回 grep が失敗した claude.ai ログイン検出を再確認 ===
+  ~/.claude.json 内のヒット数: 4
+  認証系キー: ['oauthAccount']
+```
+
+---
+
+## 🤖 Claude
+
+**前回の報告を 1 点訂正します。** 「claude.ai ログインが検出できず」と書きましたが誤りでした。`~/.claude.json` に `oauthAccount` があり、`claude.ai` の文字列も 4 件ヒットします。私の grep パターン（`"claude_ai[^"]*"`）が雑でした。
+
+## 現在の接続先
+
+`list_projects` / `get_project` を叩いた実測結果です。
+
+| 項目 | 値 |
+|---|---|
+| プロジェクト名 | **Organic** |
+| type | **`PROJECT_TYPE_DESIGN_SYSTEM`** ✅ |
+| 所有 | 本人 |
+| 編集可否 | **可** |
+| 最終更新 | 2026-08-02 |
+
+`type` が `PROJECT_TYPE_DESIGN_SYSTEM` である点が重要です。**この型は作成時に固定で後から変えられません**。通常のプロジェクトに push してもデザインシステムにはならないので、この 1 件が唯一の同期先候補になります。
+
+## できること・できないこと
+
+| 操作 | 状態 |
+|---|---|
+| プロジェクト一覧・メタデータの読み取り | ✅ 動作確認済み |
+| ファイル一覧 / 中身の読み取り | ✅ 可能（未実行） |
+| 書き込み・削除 | ⚠️ **プラン確定（`finalize_plan`）が必須** |
+| **`/design-sync` での同期** | ❌ **スキルがローカルに無い** |
+
+`design-sync` は改めて厳密に探しましたが、`~/.claude/skills/` にもプラグインキャッシュにもありません。あるのは `frontend-design`（UI デザイン指針を与える別物）だけです。
+
+## 書き込みの安全機構
+
+`DesignSync` は書き込み前に必ず関門を通す設計です。
+
+```
+list/read → finalize_plan（書くパス・消すパスを確定） → write/delete
+```
+
+> プランなしで、あるいはプラン外のパスに write / delete / register を呼ぶと**拒否される**
+
+さらに `finalize_plan` の時点で**パス一覧と読み取り元ディレクトリがユーザーに提示される**ため、私の説明とは独立に中身を確認できます。丸ごと置き換え事故を構造的に防ぐ作りです。
+
+## この組織で使うなら
+
+前回書いたとおり、**cc-sier 本体には同期する対象がありません**（draw.io 図・生成 HTML・Markdown が成果物で、コンポーネントライブラリを持っていない）。
+
+一方で `Organic` は 8/2 更新の実在プロジェクトなので、**cc-sier とは別の文脈**で作られたものと思われます。そちらで使うなら意味があります。
+
+## 次に何をするか
+
+やりたいことによって分かれます。
+
+- **中身を見たい** → `list_files` で `Organic` の構造を読めます（読み取りのみ、権限プロンプトなし）
+- **同期したい** → `/design-sync` スキルの入手が先です。**どこから入るかは未確認**なので、`/plugin marketplace` を見るか、Anthropic 側のドキュメント確認が要ります
+- **使わない** → `/design revoke` で取り消せます
+
+## 確認していないこと
+
+- **`Organic` の中身は読んでいません**（`list_files` 未実行）
+- **`/design-sync` の入手方法を調べていません**（マーケットプレイス掲載か CLI 同梱かが不明）
+- 書き込み系（`finalize_plan` 以降）は**一切実行していません**
+
+どうしますか。`Organic` の中身だけ覗いてみますか？
+
+---
+
+## 👤 Human
+
+Use the claude_design MCP (https://api.anthropic.com/v1/design/mcp, auth via /design-login) to import this project:
+https://claude.ai/design/p/14fffc24-d353-4ebd-9468-b614e726c557?file=Portal.dc.html
+
+Focus on these files (the whole project is readable):
+- `Portal.dc.html`
+
+Implement: `Portal.dc.html` これ読める？？今公開しているpagesのデザイン刷新案なんだけど！
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:DesignSync
+method: get_project
+projectId: 14fffc24-d353-4ebd-9468-b614e726c557
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+{"method":"get_project","projectId":"14fffc24-d353-4ebd-9468-b614e726c557","name":"CC-SIER組織ポータル刷新案","type":"PROJECT_TYPE_PROJECT","canEdit":true}
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+読めます。`CC-SIER組織ポータル刷新案` にアクセスできました。ファイルを確認します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:DesignSync
+method: list_files
+projectId: 14fffc24-d353-4ebd-9468-b614e726c557
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+{"method":"list_files","paths":["_ds","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23",".thumbnail","Portal.dc.html","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23/_adherence.oxlintrc.json","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23/_ds_bundle.js","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23/_ds_manifest.json","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23/readme.md","_ds/organic-9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23/styles.css","support.js"]}
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:DesignSync
+method: get_file
+projectId: 14fffc24-d353-4ebd-9468-b614e726c557
+path: Portal.dc.html
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+<persisted-output>
+Output too large (63.7KB). Full output saved to: /home/toyoki05/.claude/projects/-home-toyoki05-cc-sier-organization/9637b4fe-bb63-4823-9a31-c9d72a2a1d9e/tool-results/toolu_01JfF7MD2RbtdhzuqewtGmYe.txt
+
+Preview (first 2KB):
+{"method":"get_file","path":"Portal.dc.html","content":"<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<script src=\"./support.js\"></script>\n</head>\n<body>\n<x-dc>\n<he
+```
+
+---
+
+## 🤖 Claude
+
+
+---
+
+## 🤖 Claude
+
+読めました。**「CC-SIER組織ポータル刷新案」**、63.7KB の 1 ファイルです。構造を解析します。
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+F=/home/toyoki05/.claude/projects/-home-toyoki05-cc-sier-organization/9637b4fe-bb63-4823-9a31-c9d72a2a1d9e/tool-results/toolu_01JfF7MD2RbtdhzuqewtGmYe.txt
+python
+description: Analyze design tokens and fonts
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+HTML: 62,567 字 / 600 行
+
+=== 使用フォント ===
+   Caprasimo
+   Figtree:wght@300;400;500;600;700
+   Zen+Maru+Gothic:wght@400;500;700
+
+=== デザイントークン（var(--...)）上位 ===
+   --space-4                     63 回
+   --space-3                     62 回
+   --font-heading                37 回
+   --space-8                     32 回
+   --color-neutral-700           26 回
+   --color-accent-200            24 回
+   --space-2                     24 回
+   --color-bg                    22 回
+   --color-accent-2-300          21 回
+  
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+python3 - <<'PY'
+import re
+h=open('/tmp/portal.html',encoding='utf-8').read()
+body = h.split('</helmet>',1)[1] if '</helmet>' in h else h
+
+print("=== 画面構造（見出しテキス
+description: Extract heading structure
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== 画面構造（見出しテキスト）===
+--- font-heading を使う要素（＝見出し）---
+    cc-sier
+    27
+    67
+    0.81
+    1192
+    domain-tech-collection
+    standardization-initiative
+    日次ダイジェスト
+    AWS 構成図
+    draw.io ダイアグラム
+    ナレッジポータル
+    TodoInsights
+    M1
+    M2
+    M3
+    M4
+    202
+    0.81
+    0.800
+    13
+    改善アクション ─ 正確性（全体平均 0.85）
+    1192
+    wf-daily-digest
+    0.8
+    N/A
+    0.800
+    0.95
+    secretary
+    +0.05
+    0.99
+    153
+```
+
+---
+
+## 🤖 Claude
+
+
+```tool_use:Bash
+command: cd /home/toyoki05/cc-sier-organization
+python3 - <<'PY'
+import re
+h=open('/tmp/portal.html',encoding='utf-8').read()
+body=h.split('</helmet>',1)[1]
+print("=== サイドバー nav の項目 ===")
+nav = re.search(r'<na
+description: Extract nav and components
+```
+
+---
+
+## 👤 Human
+
+```tool_result
+=== サイドバー nav の項目 ===
+    ホーム
+    {{ kHome }}
+    ダッシュボード
+    {{ kDash }}
+    ナレッジ
+    {{ kKnow }}
+    日次ダイジェスト
+    {{ kDigest }}
+    図表ギャラリー
+    {{ kDia }}
+    インサイト
+    {{ kIns }}
+
+=== 使われている DS コンポーネント（カスタム要素）===
+   <sc-if> 8 回
+```
+
+---
+
+## 🤖 Claude
+
+読めました。**現行 Pages の実データを反映した、かなり作り込まれた刷新案**です。
+
+## 何が入っているか
+
+| 項目 | 内容 |
+|---|---|
+| ファイル | `Portal.dc.html` 単体（**62,567 字 / 600 行**） |
+| プロジェクト名 | CC-SIER組織ポータル刷新案 |
+| type | `PROJECT_TYPE_PROJECT`（デザインシステムではなく通常プロジェクト） |
+| 参照 DS | **`Organic`**（先ほど見た `9ccf8d1e-...`）を `_ds/` として同梱 |
+
+つまり **`Organic` デザインシステムを土台に、cc-sier のポータルを作り直した案**です。
+
+## 画面構成
+
+```
+┌────────────┬──────────────────────────────┐
+│ cc-sier    │                              │
+│ Organization                              │
+│ Portal     │   （メイン領域）              │
+│            │                              │
+│ ホーム      │   組織カード                  │
+│ ダッシュボード│   マイルストーン M1〜M4        │
+│ ナレッジ    │   judge スコア                │
+│ 日次ダイジェスト│  改善アクション              │
+│ 図表ギャラリー│   ワークフロー                │
+│ インサイト   │                              │
+└────────────┴──────────────────────────────┘
+   274px 固定サイドバー（sticky）
+```
+
+現行トップページが**カードを縦に並べただけ**なのに対し、こちらは**サイドバーナビ + ダッシュボード**の構成です。
+
+## 実データが入っている
+
+ハリボテではありません。中に本物の数字が埋まっています。
+
+- `domain-tech-collection` / `standardization-initiative`（**実在の組織**）
+- 日次ダイジェスト / AWS 構成図 / draw.io / ナレッジポータル / TodoInsights（**実在の 5 コンテンツ**）
+- **`0.81`** ← 今日測った Case Bank の平均 reward と一致
+- **`202`** / `1192` / `153` / `13` などの実測値
+- `wf-daily-digest`、`secretary`、`M1〜M4`
+- 「改善アクション ─ 正確性（全体平均 0.85）」← ダッシュボードの改善インサイト機能そのもの
+
+## デザインの中身
+
+**フォント**（日本語を意識した組み合わせ）
+
+| 用途 | 欧文 | 和文 |
+|---|---|---|
+| 見出し | **Caprasimo** | Zen Maru Gothic |
+| 本文 | **Figtree** | Zen Maru Gothic |
+
+`--font-heading` を **37 箇所**で使っており、見出しに一貫して効かせています。`font-variant-numeric: tabular-nums` も指定されていて、**数字が桁で揃う**ようになっています（スコアや件数を並べるダッシュボードでは効きます）。
+
+**トークン運用**が徹底しています。色・余白・角丸をすべて `var(--...)` で参照し、生の色コードをほぼ使っていません。`--space-4` が 63 回、`--space-3` が 62 回で、余白が数種類に統制されています。
+
+**アニメーション**は 2 つだけ。`pulseSoft`（点滅）と `riseIn`（下からふわっと）。控えめです。
+
+## 現行との差
+
+| | 現行 `docs/index.html` | 刷新案 |
+|---|---|---|
+| サイズ | 3.8 KB | **62.6 KB** |
+| 構成 | カード 8 枚を並べただけ | サイドバー + ダッシュボード |
+| 色指定 | ベタ書き（`#0b1222` 等） | **全面トークン化** |
+| フォント | system-ui | **Caprasimo / Figtree / Zen Maru Gothic** |
+| データ | 静的リンクのみ | **実測値を表示** |
+
+## そのままでは動きません
+
+読んだうえでの技術的な注意です。
+
+`<x-dc>` `<helmet>` `<sc-if>`（8 箇所）といった**独自要素**と、`{{ kHome }}` 形式の**テンプレート変数**が使われています。これらは `support.js` と `_ds_bundle.js` が解釈する前提で、**素の GitHub Pages に置いても描画されません**。
+
+GitHub Pages に載せるなら、どこかで
+
+- 独自要素とテンプレート変数を**素の HTML に展開する**
+- `_ds/` のスタイルを**同梱する**（Google Fonts は外部参照のままで可）
+- 表示している数値を**何が生成するか決める**（現状 `generate-dashboard.sh` が担当）
+
+が要ります。
+
+## 確認していないこと
+
+- **`support.js` と `_ds_bundle.js` の中身を読んでいません**。`<sc-if>` や `{{ }}` がどう解決されるか未確認です
+- **ブラウザで描画していません**。構造とトークンの読み取りのみで、**見た目は確認していません**
+- 埋まっている数値（`202` / `1192` / `153` 等）が**何の指標か特定していません**。`0.81` が Case Bank 平均と一致するのは確認しました
+- **書き込み系は一切実行していません**
+
+---
+
+どう進めますか。選択肢としては:
+
+1. **見た目を先に確認** — `support.js` / `_ds_bundle.js` も取得してローカルで開けるようにする
+2. **移植の実現性を調べる** — 独自要素を素の HTML に落とす手順を設計する
+3. **現行との差分を整理** — 何を捨てて何を採るかの判断材料を作る（`/company-drawio` や解析レポートと同じ形で成果物化）
+
+`Organic` 側の中身もまだ見ていないので、必要なら合わせて読みます。
+
+---
+
 ## 統計
 
 | 項目 | 値 |
 |---|---|
-| 人間の発言数 | 319 |
-| Claudeの応答数 | 550 |
-| ツール実行数 | 556 |
+| 人間の発言数 | 351 |
+| Claudeの応答数 | 597 |
+| ツール実行数 | 598 |
 | マスキング適用 | 0 種類 |
 
 ---

--- a/.companies/domain-tech-collection/.session-summaries/20260822-164254-9637b4fe.json
+++ b/.companies/domain-tech-collection/.session-summaries/20260822-164254-9637b4fe.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e",
+  "org_slug": "domain-tech-collection",
+  "date": "2026-08-22",
+  "datetime": "2026-08-22 16:42:54",
+  "tool_count": 46,
+  "by_type": {
+    "write": 0,
+    "read": 0,
+    "bash": 45,
+    "other": 1
+  },
+  "files_written": [],
+  "log_file": ".companies/domain-tech-collection/.interaction-log/2026-08-22.md"
+}

--- a/.companies/domain-tech-collection/.session-summaries/20260822-194813-9637b4fe.json
+++ b/.companies/domain-tech-collection/.session-summaries/20260822-194813-9637b4fe.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e",
+  "org_slug": "domain-tech-collection",
+  "date": "2026-08-22",
+  "datetime": "2026-08-22 19:48:13",
+  "tool_count": 48,
+  "by_type": {
+    "write": 0,
+    "read": 0,
+    "bash": 46,
+    "other": 2
+  },
+  "files_written": [],
+  "log_file": ".companies/domain-tech-collection/.interaction-log/2026-08-22.md"
+}

--- a/.companies/domain-tech-collection/.session-summaries/20260822-194942-9637b4fe.json
+++ b/.companies/domain-tech-collection/.session-summaries/20260822-194942-9637b4fe.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e",
+  "org_slug": "domain-tech-collection",
+  "date": "2026-08-22",
+  "datetime": "2026-08-22 19:49:42",
+  "tool_count": 51,
+  "by_type": {
+    "write": 0,
+    "read": 0,
+    "bash": 47,
+    "other": 4
+  },
+  "files_written": [],
+  "log_file": ".companies/domain-tech-collection/.interaction-log/2026-08-22.md"
+}

--- a/.companies/domain-tech-collection/.session-summaries/20260822-195243-9637b4fe.json
+++ b/.companies/domain-tech-collection/.session-summaries/20260822-195243-9637b4fe.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "9637b4fe-bb63-4823-9a31-c9d72a2a1d9e",
+  "org_slug": "domain-tech-collection",
+  "date": "2026-08-22",
+  "datetime": "2026-08-22 19:52:43",
+  "tool_count": 57,
+  "by_type": {
+    "write": 0,
+    "read": 0,
+    "bash": 50,
+    "other": 7
+  },
+  "files_written": [],
+  "log_file": ".companies/domain-tech-collection/.interaction-log/2026-08-22.md"
+}

--- a/.companies/domain-tech-collection/.task-log/20260822-200021-portal-redesign-plan.md
+++ b/.companies/domain-tech-collection/.task-log/20260822-200021-portal-redesign-plan.md
@@ -1,0 +1,70 @@
+---
+task_id: "20260822-200021-portal-redesign-plan"
+org: "domain-tech-collection"
+operator: "SAS-Sasao"
+status: completed
+mode: "direct"
+started: "2026-08-22T17:00:00"
+completed: "2026-08-22T17:20:00"
+request: "明日からデザインの移植（実態のページに合わせて）を行いたい。計画書いて。／HTML作成のSKILLも変更必要だから計画に載せてね"
+issue_number: null
+pr_number: null
+subagents: []
+l0_gate: null
+l0_retries: 0
+l1_gate: null
+l1_retries: 0
+l2_composite: null
+l2_retries: 0
+---
+
+## 実行計画
+
+- **実行モード**: direct
+- **判断理由**: 計画立案のみ。実装は明日以降。
+
+## エージェント作業ログ
+
+### [2026-08-22 17:00] 移植元の調査
+
+Claude Design の `DesignSync` ツールで読み取り（`/design consent` 済み）。
+
+| 対象 | 結果 |
+|---|---|
+| `CC-SIER組織ポータル刷新案` | type: `PROJECT_TYPE_PROJECT` / `Portal.dc.html` **62,567 字** |
+| `Organic` DS | type: `PROJECT_TYPE_DESIGN_SYSTEM` / readme を精読 |
+| `support.js` | **React ランタイム**（`window.React` 必須、70.6 KB） |
+
+**重要な判明事項**: `Portal.dc.html` は `<x-dc>` / `<sc-if>`×8 / `{{ }}`×42 を使う **6 画面の対話プロトタイプ**。**素の GitHub Pages では描画されない**。
+
+### [2026-08-22 17:10] 自組織の実測
+
+- 現行 Pages **8 本すべてがスクリプト生成物**。手で維持されている HTML は 0
+- テーマが正反対（現行 `#0b1222` ダーク ↔ Organic `#f5ead8` クリーム）
+- `docs/index.html` は **4 つの処理**が書き込む
+
+### [2026-08-22 17:15] オーナー指摘を反映
+
+「HTML作成のSKILLも変更必要だから計画に載せてね」を受けて実測し §2.4 を新設。
+
+| 対象 | 件数 |
+|---|---|
+| SKILL.md（HTML/CSS 規定あり） | **9 本** |
+| L2 採点プロンプト（構造採点） | **5 本** |
+
+`@.claude/rules/skill-development.md` の「**片方だけ更新すると L2 レビューが旧仕様で通過してしまう**」に該当。**生成器 / SKILL.md / review-prompt.md の 3 点セット**を各 Day のチェックリストに入れた。
+
+### [2026-08-22 17:20] 成果物
+
+- `docs/decisions/2026-08-22-portal-redesign-plan.md`（**358 行**）
+- 構成: 現状実測 → 移植方針 → §2.4 Skill も対象 → Day 1〜6 の段階計画 → オーナー判断 4 件 → リスク → 未確認事項 10 件
+
+## 未検証事項
+
+- **`Portal.dc.html` を描画していない**。構造とトークンの読み取りのみで**見た目を一度も見ていない**（Day 1-2 で解消予定）
+- **`styles.css` を取得していない**。「1 枚で自己完結」は readme の記述に依存
+- **`_ds_bundle.js` を読んでいない**。`.card` 等が CSS だけで完結するか未確認
+- `company-sheet` / `company-daily-digest` の L2 が**デザイン変更の影響を受けるか未確認**
+- **既存成果物（図 44 本等）を再生成するかを決めていない**
+- 1 日 1 段階という見積もりは**楽観的である可能性がある**（対象 28 ファイル前後）
+- **Day 1 以降は一切着手していない**

--- a/.companies/domain-tech-collection/docs/decisions/2026-08-22-portal-redesign-plan.md
+++ b/.companies/domain-tech-collection/docs/decisions/2026-08-22-portal-redesign-plan.md
@@ -1,0 +1,376 @@
+# GitHub Pages デザイン刷新 移植計画
+
+| 項目 | 内容 |
+|------|------|
+| ドキュメント種別 | 移植計画書 |
+| 作成日 | 2026-08-22 |
+| 作成者 | 技術リサーチ室（秘書室主導） |
+| 依頼 | 「明日からデザインの移植（実態のページに合わせて）を行いたい。計画書いて」 |
+| 移植元 | Claude Design プロジェクト **CC-SIER組織ポータル刷新案**（`Portal.dc.html`、62,567 字） |
+| 参照 DS | **Organic**（`9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23`、type: `PROJECT_TYPE_DESIGN_SYSTEM`） |
+| ステータス | **計画のみ。実装は未着手** |
+
+---
+
+## 0. 3 行で
+
+- 移植元は **React で動く 6 画面のプロトタイプ**。**そのままでは GitHub Pages で描画されない**。
+- 現行ページは **8 本すべてがスクリプト生成物**。手で HTML を置いても**次の生成で消える**。
+- したがって移植とは「HTML を差し替える」ことではなく、**`styles.css` を持ち込み、生成器のテンプレートを書き換える**作業になる。
+- **さらに Skill 側（SKILL.md 9 本 + L2 採点プロンプト 5 本）も同時に直す必要がある。** 片方だけ直すと L2 が旧仕様で通してしまう。
+
+---
+
+## 1. 現状の実測（2026-08-22）
+
+### 1.1 現行 Pages の全体像
+
+| ページ | サイズ | 生成元 |
+|---|---|---|
+| `docs/index.html` | 3.7 KB | `generate-dashboard.sh`（**＋3 スクリプトがカードを挿入**） |
+| `docs/secretary/{org}/dashboard.html` | 67.3 KB | `generate-dashboard.sh` |
+| `docs/daily-digest/index.html` | **5,933 KB** | `generate-daily-digest-html.sh` |
+| `docs/handover/index.html` | 567 KB | `generate-handover-html.sh` |
+| `docs/insights/index.html` | 31.7 KB | `generate-insights-html.py` |
+| `docs/insights/analyses/index.html` | 7.0 KB | `generate-insights-analyses-html.sh` |
+| `docs/diagrams/index.html` | 26.9 KB | `/company-diagram` 系 |
+| `docs/drawio/index.html` | 19.2 KB | `/company-drawio` |
+
+**手で維持されている HTML は 1 つも無い。**
+
+### 1.2 テーマが正反対
+
+| | 現行 | Organic |
+|---|---|---|
+| 地色 | `#0b1222`（**ダーク**） | `#f5ead8`（**クリーム / ライト**） |
+| アクセント | `#3b82f6`（青） | `#c67139`（テラコッタ） |
+| 第 2 アクセント | なし | `#7a8a5e`（セージ） |
+| 見出しフォント | system-ui | **Caprasimo** |
+| 本文フォント | system-ui | **Figtree** + Zen Maru Gothic |
+| 角丸 | 8px | **16px / ボタンは 999px（ピル）** |
+
+**単なる配色変更ではなく、明暗の反転を含む全面刷新**である。
+
+### 1.3 移植元の実体
+
+`Portal.dc.html` は静的 HTML ではない。
+
+| 要素 | 中身 |
+|---|---|
+| `<x-dc>` | `support.js`（**React ランタイム**、70.6 KB）が解釈するテンプレート |
+| `<sc-if>` × 8 | **画面の出し分け**（home / dash / know / digest / dia / ins） |
+| `{{ }}` × 42（ユニーク 33） | 大半が**ナビ状態とキーボードヒント**（`goDash` / `isHome` / `kHome` 等）。実データ変数ではない |
+| `data-props` | `initialScreen` の enum（home/dash/know/digest/…） |
+
+`support.js` は冒頭で `window.React` / `window.ReactDOM` を要求する。**React を読み込まない限り何も描画されない。**
+
+つまり `Portal.dc.html` は **「1 ファイルに 6 画面を詰めた対話プロトタイプ」**であり、配布物ではない。
+
+---
+
+## 2. 移植方針
+
+### 2.1 採るもの・捨てるもの
+
+| | 扱い | 理由 |
+|---|---|---|
+| **`styles.css`（Organic の唯一のスタイルシート）** | ✅ **そのまま採る** | DS 側が「全ページからこの 1 枚をリンクせよ」と明言。自己完結しており Pages に置ける |
+| **マークアップ構造・クラス**（`.card` `.btn` `.tag` `.nav` `.table`） | ✅ **採る** | DS が「component ページは素の HTML なので view source してコピーせよ」と明記 |
+| **画面レイアウト**（274px サイドバー + メイン） | ✅ **採る** | 現行のカード羅列より情報設計が良い |
+| **Google Fonts の 3 書体** | ✅ 採る | 外部参照のままで可 |
+| `<x-dc>` / `<sc-if>` / `{{ }}` | ❌ **捨てる** | React 前提。生成器（bash / python）と噛み合わない |
+| `support.js` / `_ds_bundle.js` | ❌ **捨てる** | 同上 |
+| React 本体 | ❌ **持ち込まない** | 現行パイプラインに npm もビルドも無い |
+
+### 2.2 中心となる判断
+
+> **移植先は HTML ファイルではなく、生成器のテンプレートである。**
+
+`docs/index.html` を手で書き換えても、次に `generate-dashboard.sh` が走った時点で消える。実際、**解析レポートのカードが 6 日間毎晩消えていた**事故が 2026-08-22 に発覚したばかりである（`generate-insights-html.py` の正規表現が巻き添え削除していた）。
+
+**同じ轍を踏まないため、この計画では最初から生成器を書き換える。**
+
+### 2.3 画面マッピング
+
+プロトタイプの 6 画面は、実ページにそのまま対応する。
+
+| プロトタイプ画面 | 実ページ | 生成器 |
+|---|---|---|
+| `home` | `docs/index.html` | `generate-dashboard.sh` |
+| `dash` | `docs/secretary/{org}/dashboard.html` | `generate-dashboard.sh` |
+| `know` | `docs/handover/index.html` | `generate-handover-html.sh` |
+| `digest` | `docs/daily-digest/index.html` | `generate-daily-digest-html.sh` |
+| `dia` | `docs/diagrams/` + `docs/drawio/` | `/company-diagram` 系 / `/company-drawio` |
+| `ins` | `docs/insights/analyses/` | `generate-insights-analyses-html.sh` |
+
+**プロトタイプの画面切替（`<sc-if>`）は、実世界では「サイドバーのリンク」になる。** React が要らなくなるのはこのためである。
+
+---
+
+## 2.4 ⚠️ 生成器だけ直しても足りない — Skill も対象
+
+`docs/` の HTML は **hooks（生成器）と Skill（指示書）の両方**が形を決めている。**片方だけ直すと必ず事故る。**
+
+### 2.4.1 なぜ Skill も直すのか
+
+`@.claude/rules/skill-development.md` にこう明記されている。
+
+> SKILL.md の必須セクション変更は **必ず** `references/review-prompt.md` の採点基準にも反映する。**片方だけ更新すると L2 レビューが旧仕様で通過してしまう。**
+
+さらに `@CLAUDE.md` は `/company-diagram` の詳細ページについて **必須 7 セクション固定順序**（凡例 → 概要 → データフロー → レイヤー構成 → 設計のポイント → コスト概算 → 学習ポイント）を定め、**順序違反も `critical_triggered = true` 扱い**としている。
+
+**デザインを変えて構造が変われば、この採点基準ごと作り直しになる。**
+
+> 過去の実例: `/company-diagram` の 9 フェーズ化リライトで `aws-cost-estimation.md` 参照と学習ポイント生成を取りこぼし、**PR #251 → #253 → #254 の 3 段階ですり抜け修正**が発生している。
+
+### 2.4.2 対象一覧（実測 2026-08-22）
+
+**SKILL.md に HTML / CSS の規定を含むもの — 9 本**
+
+| Skill | 言及箇所 | 対応するページ |
+|---|---|---|
+| `company-diagram-v2` | **33** | `docs/diagrams/` |
+| `company-drawio` | **32** | `docs/drawio/` |
+| `company-diagram` | **31** | `docs/diagrams/` |
+| `company-insights-cycle` | 20 | `docs/insights/analyses/` |
+| `company-digest-html` | 18 | `docs/daily-digest/` |
+| `company-daily-digest` | 13 | `docs/daily-digest/` |
+| `company-handover` | 10 | `docs/handover/` |
+| `company-dashboard` | 5 | `docs/index.html` / `dashboard.html` |
+| `company-cycle` | 4 | （オーケストレータ。参照のみ） |
+
+**L2 採点プロンプトで HTML 構造を採点しているもの — 5 本**
+
+| Skill | 構造言及 | 備考 |
+|---|---|---|
+| `company-diagram-v2` | **39** | 最も重い |
+| `company-diagram` | 24 | 必須 7 セクションを採点 |
+| `company-drawio` | 23 | |
+| `company-sheet` | 7 | xlsx 側。**HTML 刷新の影響は薄いと推測（未確認）** |
+| `company-daily-digest` | 4 | |
+
+**加えて `@CLAUDE.md` 本体**にも必須 7 セクションの規定があり、変更するなら 3 箇所（SKILL.md / review-prompt.md / CLAUDE.md）を揃える必要がある。
+
+### 2.4.3 各ページで「3 点セット」を揃える
+
+**ページを 1 つ直すたびに、次の 3 つを同時に更新する。**
+
+```
+① hooks の生成器          … 実際に出る HTML
+② SKILL.md               … 何を出すべきかの指示
+③ references/review-prompt.md … 出たものをどう採点するか
+```
+
+**②③ を放置すると、新デザインの成果物が「旧仕様に合っていない」として L2 に落とされる**か、逆に**旧仕様のまま通ってしまう**。どちらも起きる。
+
+### 2.4.4 同期を忘れない
+
+`plugins/cc-sier/skills/` が **VCS 真ソース**で、`.claude/skills/` は同期先である。
+
+```bash
+cp plugins/cc-sier/skills/{name}/SKILL.md .claude/skills/{name}/SKILL.md
+cp plugins/cc-sier/skills/{name}/references/*.md .claude/skills/{name}/references/
+diff -rq plugins/cc-sier/skills/{name}/ .claude/skills/{name}/
+```
+
+> **なお現時点で `plugins/` に存在しない Skill が 3 本ある**（`company-evolve` / `company-quality-setup` / `company-report`、カタログ候補 AE）。**本移植の対象ではない**が、触る場合は先に移送が要る。
+
+---
+
+## 3. 段階計画
+
+**原則: 1 ページずつ。全部いっぺんに変えない。**
+
+理由は 2 つ。①生成器が 6 本あり、壊したときの切り分けが不可能になる ②`docs/index.html` は 4 つの処理が書き込む特殊なファイルで、最後に回すべきである。
+
+### Day 1 — 土台を置く（変更を伴わない）
+
+| # | 作業 | 完了条件（証拠） |
+|---|---|---|
+| 1-1 | `Organic` から `styles.css` を取得し `docs/assets/organic/styles.css` に配置 | ファイルが存在し、`--color-bg: #f5ead8` を含む |
+| 1-2 | `Portal.dc.html` をローカルで**描画して目視**する（React を CDN で読ませた検証用 HTML を `/tmp` に作る） | **スクリーンショットまたは目視で「見えた」と言える状態** |
+| 1-3 | 6 画面それぞれのマークアップを抽出し、`<sc-if>` を外した素の HTML 断片として `/tmp` に保存 | 6 ファイルが生成され、`{{` が 0 件 |
+| 1-4 | Lucide アイコンの扱いを決める（CDN / インライン SVG / 使わない） | 決定が本計画書に追記されている |
+
+> **Day 1 は `docs/` を一切変更しない。** 土台の確認だけで終える。
+
+### Day 2 — いちばん安全な 1 ページで試す
+
+対象: **`docs/insights/analyses/index.html`**
+
+選定理由: ①生成器が 1 本だけ（`generate-insights-analyses-html.sh`）②他の処理が触らない ③**自分で作った生成器なので構造を把握している** ④壊れても影響が解析レポート閲覧に限定される
+
+| # | 作業 | 完了条件（証拠） |
+|---|---|---|
+| 2-1 | `generate-insights-analyses-html.sh` の `STYLE` 定数を Organic トークン参照に置き換え | 生成された HTML に `var(--color-` が出現し、生の `#0b1222` が 0 件 |
+| 2-2 | 一覧ページを `.card` クラス構成に変更 | `class="card"` が出現 |
+| 2-3 | 個別レポートページに `.table` `.tag` を適用 | 生成 10 本すべてでエラーなし |
+| 2-4 | **`company-insights-cycle/SKILL.md` の Phase 2 記述を新デザインに合わせる** | SKILL.md に旧構造の記述が残っていない |
+| 2-5 | **ブラウザで開いて目視** | ライト/ダーク両方で表示確認（**目視必須**） |
+| 2-6 | リンク健全性検査 | 壊れたリンク 0 件 |
+| 2-7 | `plugins/` ↔ `.claude/skills/` を同期 | `diff -rq` が差分なし |
+
+> `company-insights-cycle` に **L2 採点プロンプトは無い**（レビュー付き Skill ではない）。**3 点セットのうち ③ が無い最も軽いケース**であり、Day 2 の題材として適している。
+
+### Day 3 — 独立した 2 ページ
+
+対象: `docs/diagrams/` と `docs/drawio/`（互いに独立、他が触らない）
+
+**本移植で最も重い 2 ページ。** Day 2 のような「生成器だけ」では済まない。
+
+| # | 作業 | 完了条件（証拠） |
+|---|---|---|
+| 3-1 | 生成器（`/company-drawio` の HTML 出力部）を Organic トークンへ | 生の色コード 0 件 |
+| 3-2 | **`company-drawio/SKILL.md`**（HTML 言及 **32 箇所**）を更新 | 旧構造の記述が残っていない |
+| 3-3 | **`company-drawio/references/review-prompt.md`**（構造言及 **23 箇所**）の採点基準を新構造へ | 新旧の基準が混在していない |
+| 3-4 | 同じ 3 点を `company-diagram-v2`（SKILL **33** / review **39**）に適用 | 同上 |
+| 3-5 | `company-diagram`（SKILL **31** / review **24**）も同様 | 同上 |
+| 3-6 | **`CLAUDE.md` の必須 7 セクション規定**を新構造に合わせるか判断 | 判断が計画書に追記されている |
+| 3-7 | **実際に 1 図を生成して L0/L1/L2 を通す** | `l2_composite ≥ 0.85` かつ `critical_triggered: false` |
+| 3-8 | `plugins/` ↔ `.claude/skills/` 同期 | `diff -rq` 差分なし |
+
+> **3-7 が本 Day の本体である。** 採点基準を書き換えたら、**実際にレビューを通してみるまで直ったとは言えない**。
+>
+> **Day 2 で問題が出た場合はここに進まず、Day 2 に戻る。**
+
+### Day 4 — 大物 2 ページ
+
+対象: `docs/daily-digest/index.html`（**5.9 MB**）と `docs/handover/index.html`（567 KB）
+
+**注意**: daily-digest は毎晩 GitHub Actions が生成する。生成器を変えると**翌朝から本番に出る**。ローカルで生成 → 目視 → その後に main へ入れる順序を守る。
+
+3 点セットの対象:
+
+| ページ | 生成器 | SKILL.md | review-prompt.md |
+|---|---|---|---|
+| daily-digest | `generate-daily-digest-html.sh` | `company-digest-html`（18）+ `company-daily-digest`（13） | `company-daily-digest`（4） |
+| handover | `generate-handover-html.sh` | `company-handover`（10） | **無し** |
+
+> `company-daily-digest` の L2 は **s6「禁則違反」が致命軸**で、絵文字禁止など**文面のルール**を採点している。**デザイン変更で影響を受けるかは未確認**。Day 4 で確認する。
+
+### Day 5 — ダッシュボードとトップ（最難関）
+
+対象: `docs/secretary/{org}/dashboard.html` と `docs/index.html`
+
+**`docs/index.html` は 4 つの処理が書き込む。**
+
+| 処理 | 起動元 |
+|---|---|
+| `generate-dashboard.sh` | ローカル `/company-dashboard`（**workflow からは呼ばれない**） |
+| `generate-insights-html.py` | daily-insights-sync（**毎晩**） |
+| `generate-daily-digest-html.sh` | daily-digest-automation（**毎晩**） |
+| `generate-insights-analyses-html.sh` | ローカル `/company-insights-cycle` |
+
+サイドバー構成にすると、**現在の「カードを末尾に挿入する」方式が成立しなくなる**。3 つの挿入処理をどう作り変えるかを Day 5 で設計する。
+
+あわせて **`company-dashboard/SKILL.md`**（HTML 言及 5 箇所）の報告形式・構成説明も更新する。L2 採点プロンプトは無い。
+
+> **ここが本計画で最も壊しやすい箇所である。** Day 4 までを終えてから着手し、**Day 5 だけで 1 日を使う**前提で見積もる。
+
+### Day 6 以降 — 仕上げ
+
+- ダークモード対応の方針決定（§4 の判断事項）
+- 全ページの目視確認
+- `artifact-placement.md` への記載（`docs/assets/` の位置づけ）
+
+---
+
+## 4. オーナーの判断が要る点
+
+**着手前に決めてほしい 4 件。** 決まらないと Day 1 で止まる。
+
+### (1) ダークモードをどうするか
+
+現行は**全ページがダーク**で、`@media (prefers-color-scheme: dark)` を持つ。Organic は**ライト前提**のクリーム地である。
+
+| 選択肢 | 内容 | コスト |
+|---|---|---|
+| A | **ライト固定にする**（Organic のまま） | 小。DS の意図に忠実 |
+| B | ダークのトークンセットを自作して両対応 | 大。DS が持たない値を発明することになる |
+| C | 当面ライト、要望が出たら B | 小 |
+
+> DS の readme は「**パレットをグレーに脱色するな。暖かさが要点だ**」と明記している。B は DS の思想と衝突する可能性が高い。
+
+### (2) 対象組織の範囲
+
+現行トップには **`domain-tech-collection` と `standardization-initiative` の 2 組織**のダッシュボードカードがある。刷新案のサイドバーは単一組織前提に見える。
+
+- 2 組織を並べるのか
+- 組織切替 UI を作るのか
+- `jutaku-dev-team`（3 組織目、Pages 未公開）をどうするか
+
+### (3) 移植の完了条件
+
+**「どうなったら完了か」を先に決める。** これは 2026-08-22 の解析で得た **Proof-or-Stop**（AI の「終わりました」は主張であって事実ではない）を適用するためである。
+
+案: **全 8 ページがブラウザで目視確認され、リンク健全性検査が 0 件、かつ nightly を 1 晩通しても壊れていないこと。**
+
+### (4) 既存の情報量を減らすか
+
+刷新案は情報が整理されている一方、現行の `dashboard.html`（67 KB）は Chart.js のグラフを多数持つ。**捨てる情報があるかどうか**を決めておかないと、Day 5 で判断が止まる。
+
+---
+
+## 5. リスクと備え
+
+| リスク | 影響 | 備え |
+|---|---|---|
+| **生成器を壊すと毎晩の自動処理が失敗する** | 大 | 1 ページずつ。各日の終わりに必ずローカル生成して目視 |
+| **`docs/index.html` の 4 重書き込み** | 大 | Day 5 まで触らない。設計に 1 日使う |
+| daily-digest は 5.9 MB あり、生成が重い | 中 | Day 4 でローカル生成の所要時間を測ってから判断 |
+| Organic の `styles.css` が想定より大きい | 小 | Day 1-1 でサイズを測る |
+| Lucide アイコンが外部依存になる | 小 | インライン SVG に落とす選択肢を Day 1-4 で検討 |
+| **ライト化で既存の見た目を好む人が困る** | 中 | §4(1) をオーナーが決める |
+| **生成器だけ直して SKILL.md / review-prompt.md を放置する** | **大** | §2.4 の 3 点セットを各 Day のチェックリストに入れた。Day 3-7 で**実際に L2 を通す** |
+| **`plugins/` ↔ `.claude/skills/` の同期漏れ** | 中 | 各 Day の最後に `diff -rq`。**過去に同期漏れの実績あり**（候補 AE） |
+| L2 採点基準を変えた結果、**旧成果物が全部 fail になる** | 中 | 既存 44 図を再生成するのか、採点を新規分のみに適用するのかを **Day 3 で決める**（**未検討**） |
+
+---
+
+## 6. この計画で確認していないこと
+
+| # | 内容 |
+|---|---|
+| 1 | **`Portal.dc.html` を描画していない**。構造とトークンの読み取りのみで、**見た目を一度も見ていない**（Day 1-2 で解消する） |
+| 2 | **`styles.css` を取得していない**。サイズも中身も未確認。「1 枚で自己完結」は readme の記述に依存 |
+| 3 | **`_ds_bundle.js` を読んでいない**。`.card` 等のクラスが CSS だけで完結するのか、JS を要するのかは**未確認** |
+| 4 | 各生成器の**改修工数を見積もっていない**。Day 2〜5 の粒度は「1 日 1 段階」という仮置き |
+| 5 | プロトタイプに埋まっている数値（`202` / `1192` / `153`）が**何の指標か特定していない**（`0.81` が Case Bank 平均と一致することのみ確認） |
+| 6 | `docs/assets/` というディレクトリは**現状存在しない**。`artifact-placement.md` にも記載が無い |
+| 7 | **`company-sheet` の review-prompt（構造言及 7 箇所）が HTML 刷新の影響を受けるかを確認していない**。xlsx 側なので薄いと推測しただけ |
+| 8 | `company-daily-digest` の L2 致命軸 s6（禁則違反）が**デザイン変更で影響を受けるか未確認** |
+| 9 | **既存成果物（図 44 本・ダイジェスト 129 日分等）を再生成するかを決めていない**。採点基準を変えると旧成果物の扱いが問題になる |
+| 10 | **Day 1 以降は一切着手していない**。本書は計画のみ |
+
+---
+
+## 7. 明日の最初の一手
+
+```
+1. §4 の判断 4 件をオーナーに確認する（特に (1) ダークモード）
+2. Day 1-1: styles.css を取得してサイズを測る
+3. Day 1-2: React を CDN で読ませて Portal.dc.html を描画し、目視する
+```
+
+**作業対象の総量（実測）**
+
+| 種別 | 件数 |
+|---|---|
+| ページ | **8** |
+| 生成器（hooks） | **6** |
+| SKILL.md（HTML 規定あり） | **9** |
+| L2 採点プロンプト | **5** |
+| ルールファイル | `CLAUDE.md`（必須 7 セクション）/ `artifact-placement.md` |
+
+**合計 28 ファイル前後**を触ることになる。1 日 1 段階という見積もりは、この規模に対して**楽観的である可能性がある**。
+
+**Day 1-2 を先にやる価値が高い。** 見た目を一度も見ないまま生成器を書き換えるのは、今日学んだ Proof-or-Stop の反対である。
+
+---
+
+## 関連
+
+- [`loop-engineering-proof-or-stop.md`](../../../../docs/insights/analyses/loop-engineering-proof-or-stop.md) — 完了条件の考え方（§4-3 の根拠）
+- `@.claude/rules/artifact-placement.md` — `docs/assets/` の位置づけを Day 6 で追記する
+- Claude Design: `CC-SIER組織ポータル刷新案`（`14fffc24-d353-4ebd-9468-b614e726c557`）
+- Claude Design: `Organic`（`9ccf8d1e-067c-4ccb-bc4a-0a6417c90f23`）


### PR DESCRIPTION
## 依頼

> 明日からデザインの移植（実態のページに合わせて）を行いたい。計画書いて。今日は作業終了すると思う
> ※HTML作成のSKILLも変更必要だから計画に載せてね

## 成果物

`.companies/domain-tech-collection/docs/decisions/2026-08-22-portal-redesign-plan.md`（**376 行**）

**計画のみ。実装は一切着手していない。**

## 調査でわかった 3 つの障害

### ① 移植元は React で動くプロトタイプ

`Portal.dc.html`（62,567 字）は `<x-dc>` / `<sc-if>`×8 / `{{ }}`×42 を使い、`support.js`（**React ランタイム**、`window.React` 必須）が解釈する。**素の GitHub Pages では描画されない。**

実体は **6 画面（home/dash/know/digest/dia/ins）を 1 ファイルに詰めた対話プロトタイプ**。その 6 画面は実ページにそのまま対応するので、**画面切替は React ではなくサイドバーのリンクになる**。

### ② 現行ページは全部スクリプト生成物

| ページ | サイズ | 生成元 |
|---|---|---|
| `docs/index.html` | 3.7 KB | `generate-dashboard.sh`（**＋3 スクリプトが挿入**） |
| `daily-digest/index.html` | **5,933 KB** | `generate-daily-digest-html.sh` |
| `handover/index.html` | 567 KB | `generate-handover-html.sh` |
| 他 5 本 | — | 各生成器 |

**手で維持されている HTML は 1 つも無い。** HTML を書き換えても次の生成で消える（**解析カードが 6 日間毎晩消えていた事故が本日発覚したばかり**）。

### ③ テーマが正反対

現行 `#0b1222`（ダーク）↔ Organic `#f5ead8`（クリーム）。単なる配色変更ではなく**明暗の反転**。

## ご指摘の反映 — §2.4 を新設

「HTML作成のSKILLも変更必要」を受けて実測した。

**SKILL.md に HTML/CSS 規定があるもの — 9 本**

`company-diagram-v2`(33) / `company-drawio`(32) / `company-diagram`(31) / `company-insights-cycle`(20) / `company-digest-html`(18) / `company-daily-digest`(13) / `company-handover`(10) / `company-dashboard`(5) / `company-cycle`(4)

**L2 採点プロンプトで構造を採点しているもの — 5 本**

`company-diagram-v2`(39) / `company-diagram`(24) / `company-drawio`(23) / `company-sheet`(7) / `company-daily-digest`(4)

`@.claude/rules/skill-development.md` にこうある。

> SKILL.md の必須セクション変更は **必ず** `references/review-prompt.md` の採点基準にも反映する。**片方だけ更新すると L2 レビューが旧仕様で通過してしまう。**

そこで**ページ 1 つにつき 3 点セットを同時更新**する方針にした。

```
① hooks の生成器          … 実際に出る HTML
② SKILL.md               … 何を出すべきかの指示
③ references/review-prompt.md … どう採点するか
```

## 段階計画

| Day | 対象 | 要点 |
|---|---|---|
| 1 | 土台 | **`docs/` を一切変更しない**。styles.css 取得 + **Portal を描画して目視** |
| 2 | `insights/analyses/` | **L2 が無い最軽量ケース**で 3 点セットを試す |
| 3 | `diagrams/` `drawio/` | **最も重い**。SKILL 3 本 + review 3 本。**実際に L2 を通すまでが本体** |
| 4 | `daily-digest` `handover` | 毎晩 Actions が生成する。ローカル生成 → 目視 → main の順序厳守 |
| 5 | `dashboard` `index.html` | **最難関**。index.html は 4 処理が書き込む。**1 日使う前提** |
| 6+ | 仕上げ | ダークモード方針・全ページ目視 |

**作業対象は 28 ファイル前後**。1 日 1 段階という見積もりは**楽観的である可能性がある**と明記した。

## オーナー判断が要る 4 件（着手前）

1. **ダークモードをどうするか** — Organic はライト前提。DS は「グレーに脱色するな、暖かさが要点」と明記しており、ダーク版の自作は思想と衝突しうる
2. **対象組織の範囲** — 現行トップは 2 組織。刷新案は単一組織前提に見える
3. **完了条件** — 本日の Proof-or-Stop を適用。案「全 8 ページ目視 + リンク 0 件 + nightly を 1 晩通す」
4. **既存の情報量を減らすか** — `dashboard.html`(67KB) の Chart.js 群を残すか

## 確認していないこと（計画書 §6 に 10 件）

- **`Portal.dc.html` を描画していない**。見た目を一度も見ていない
- **`styles.css` を取得していない**。「1 枚で自己完結」は readme の記述に依存
- **`_ds_bundle.js` を読んでいない**。`.card` 等が CSS だけで完結するか未確認
- **既存成果物（図 44 本等）を再生成するか決めていない**
- **Day 1 以降は一切着手していない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)